### PR TITLE
Simplify tool calling

### DIFF
--- a/source/compilers/autofix.ts
+++ b/source/compilers/autofix.ts
@@ -5,13 +5,13 @@ import * as toolMap from "../tools/tool-defs/index.ts";
 import { fixEditPrompt, fixJsonPrompt, JsonFixResponse, DiffApplyResponse } from "../autofix-prompts.ts";
 import { trackTokens } from "../token-tracker.ts";
 
-type DiffEdit = t.GetType<typeof toolMap.edit.DiffEdit>;
+type Edit = t.GetType<typeof toolMap.edit.ArgumentsSchema>;
 export async function autofixEdit(
   config: Config,
   file: string,
-  edit: DiffEdit,
+  edit: Edit,
   abortSignal: AbortSignal,
-): Promise<DiffEdit | null> {
+): Promise<Edit | null> {
   const result = await autofix(config.diffApply, config, fixEditPrompt({ file, edit }), abortSignal);
   if(result == null) return null;
   try {
@@ -20,7 +20,7 @@ export async function autofixEdit(
     const sliced = DiffApplyResponse.slice(parsed);
     if(!sliced.success) return null;
     return {
-      type: "diff",
+      ...edit,
       search: sliced.search,
       replace: edit.replace,
     };

--- a/source/ir/llm-ir.ts
+++ b/source/ir/llm-ir.ts
@@ -286,6 +286,9 @@ function collapseToIR(
   if(item.type === "tool-output") {
     return assertPrevAssistantToolCall("tool-output", item, prev, prev => {
       switch(prev.toolCall.function.name) {
+        case "append":
+        case "prepend":
+        case "rewrite":
         case "edit":
         case "create":
         case "read": return [

--- a/source/state.ts
+++ b/source/state.ts
@@ -335,7 +335,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     } catch(e) {
       const fn = lastHistoryItem.tool.function;
       let fixed = false;
-      if(fn.name === "edit" && fn.arguments.edit.type === "diff") {
+      if(fn.name === "edit") {
         set({
           modeData: {
             mode: "diff-apply",
@@ -345,7 +345,7 @@ export const useAppStore = create<UiState>((set, get) => ({
         const path = fn.arguments.filePath;
         try {
           const file = await fs.readFile(path, "utf8");
-          const fix = await autofixEdit(config, file, fn.arguments.edit, abortController.signal);
+          const fix = await autofixEdit(config, file, fn.arguments, abortController.signal);
           if (abortController.signal.aborted) {
             set({ modeData: { mode: "input" } });
             return;
@@ -354,13 +354,13 @@ export const useAppStore = create<UiState>((set, get) => ({
             // Validate that the edit applies before marking as fixed
             await validateTool(abortController.signal, transport, {
               name: "edit",
-              arguments: {
-                filePath: fn.arguments.filePath,
-                edit: fix,
-              },
+              arguments: fix,
             }, config);
             fixed = true;
-            fn.arguments.edit = fix;
+            fn.arguments = {
+              ...fn.arguments,
+              ...fix,
+            };
           }
         } catch {}
       }

--- a/source/tools/tool-defs/append.ts
+++ b/source/tools/tool-defs/append.ts
@@ -1,0 +1,45 @@
+import { t } from "structural";
+import { fileTracker } from "../file-tracker.ts";
+import { attemptUntrackedRead, ToolDef } from "../common.ts";
+import { Transport } from "../../transports/transport-common.ts";
+
+const ArgumentsSchema = t.subtype({
+  filePath: t.str.comment("The path to the file"),
+  text: t.str.comment("The text to append"),
+}).comment("Appends to a file");
+
+const Schema = t.subtype({
+  name: t.value("append"),
+  arguments: ArgumentsSchema,
+});
+
+export default {
+  Schema, ArgumentsSchema, validate,
+  async run(signal, transport, call) {
+    const { filePath } = call.tool.arguments;
+    const edit = call.tool.arguments;
+    await fileTracker.assertCanEdit(transport, signal, filePath);
+
+    const file = await attemptUntrackedRead(transport, signal, filePath);
+    const replaced = runEdit({
+      file, edit,
+    });
+    await fileTracker.write(transport, signal, filePath, replaced);
+    return {
+      content: "",
+    };
+  },
+} satisfies ToolDef<t.GetType<typeof Schema>>;
+
+async function validate(signal: AbortSignal, transport: Transport, toolCall: t.GetType<typeof Schema>) {
+  await fileTracker.assertCanEdit(transport, signal, toolCall.arguments.filePath);
+  await attemptUntrackedRead(transport, signal, toolCall.arguments.filePath);
+  return null;
+}
+
+function runEdit({ file, edit }: {
+  file: string,
+  edit: t.GetType<typeof ArgumentsSchema>,
+}): string {
+  return file + edit.text;
+}

--- a/source/tools/tool-defs/edit.ts
+++ b/source/tools/tool-defs/edit.ts
@@ -4,41 +4,16 @@ import { ToolError, attemptUntrackedRead, ToolDef } from "../common.ts";
 import { Transport } from "../../transports/transport-common.ts";
 
 const DiffEdit = t.subtype({
-  type: t.value("diff"),
   search: t.str.comment(`
     The search string to replace. Must EXACTLY match the text you intend to replace, including
-    whitespace, punctuation, etc. Make sure to give a few lines of context above and below.
+    whitespace, punctuation, etc. Make sure to give a few lines of context above and below so you
+    don't accidentally replace a different matching substring in the same file.
   `),
   replace: t.str.comment("The string you want to insert into the file"),
-}).comment("Applies a search/replace edit to a file");
-
-const AppendEdit = t.subtype({
-  type: t.value("append"),
-  text: t.str.comment("The text to append"),
-}).comment("Appends to a file");
-
-const PrependEdit = t.subtype({
-  type: t.value("prepend"),
-  text: t.str.comment("The text to prepend"),
-}).comment("Prepends to a file");
-
-const RewriteEdit = t.subtype({
-  type: t.value("rewrite-whole"),
-  text: t.str.comment("The replaced file contents. This will rewrite and replace the entire file"),
-}).comment(`
-  Rewrites the entire file. If you need to rewrite large chunks of the file, or are struggling to
-  to make a diff edit work, use this as a last resort. Prefer other edit types unless you are
-  struggling (have failed multiple times in a row).
-  This overwrites the ENTIRE file, so make sure to write everything you intend to overwrite: you
-  can't leave anything out by saying e.g. "[The rest of the file stays the same]"
-`);
-
-const AllEdits = DiffEdit.or(AppendEdit).or(PrependEdit).or(RewriteEdit);
-
-const ArgumentsSchema = t.subtype({
-  filePath: t.str.comment("The path to the file"),
-  edit: AllEdits,
 });
+const ArgumentsSchema = DiffEdit.and(t.subtype({
+  filePath: t.str.comment("The path to the file"),
+})).comment("Applies a search/replace edit to a file. This should be your default tool to edit existing files.");
 
 const Schema = t.subtype({
   name: t.value("edit"),
@@ -46,15 +21,16 @@ const Schema = t.subtype({
 });
 
 export default {
-  Schema, ArgumentsSchema, validate, AllEdits, PrependEdit, AppendEdit, DiffEdit, RewriteEdit,
+  Schema, ArgumentsSchema, validate, DiffEdit,
   async run(signal, transport, call) {
-    const { filePath, edit } = call.tool.arguments;
+    const { filePath } = call.tool.arguments;
+    const diff = call.tool.arguments;
     await fileTracker.assertCanEdit(transport, signal, filePath);
 
     const file = await attemptUntrackedRead(transport, signal, filePath);
     const replaced = runEdit({
       path: filePath,
-      file, edit,
+      file, diff,
     });
     await fileTracker.write(transport, signal, filePath, replaced);
     return {
@@ -62,42 +38,19 @@ export default {
     };
   },
 } satisfies ToolDef<t.GetType<typeof Schema>> & {
-  AllEdits: typeof AllEdits,
-  PrependEdit: typeof PrependEdit,
-  AppendEdit: typeof AppendEdit,
   DiffEdit: typeof DiffEdit,
-  RewriteEdit: typeof RewriteEdit,
 };
 
 async function validate(signal: AbortSignal, transport: Transport, toolCall: t.GetType<typeof Schema>) {
   await fileTracker.assertCanEdit(transport, signal, toolCall.arguments.filePath);
   const file = await attemptUntrackedRead(transport, signal, toolCall.arguments.filePath);
-  switch(toolCall.arguments.edit.type) {
-    case "append": return null;
-    case "prepend": return null;
-    case "rewrite-whole": return null;
-    case "diff":
-      return validateDiff({ file, diff: toolCall.arguments.edit, path: toolCall.arguments.filePath });
-  }
+  return validateDiff({ file, diff: toolCall.arguments, path: toolCall.arguments.filePath });
 }
 
-function runEdit({ path, file, edit }: {
+function runEdit({ path, file, diff }: {
   path: string,
   file: string,
-  edit: t.GetType<typeof AllEdits>,
-}): string {
-  switch(edit.type) {
-    case "diff": return diffEditFile({ path, file, diff: edit });
-    case "append": return file + edit.text;
-    case "prepend": return edit.text + file;
-    case "rewrite-whole": return edit.text;
-  }
-}
-
-function diffEditFile({ path, file, diff }: {
-  path: string,
-  file: string,
-  diff: t.GetType<typeof DiffEdit>,
+  diff: t.GetType<typeof ArgumentsSchema>,
 }): string {
   validateDiff({ path, file, diff });
   return file.replace(diff.search, diff.replace);
@@ -106,7 +59,7 @@ function diffEditFile({ path, file, diff }: {
 function validateDiff({ path, file, diff }: {
   path: string,
   file: string,
-  diff: t.GetType<typeof DiffEdit>,
+  diff: t.GetType<typeof ArgumentsSchema>,
 }) {
   if(!file.includes(diff.search)) {
     throw new ToolError(`

--- a/source/tools/tool-defs/index.ts
+++ b/source/tools/tool-defs/index.ts
@@ -5,3 +5,6 @@ export { default as edit } from "./edit.ts";
 export { default as create } from "./create.ts";
 export { default as mcp } from "./mcp.ts";
 export { default as fetch } from "./fetch.ts";
+export { default as append } from "./append.ts";
+export { default as prepend } from "./prepend.ts";
+export { default as rewrite } from "./rewrite.ts";

--- a/source/tools/tool-defs/prepend.ts
+++ b/source/tools/tool-defs/prepend.ts
@@ -1,0 +1,45 @@
+import { t } from "structural";
+import { fileTracker } from "../file-tracker.ts";
+import { attemptUntrackedRead, ToolDef } from "../common.ts";
+import { Transport } from "../../transports/transport-common.ts";
+
+const ArgumentsSchema = t.subtype({
+  filePath: t.str.comment("The path to the file"),
+  text: t.str.comment("The text to prepend"),
+}).comment("Prepends to a file");
+
+const Schema = t.subtype({
+  name: t.value("prepend"),
+  arguments: ArgumentsSchema,
+});
+
+export default {
+  Schema, ArgumentsSchema, validate,
+  async run(signal, transport, call) {
+    const { filePath } = call.tool.arguments;
+    const edit = call.tool.arguments;
+    await fileTracker.assertCanEdit(transport, signal, filePath);
+
+    const file = await attemptUntrackedRead(transport, signal, filePath);
+    const replaced = runEdit({
+      file, edit,
+    });
+    await fileTracker.write(transport, signal, filePath, replaced);
+    return {
+      content: "",
+    };
+  },
+} satisfies ToolDef<t.GetType<typeof Schema>>;
+
+async function validate(signal: AbortSignal, transport: Transport, toolCall: t.GetType<typeof Schema>) {
+  await fileTracker.assertCanEdit(transport, signal, toolCall.arguments.filePath);
+  await attemptUntrackedRead(transport, signal, toolCall.arguments.filePath);
+  return null;
+}
+
+function runEdit({ file, edit }: {
+  file: string,
+  edit: t.GetType<typeof ArgumentsSchema>,
+}): string {
+  return edit.text + file;
+}

--- a/source/tools/tool-defs/rewrite.ts
+++ b/source/tools/tool-defs/rewrite.ts
@@ -1,0 +1,46 @@
+import { t } from "structural";
+import { fileTracker } from "../file-tracker.ts";
+import { attemptUntrackedRead, ToolDef } from "../common.ts";
+import { Transport } from "../../transports/transport-common.ts";
+
+const ArgumentsSchema = t.subtype({
+  filePath: t.str.comment("The path to the file"),
+  text: t.str.comment("The replaced file contents. This will rewrite and replace the entire file"),
+}).comment(`
+  Rewrites the entire file. If you need to rewrite large chunks of the file, or are struggling to
+  to make a diff edit work, use this as a last resort. Prefer other edit types unless you are
+  struggling (have failed multiple times in a row).
+  This overwrites the ENTIRE file, so make sure to write everything you intend to overwrite: you
+  can't leave anything out by saying e.g. "[The rest of the file stays the same]"
+`);
+
+const Schema = t.subtype({
+  name: t.value("rewrite"),
+  arguments: ArgumentsSchema,
+});
+
+export default {
+  Schema, ArgumentsSchema, validate,
+  async run(signal, transport, call) {
+    const { filePath } = call.tool.arguments;
+    const edit = call.tool.arguments;
+    await fileTracker.assertCanEdit(transport, signal, filePath);
+    const replaced = runEdit({ edit });
+    await fileTracker.write(transport, signal, filePath, replaced);
+    return {
+      content: "",
+    };
+  },
+} satisfies ToolDef<t.GetType<typeof Schema>>;
+
+async function validate(signal: AbortSignal, transport: Transport, toolCall: t.GetType<typeof Schema>) {
+  await fileTracker.assertCanEdit(transport, signal, toolCall.arguments.filePath);
+  await attemptUntrackedRead(transport, signal, toolCall.arguments.filePath);
+  return null;
+}
+
+function runEdit({ edit }: {
+  edit: t.GetType<typeof ArgumentsSchema>,
+}): string {
+  return edit.text;
+}

--- a/training/fast-apply/generate-diff-training.ts
+++ b/training/fast-apply/generate-diff-training.ts
@@ -135,7 +135,6 @@ function cutAmbiguous(diff: Diff): BreakResponse {
     diff: {
       file: diff.file,
       edit: {
-        type: "diff",
         search: cut,
         replace: diff.edit.replace,
       },
@@ -151,7 +150,6 @@ function breakEditMessages(edit: Diff): BreakResponse {
     brokenEdit = {
       file: edit.file,
       edit: {
-        type: "diff",
         search: breakSearchStringRandomly(brokenEdit.edit, brokenEdit.file),
         replace: edit.edit.replace,
       },

--- a/training/generate-edits.ts
+++ b/training/generate-edits.ts
@@ -32,7 +32,6 @@ export async function* genDiffs(gitDir: string): AsyncGenerator<Diff> {
         const replaceLines = getFromRange(afterLines, chunk.toFileRange);
 
         const edit: t.GetType<typeof edits.DiffEdit> = {
-          type: "diff",
           search: searchLines.join("\n"),
           replace: replaceLines.join("\n"),
         };


### PR DESCRIPTION
While working on SGLang's tool call parser, I came to appreciate how elegant GLM-4.x's tool call format is for LLMs. Instead of asking the LLM to generate JSON, like most tool call formats, it uses a pseudo-XML format:

```
<tool_call>tool_name
<arg_key>argument_name</arg_key>
<arg_value>argument_value</arg_value>
...etc etc for more key/value pairs
</tool_call>
```

The really nice thing about this is that it means the LLM doesn't need to keep track of escaping JSON special characters; for example, in theory one could have an `append` tool that looks like this

```
<tool_call>append
<arg_key>file_path</arg_key>
<arg_value>some_file.txt</arg_value>
<arg_key>text</arg_key>
<arg_value>hello, my "friend"</arg_value>
</tool_call>
```

Whereas with more typical JSON-based tool call formats for LLMs, they'd have to carefully track how many levels deep they are in JSON and escape the correct numbers of times i.e. `\"friend\"`. Many LLMs fail tool calls due to needing to track JSON escaping — that's why we built the autofix models! — but GLM-4.x should fail less than that.

Except... Well, our edit format is:

```
{
  filePath: string,
  edit: {
    // Nested JSON that swaps between different edit types
  }
}
```

So GLM-4.x still needs to track JSON escaping, since the `edit` value is JSON!

There are two ways we could fix this:

1. Have a base type with a `filePath` argument that gets intersected with the union of all edit types.
2. Have different tools for every edit type.

As a type nerd, I actually prefer the elegance of option (1). But... unfortunately, many LLM inference providers don't support root-level `anyOf` and `allOf` JSON Schemas (Synthetic does, at least for GLM-4.6, because my forked tool call parser supports it! But e.g. OpenAI doesn't, which breaks the idea of Octo being able to switch providers easily). So, I've refactored Octo's tool calls to just use unique tools for each edit type: append, prepend, rewrite, and `edit` (which now refers to what `diff` used to mean).

Doing this should make GLM-4.6 much more robust at tool calling with Octo.