### PR TITLE
Add Home/End and Ctrl+arrow text input navigation

### DIFF
--- a/source/components/emacs-mode.tsx
+++ b/source/components/emacs-mode.tsx
@@ -44,8 +44,8 @@ export function useEmacsKeyHandler() {
         return { consumed: true };
       }
 
-      // Meta+B: Back one word
-      if (key.meta && input === "b") {
+      // Meta+B or Ctrl+Left: Back one word
+      if ((key.meta && input === "b") || (key.ctrl && key.leftArrow)) {
         if (showCursor && cursorPosition > 0) {
           let wordStart = cursorPosition;
           // Skip whitespace
@@ -61,8 +61,8 @@ export function useEmacsKeyHandler() {
         return { consumed: true };
       }
 
-      // Meta+F: Forward one word
-      if (key.meta && input === "f") {
+      // Meta+F or Ctrl+Right: Forward one word
+      if ((key.meta && input === "f") || (key.ctrl && key.rightArrow)) {
         if (showCursor && cursorPosition < valueLength) {
           let wordEnd = cursorPosition;
           // Skip whitespace

--- a/source/components/vim-mode.tsx
+++ b/source/components/vim-mode.tsx
@@ -604,6 +604,15 @@ export function useVimKeyHandler(
         },
       };
 
+      // Ctrl+Arrow keys redirect to vim word navigation (check before regular arrows)
+      if (key.ctrl && key.leftArrow) {
+        return commands["b"]();
+      }
+
+      if (key.ctrl && key.rightArrow) {
+        return commands["e"]();
+      }
+
       // Arrow keys and Home/End redirect to vim commands
       if (key.leftArrow) {
         return commands["h"]();


### PR DESCRIPTION
The Home/End key input in ink depends on ink >= v6.6.0 as that was the first release to support it.  Octofriend moved to ink v6.6.0 in fbc7ddffbefd1da51c00df95b8e017a3dabfc44a.

Fixes: https://github.com/synthetic-lab/octofriend/issues/43