### PR TITLE
fix: gracefully handle MCP server connection failures without crashing

### DIFF
--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -108,14 +108,20 @@ async function runMain(opts: {
     // Connect to all MCP servers on boot
     if(config.mcpServers && Object.keys(config.mcpServers).length > 0) {
       for(const server of Object.keys(config.mcpServers)) {
-        console.log("Connecting to", server, "MCP server...");
-        // Run the basic connection setup with logging enabled, so that first-time setup gets logged
-        const client = await connectMcpServer(server, config, true);
-        await client.close();
-        // Then run the cache setup codepath, so future results use a cached client with logging off
-        await getMcpClient(server, config);
+        try {
+          console.log("Connecting to", server, "MCP server...");
+          // Run the basic connection setup with logging enabled, so that first-time setup gets logged
+          const client = await connectMcpServer(server, config, true);
+          await client.close();
+          // Then run the cache setup codepath, so future results use a cached client with logging off
+          await getMcpClient(server, config);
+          console.log("Connected to", server, "MCP server");
+        } catch (error) {
+          console.warn(`Warning: Failed to connect to "${server}" MCP server: ${error instanceof Error ? error.message : String(error)}`);
+          console.warn("Octo will continue without this MCP server.");
+        }
       }
-      console.log("All MCP servers connected.");
+      console.log("MCP server initialization complete.");
     }
 
 	  const { waitUntilExit } = render(


### PR DESCRIPTION
PR Summary

  ## Summary
  Fixes issue where Octo crashes during startup when an MCP server path doesn't exist.

  ## Changes
  - Added try-catch blocks around MCP server initialization in `source/cli.tsx`
  - When a server fails to connect, Octo now logs a warning and continues with remaining servers
  - Octo will start successfully even with invalid MCP server configurations

  ## Testing
  - Tested with invalid `/Users/jon/code/clojure-mcp` path in config
  - Octo now starts gracefully with warning message instead of crashing
  - Other valid MCP servers (if any) continue to initialize normally

  ## Fixes
  Fixes synthetic-lab/octofriend#44