### PR TITLE
Instructions that show up on Windows execution (when not using bash)

### DIFF
--- a/source/platform.ts
+++ b/source/platform.ts
@@ -1,0 +1,33 @@
+import os from 'os';
+
+export const Platform = {
+  windows: 'windows',
+  macos: 'macos',
+  linux: 'linux',
+  other: 'other',
+} as const;
+
+export type PlatformKey = typeof Platform[keyof typeof Platform];
+
+const PLATFORM_MAP: Record<string, PlatformKey> = {
+  'win32': Platform.windows,
+  'darwin': Platform.macos,
+  'linux': Platform.linux,
+};
+
+export function getPlatform(): PlatformKey {
+  const platform = os.platform();
+  return PLATFORM_MAP[platform] || Platform.other;
+}
+
+export function isWindows(): boolean {
+  return os.platform() === 'win32';
+}
+
+export function isMacOS(): boolean {
+  return os.platform() === 'darwin';
+}
+
+export function isLinux(): boolean {
+  return os.platform() === 'linux';
+}


### PR DESCRIPTION
On first time setup only, we check if user is on Windows. If they are, and bash is not available (tested by running `bash --version`), then we prompt them to install either Git Bash or WSL and run it on there. (put Git Bash ahead of WSL because the local file system is easily accessible with the former)

**Screenshots:**
Loading (only on Windows environment during first time setup, only takes about a second)
<img width="679" height="80" alt="Screenshot 2026-01-08 231828" src="https://github.com/user-attachments/assets/80a9b109-ada6-433e-bf2f-6a86e860431e" />

Installation instructions:
<img width="909" height="282" alt="Screenshot 2026-01-08 232603" src="https://github.com/user-attachments/assets/527e26b5-20ec-4b76-ab79-785196c9d891" />

On Git Bash in Windows environment:
<img width="569" height="318" alt="Screenshot 2026-01-08 232319" src="https://github.com/user-attachments/assets/318e5c0b-146c-4285-b64b-4c557c8a2dbc" />
