### PR TITLE
Vim emulation mode improvements

### DIFF
--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -81,8 +81,6 @@ export default function TextInput({
 		});
 	}, [originalValue, focus, showCursor]);
 
-	const cursorActualWidth = highlightPastedText ? cursorWidth : 0;
-
 	const value = mask ? mask.repeat(originalValue.length) : originalValue;
 	let renderedValue = value;
 	let renderedPlaceholder = placeholder ? chalk.grey(placeholder) : undefined;
@@ -96,19 +94,28 @@ export default function TextInput({
 
 		renderedValue = value.length > 0 ? '' : chalk.inverse(' ');
 
+		const lines = value.split('\n');
 		let i = 0;
 
-		for (const char of value) {
-			renderedValue +=
-				i >= renderCursorPosition - cursorActualWidth && i <= renderCursorPosition
-					? chalk.inverse(char)
-					: char;
+		for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+			const line = lines[lineIndex];
 
-			i++;
-		}
+			for (const char of line) {
+				renderedValue += i === renderCursorPosition ? chalk.inverse(char) : char;
+				i++;
+			}
 
-		if (value.length > 0 && renderCursorPosition === value.length) {
-			renderedValue += chalk.inverse(' ');
+			if (
+        i === renderCursorPosition
+        && !(lineIndex === 0 && line.length === 0 && renderCursorPosition === 0)
+      ) {
+				renderedValue += chalk.inverse(' ');
+			}
+
+			if (lineIndex < lines.length - 1) {
+				renderedValue += '\n';
+				i++;
+			}
 		}
 	}
 

--- a/source/components/vim-mode.tsx
+++ b/source/components/vim-mode.tsx
@@ -52,6 +52,169 @@ const getLineStart = (text: string, lineIndex: number): number => {
   return position;
 };
 
+const getLineRange = (text: string, cursorPosition: number): { start: number, end: number } => {
+  const currentLineInfo = getLineInfo(text, cursorPosition);
+  const start = getLineStart(text, currentLineInfo.lineIndex);
+  const lines = text.split('\n');
+  const line = lines[currentLineInfo.lineIndex];
+  let end = start + line.length;
+  if (currentLineInfo.lineIndex < lines.length - 1) {
+    end += 1; // Include the newline character
+  }
+  return { start, end };
+};
+
+type Motion = (text: string, cursorPosition: number) => { start: number, end: number };
+
+type Operator = (text: string, range: { start: number, end: number }, motionChar?: string) => {
+  newText: string,
+  newCursorPosition?: number,
+  enterInsertMode?: boolean,
+};
+
+type PendingCommand = {
+  operator: Operator;
+  operatorChar: string;
+};
+
+type TextState = {
+  text: string;
+  cursorPosition: number;
+};
+
+const motions: Record<string, Motion> = {
+  'w': (text, cursorPosition) => {
+    const textLength = text.length;
+    if (cursorPosition >= textLength) {
+      return { start: cursorPosition, end: cursorPosition };
+    }
+
+    const currentChar = text[cursorPosition];
+    let endPosition: number;
+
+    if (isWhitespace(currentChar)) {
+      endPosition = cursorPosition;
+      while (endPosition < textLength && isWhitespace(text[endPosition])) {
+        endPosition++;
+      }
+    } else {
+      let wordEnd = cursorPosition;
+      while (wordEnd < textLength && !isWhitespace(text[wordEnd])) {
+        wordEnd++;
+      }
+      endPosition = wordEnd;
+      while (endPosition < textLength && isWhitespace(text[endPosition])) {
+        endPosition++;
+      }
+    }
+
+    return { start: cursorPosition, end: endPosition };
+  },
+  'b': (text, cursorPosition) => {
+    if (cursorPosition === 0) {
+      return { start: 0, end: 0 };
+    }
+
+    let start = cursorPosition;
+    while (start > 0 && isWhitespace(text[start - 1])) {
+      start--;
+    }
+    while (start > 0 && !isWhitespace(text[start - 1])) {
+      start--;
+    }
+
+    return { start: start, end: cursorPosition };
+  },
+  'e': (text, cursorPosition) => {
+    const textLength = text.length;
+    const currentChar = text[cursorPosition];
+    const nextChar = cursorPosition + 1 < textLength ? text[cursorPosition + 1] : '';
+    const atWordEnd = !isWhitespace(currentChar)
+                    && (cursorPosition === textLength - 1
+                    || isWhitespace(nextChar))
+                    ;
+
+    let endPos: number;
+
+    if (atWordEnd) {
+      endPos = cursorPosition + 1;
+      while (endPos < textLength && isWhitespace(text[endPos])) {
+        endPos++;
+      }
+      while (endPos < textLength && !isWhitespace(text[endPos])) {
+        endPos++;
+      }
+    } else {
+      endPos = cursorPosition;
+      while (endPos < textLength && isWhitespace(text[endPos])) {
+        endPos++;
+      }
+      while (endPos < textLength && !isWhitespace(text[endPos])) {
+        endPos++;
+      }
+    }
+
+    const vimEndPos = Math.max(0, endPos - 1);
+    return { start: cursorPosition, end: vimEndPos + 1 };
+  },
+  '0': (_, cursorPosition) => {
+    return { start: cursorPosition, end: 0 };
+  },
+  '$': (text, cursorPosition) => {
+    const lastCharPos = Math.max(0, text.length - 1);
+    return { start: cursorPosition, end: lastCharPos + 1 };
+  },
+  '^': (text, cursorPosition) => {
+    let newCursorPosition = 0;
+    const textLength = text.length;
+
+    while (newCursorPosition < textLength && isWhitespace(text[newCursorPosition])) {
+      newCursorPosition++;
+    }
+
+    return { start: cursorPosition, end: newCursorPosition };
+  },
+};
+
+const operators: Record<string, Operator> = {
+  'd': (text, { start, end }) => {
+    const actualEnd = Math.min(end, text.length);
+    const actualStart = Math.min(start, actualEnd);
+    const newText = text.slice(0, actualStart) + text.slice(actualEnd);
+    let newCursorPosition = actualStart;
+    if (newText.length === 0) {
+      newCursorPosition = 0;
+    } else if (newCursorPosition >= newText.length) {
+      newCursorPosition = newText.length - 1;
+    }
+    return { newText, newCursorPosition };
+  },
+  'c': (text, { start, end }, motionChar) => {
+    let actualEnd = Math.min(end, text.length);
+    const actualStart = Math.min(start, actualEnd);
+
+    // For change operator with word motions (cw), trim trailing whitespace (like ce behavior in vim)
+    if (motionChar === 'w' || motionChar === 'e') {
+      let trimmedEnd = actualEnd;
+      for(; trimmedEnd > actualStart; trimmedEnd--) {
+        const char = text[trimmedEnd - 1];
+        if (char === '\n' || char === '\r') {
+          continue;
+        }
+        if (!isWhitespace(char)) break;
+      }
+      actualEnd = trimmedEnd;
+    }
+
+    const newText = text.slice(0, actualStart) + text.slice(actualEnd);
+    let newCursorPosition = actualStart;
+    if (newCursorPosition > newText.length) {
+      newCursorPosition = newText.length;
+    }
+    return { newText, newCursorPosition, enterInsertMode: true };
+  },
+};
+
 export function VimModeIndicator({
   vimEnabled,
   vimMode
@@ -74,6 +237,21 @@ export function useVimKeyHandler(
   vimMode: 'NORMAL' | 'INSERT',
   setVimMode: (mode: 'NORMAL' | 'INSERT') => void
 ) {
+  const pendingCommandRef = React.useRef<PendingCommand | null>(null);
+  const undoStackRef = React.useRef<TextState[]>([]);
+  const redoStackRef = React.useRef<TextState[]>([]);
+  const insertStartStateRef = React.useRef<TextState | null>(null);
+
+  const saveState = (text: string, cursorPosition: number) => {
+    undoStackRef.current.push({ text, cursorPosition });
+    redoStackRef.current = [];
+  };
+
+  const enterInsertMode = (text: string, cursorPosition: number) => {
+    insertStartStateRef.current = { text, cursorPosition };
+    setVimMode('INSERT');
+  };
+
   return {
     handle(
       input: string,
@@ -84,13 +262,20 @@ export function useVimKeyHandler(
     ): { consumed: boolean, newCursorPosition?: number, newValue?: string } {
       if (vimMode === 'INSERT') {
         if (key.escape || (key.ctrl && input === 'c')) {
-          // When returning from INSERT to NORMAL, move cursor left to be ON a character
           let newCursorPosition = cursorPosition;
           if (cursorPosition > 0) {
             newCursorPosition = cursorPosition - 1;
           }
+          if (insertStartStateRef.current !== null) {
+            saveState(insertStartStateRef.current.text, insertStartStateRef.current.cursorPosition);
+            insertStartStateRef.current = null;
+          }
           setVimMode('NORMAL');
           return { consumed: true, newCursorPosition };
+        }
+
+        if (insertStartStateRef.current === null) {
+          insertStartStateRef.current = { text: currentValue, cursorPosition };
         }
 
         if(key.return) {
@@ -105,14 +290,107 @@ export function useVimKeyHandler(
 
       if(key.return) return { consumed: false };
 
+      // Check if we have a pending operator waiting for a motion
+      if (pendingCommandRef.current) {
+        const pending = pendingCommandRef.current;
+
+        // Check if the same operator is pressed again (dd, cc, etc.) - operate on the current line
+        if (input === pending.operatorChar) {
+          const lineRange = getLineRange(currentValue, cursorPosition);
+          const result = pending.operator(currentValue, lineRange, input);
+
+          pendingCommandRef.current = null;
+
+          let finalCursorPosition = result.newCursorPosition;
+          if (finalCursorPosition !== undefined) {
+            finalCursorPosition = clampToVimBounds(finalCursorPosition, result.newText.length);
+          }
+
+          const response: { consumed: boolean, newCursorPosition?: number, newValue?: string } = {
+            consumed: true,
+            newValue: result.newText,
+          };
+
+          if (finalCursorPosition !== undefined) {
+            response.newCursorPosition = finalCursorPosition;
+          }
+
+          if (result.enterInsertMode) {
+            enterInsertMode(currentValue, cursorPosition);
+          } else {
+            saveState(currentValue, cursorPosition);
+          }
+
+          return response;
+        }
+
+        // Check if the input is a motion
+        if (input in motions) {
+          const motion = motions[input];
+          const range = motion(currentValue, cursorPosition);
+          const result = pending.operator(currentValue, range, input);
+
+          pendingCommandRef.current = null;
+
+          let finalCursorPosition = result.newCursorPosition;
+          if (finalCursorPosition !== undefined) {
+            finalCursorPosition = clampToVimBounds(finalCursorPosition, result.newText.length);
+          }
+
+          const response: { consumed: boolean, newCursorPosition?: number, newValue?: string } = {
+            consumed: true,
+            newValue: result.newText,
+          };
+
+          if (finalCursorPosition !== undefined) {
+            response.newCursorPosition = finalCursorPosition;
+          }
+
+          if (result.enterInsertMode) {
+            enterInsertMode(currentValue, cursorPosition);
+          } else {
+            saveState(currentValue, cursorPosition);
+          }
+
+          return response;
+        }
+
+        // Not a motion, cancel the pending operator
+        pendingCommandRef.current = null;
+        // Continue to process this key as a normal command
+      }
+
+      // Handle redo (Ctrl-r)
+      if (key.ctrl && input === 'r') {
+        if (redoStackRef.current.length === 0) return { consumed: true };
+        const state = redoStackRef.current.pop()!;
+        undoStackRef.current.push({ text: currentValue, cursorPosition });
+        return { consumed: true, newValue: state.text, newCursorPosition: state.cursorPosition };
+      }
+
+      // Check if input is an operator
+      if (input in operators) {
+        pendingCommandRef.current = {
+          operator: operators[input],
+          operatorChar: input,
+        };
+        return { consumed: true };
+      }
+
       const commands: Record<string, () => { consumed: boolean, newCursorPosition?: number, newValue?: string }> = {
+        'u': () => {
+          if (undoStackRef.current.length === 0) return { consumed: true };
+          const state = undoStackRef.current.pop()!;
+          redoStackRef.current.push({ text: currentValue, cursorPosition });
+          return { consumed: true, newValue: state.text, newCursorPosition: state.cursorPosition };
+        },
         'i': () => {
-          setVimMode('INSERT');
+          enterInsertMode(currentValue, cursorPosition);
           return { consumed: true };
         },
         'a': () => {
           const newCursorPosition = Math.min(valueLength, cursorPosition + 1);
-          setVimMode('INSERT');
+          enterInsertMode(currentValue, cursorPosition);
           return { consumed: true, newCursorPosition };
         },
         'h': () => {
@@ -122,14 +400,12 @@ export function useVimKeyHandler(
           return vimCommandResult(cursorPosition, valueLength);
         },
         'l': () => {
-          // In NORMAL mode, cursor stays ON character, not after
           if (cursorPosition < valueLength - 1) {
             return vimCommandResult(cursorPosition + 1, valueLength);
           }
           return vimCommandResult(cursorPosition, valueLength);
         },
         'k': () => {
-          // Move up one line
           const lines = currentValue.split('\n');
           const currentLineInfo = getLineInfo(currentValue, cursorPosition);
 
@@ -144,7 +420,6 @@ export function useVimKeyHandler(
           return vimCommandResult(cursorPosition, valueLength);
         },
         'j': () => {
-          // Move down one line
           const lines = currentValue.split('\n');
           const currentLineInfo = getLineInfo(currentValue, cursorPosition);
 
@@ -159,32 +434,42 @@ export function useVimKeyHandler(
           return vimCommandResult(cursorPosition, valueLength);
         },
         'o': () => {
-          // Create new line below and enter insert mode
           const currentLineInfo = getLineInfo(currentValue, cursorPosition);
           const insertPosition = getLineStart(currentValue, currentLineInfo.lineIndex + 1);
+          saveState(currentValue, cursorPosition);
 
-          setVimMode('INSERT');
+          const newValue = [
+            currentValue.slice(0, insertPosition),
+            currentValue.slice(insertPosition)
+          ].join("\n");
+          enterInsertMode(currentValue, cursorPosition);
+
           return {
             consumed: true,
             newCursorPosition: insertPosition,
-            newValue: currentValue.slice(0, insertPosition) + '\n' + currentValue.slice(insertPosition)
+            newValue,
           };
         },
         'O': () => {
-          // Create new line above and enter insert mode
           const currentLineInfo = getLineInfo(currentValue, cursorPosition);
           const insertPosition = getLineStart(currentValue, currentLineInfo.lineIndex);
+          saveState(currentValue, cursorPosition);
 
-          setVimMode('INSERT');
+          const newValue = [
+            currentValue.slice(0, insertPosition),
+            currentValue.slice(insertPosition)
+          ].join("\n");
+          enterInsertMode(currentValue, cursorPosition);
+
           return {
             consumed: true,
             newCursorPosition: insertPosition,
-            newValue: currentValue.slice(0, insertPosition) + '\n' + currentValue.slice(insertPosition)
+            newValue,
           };
         },
         'x': () => {
-          // Delete character under cursor - position N means ON Nth character
           if (valueLength > 0) {
+            saveState(currentValue, cursorPosition);
             const beforeCursor = currentValue.slice(0, cursorPosition);
             const afterCursor = currentValue.slice(cursorPosition + 1);
             const newValue = beforeCursor + afterCursor;
@@ -201,7 +486,6 @@ export function useVimKeyHandler(
           return { consumed: true };
         },
         'w': () => {
-          // Move to start of next word
           const earlyExit = vimEarlyExit(cursorPosition >= valueLength - 1);
           if (earlyExit) return earlyExit;
 
@@ -209,21 +493,18 @@ export function useVimKeyHandler(
           let newCursorPosition: number;
 
           if (isWhitespace(currentChar)) {
-            // On whitespace: find next non-whitespace
             newCursorPosition = cursorPosition;
-            while (newCursorPosition < valueLength && /\s/.test(currentValue[newCursorPosition])) {
+            while (newCursorPosition < valueLength && isWhitespace(currentValue[newCursorPosition])) {
               newCursorPosition++;
             }
           } else {
-            // On word: find end of current word, then start of next word
             let wordEnd = cursorPosition;
-            while (wordEnd < valueLength && !/\s/.test(currentValue[wordEnd])) {
+            while (wordEnd < valueLength && !isWhitespace(currentValue[wordEnd])) {
               wordEnd++;
             }
 
-            // Skip whitespace to find next word start
             newCursorPosition = wordEnd;
-            while (newCursorPosition < valueLength && /\s/.test(currentValue[newCursorPosition])) {
+            while (newCursorPosition < valueLength && isWhitespace(currentValue[newCursorPosition])) {
               newCursorPosition++;
             }
           }
@@ -231,52 +512,49 @@ export function useVimKeyHandler(
           return vimCommandResult(newCursorPosition, valueLength);
         },
         'b': () => {
-          // Move to start of previous word
           const earlyExit = vimEarlyExit(cursorPosition === 0);
           if (earlyExit) return earlyExit;
 
           let wordStart = cursorPosition;
-          while (wordStart > 0 && /\s/.test(currentValue[wordStart - 1])) {
+          while (wordStart > 0 && isWhitespace(currentValue[wordStart - 1])) {
             wordStart--;
           }
-          while (wordStart > 0 && !/\s/.test(currentValue[wordStart - 1])) {
+          while (wordStart > 0 && !isWhitespace(currentValue[wordStart - 1])) {
             wordStart--;
           }
 
           return vimCommandResult(wordStart, valueLength);
         },
         'e': () => {
-          // Move to end of current word (or next word if at word end)
           const earlyExit = vimEarlyExit(cursorPosition >= valueLength - 1);
           if (earlyExit) return earlyExit;
 
           const currentChar = currentValue[cursorPosition];
           const nextChar = cursorPosition + 1 < valueLength ? currentValue[cursorPosition + 1] : '';
-          const atWordEnd = !isWhitespace(currentChar) && (cursorPosition === valueLength - 1 || isWhitespace(nextChar));
+          const atWordEnd = !isWhitespace(currentChar)
+                          && (cursorPosition === valueLength - 1
+                          || isWhitespace(nextChar));
 
           let wordEnd: number;
 
           if (atWordEnd) {
-            // Already at word end, find next word and go to its end
             wordEnd = cursorPosition + 1;
-            while (wordEnd < valueLength && /\s/.test(currentValue[wordEnd])) {
+            while (wordEnd < valueLength && isWhitespace(currentValue[wordEnd])) {
               wordEnd++;
             }
-            while (wordEnd < valueLength && !/\s/.test(currentValue[wordEnd])) {
+            while (wordEnd < valueLength && !isWhitespace(currentValue[wordEnd])) {
               wordEnd++;
             }
           } else {
-            // Go to end of current word
             wordEnd = cursorPosition;
-            while (wordEnd < valueLength && /\s/.test(currentValue[wordEnd])) {
+            while (wordEnd < valueLength && isWhitespace(currentValue[wordEnd])) {
               wordEnd++;
             }
-            while (wordEnd < valueLength && !/\s/.test(currentValue[wordEnd])) {
+            while (wordEnd < valueLength && !isWhitespace(currentValue[wordEnd])) {
               wordEnd++;
             }
           }
 
-          // e goes to last character of word, step back from emacs meta-f position
           const vimPos = Math.max(0, wordEnd - 1);
           return vimCommandResult(vimPos, valueLength);
         },
@@ -284,7 +562,6 @@ export function useVimKeyHandler(
           return { consumed: true, newCursorPosition: 0 };
         },
         '$': () => {
-          // In NORMAL mode, cursor goes ON last character, not after
           const lastCharPos = Math.max(0, valueLength - 1);
           return { consumed: true, newCursorPosition: lastCharPos };
         },
@@ -298,13 +575,16 @@ export function useVimKeyHandler(
           return { consumed: true, newCursorPosition };
         },
         'I': () => {
-          setVimMode('INSERT');
+          enterInsertMode(currentValue, cursorPosition);
           return { consumed: true, newCursorPosition: 0 };
         },
         'A': () => {
-          // In INSERT mode, cursor can be after last character
-          setVimMode('INSERT');
-          return { consumed: true, newCursorPosition: valueLength };
+          const currentLineInfo = getLineInfo(currentValue, cursorPosition);
+          const lineStart = getLineStart(currentValue, currentLineInfo.lineIndex);
+          const lines = currentValue.split('\n');
+          const currentLine = lines[currentLineInfo.lineIndex];
+          enterInsertMode(currentValue, cursorPosition);
+          return { consumed: true, newCursorPosition: lineStart + currentLine.length };
         },
       };
 


### PR DESCRIPTION
Adds hella more Vim emulation commands (dd, cc, u, ctrl-R, d-`[motion]`, c-`[motion]`) to @bradfa's original Vim emulation code, and fixes a bug in our existing TextInput's cursor rendering on multi-line text.

