### PR TITLE
Allow menu to be opened by Esc as well as Ctrl-P

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -336,7 +336,11 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
       }
 
       abortResponse();
-      if (modeData.mode === "menu") closeMenu();
+      if (modeData.mode === "menu") {
+        closeMenu();
+      } else {
+        openMenu();
+      }
     }
 
     if (key.ctrl && input === "p") {


### PR DESCRIPTION
A small proposal to preserve the Esc hotkey (along with ctrl-p)

The new menu hotkeys are great (though still personally prefer commands :P) but personally find it much faster to Esc than modifier + key.

Tested locally on dev.