### PR TITLE
UI tweaks for chained/unchained toggling

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -238,7 +238,7 @@ function BottomBar({ inputHistory, metadata, tempNotification }: {
       </Box>
       <Text color={themeColor}>{versionCheck}</Text>
     </Box>
-    <Box height={1}>
+    <Box minHeight={1}>
       {displayedTempNotification && (
         <Box width="100%" flexShrink={0}>
           <Text color={themeColor} wrap="wrap">{displayedTempNotification}</Text>


### PR DESCRIPTION
Couple tiny UI tweaks after playing around with the (awesome!) toggle.

1. Always reserves space for the temp notification, even if it's not currently showing, to prevent the UI from jumping around when you're toggling modes — otherwise, the UI jumps upwards when you toggle, since previously the temp notification took up 0 space.
2. Slightly toned down the unchained mode text: it already turns the whole UI red so it felt like we didn't need to capitalize it and make the (non-temporary) mode text red too.
3. Shows the notif about modes on boot, since most people won't know what "Collaboration mode" means at first.

Ignore the fact that my terminal font doesn't have a nice emoji for :zap: ! It's still the :zap: emoji, I didn't change that.

With temp notif displayed:
<img width="1898" height="1010" alt="image" src="https://github.com/user-attachments/assets/64951468-3814-42b6-be50-4703acfe7c14" />

Without:
<img width="1898" height="1010" alt="image" src="https://github.com/user-attachments/assets/f5033640-e71e-4101-bddb-53a736fb4a36" />

