### PR TITLE
Prevent key strokes after control to leak into input.

### DIFF
--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -191,13 +191,7 @@ export default function TextInput({
         // Vim didn't consume it, continue with normal processing
       }
 
-      if (
-        key.upArrow ||
-        key.downArrow ||
-        (key.ctrl && input === "c") ||
-        key.tab ||
-        (key.shift && key.tab)
-      ) {
+      if (key.upArrow || key.downArrow || key.ctrl || key.tab || (key.shift && key.tab)) {
         return;
       }
 


### PR DESCRIPTION
When I did Ctrl+P earlier to open the menu, I noticed that it added a "p" in the input, so decided to blanket ignore any characters typed after "Ctrl".

The question is, I don't use Vim; would this fix mess things up? I didn't try it yet but...