### PR TITLE
Add 'Create OCTO.md' option to Ctrl+p menu

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -111,7 +111,7 @@ function toStaticItems(messages: HistoryItem[]): Array<StaticItem> {
   }));
 }
 
-const TransportContext = createContext<Transport>(new LocalTransport());
+export const TransportContext = createContext<Transport>(new LocalTransport());
 
 const UNCHAINED_NOTIF = "Octo runs edits and shell commands automatically";
 const CHAINED_NOTIF = "Octo asks permission before running edits or shell commands";

--- a/source/components/confirm-dialog.tsx
+++ b/source/components/confirm-dialog.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Box } from "ink";
+import { Box, Text, useInput } from "ink";
 import { KbShortcutSelect, Item, ShortcutArray } from "./kb-select/kb-shortcut-select.tsx";
 
 export function ConfirmDialog({
@@ -8,12 +8,16 @@ export function ConfirmDialog({
   onConfirm,
   onReject,
   rejectFirst = false,
+  title,
+  message,
 }: {
   confirmLabel: string;
   rejectLabel: string;
   onConfirm: () => any;
   onReject: () => any;
   rejectFirst?: boolean;
+  title?: string;
+  message?: string;
 }) {
   const items = [
     {
@@ -47,9 +51,19 @@ export function ConfirmDialog({
     return onReject();
   }, []);
 
+  useInput((_, key) => {
+    if (key.escape) {
+      onReject();
+    }
+  });
+
   return (
-    <Box justifyContent="center">
-      <KbShortcutSelect shortcutItems={items} onSelect={onSelect} />
+    <Box flexDirection="column" gap={1}>
+      {title && <Text bold>{title}</Text>}
+      {message && <Text>{message}</Text>}
+      <Box justifyContent="center">
+        <KbShortcutSelect shortcutItems={items} onSelect={onSelect} />
+      </Box>
     </Box>
   );
 }

--- a/source/state.ts
+++ b/source/state.ts
@@ -118,6 +118,44 @@ export const useAppStore = create<UiState>((set, get) => ({
   clearNonce: 0,
 
   input: async ({ config, query, transport }) => {
+    if (query === "/init") {
+      const { fileExists } = await import("./fs-utils.ts");
+      const octoMdExists = await fileExists("OCTO.md");
+
+      if (octoMdExists) {
+        query = `There is already an OCTO.md file in this directory. Please review it and update it to be more helpful and comprehensive.
+
+You should:
+1. First, read the existing OCTO.md to understand what's already there
+2. Explore the project structure using the list tool to understand the codebase
+3. Read key files like package.json, README.md, or similar to understand the project's purpose, dependencies, and architecture
+4. Update the OCTO.md file with improved or missing context including:
+   - What this project is about
+   - Tech stack and key dependencies
+   - Project structure overview
+   - Build/test/development commands
+   - Any coding conventions or guidelines specific to this project
+   - Helpful tips for working effectively with this codebase
+
+Use the rewrite tool to update the OCTO.md file. Focus on actionable, specific guidance rather than generic advice. Keep existing good content and improve or expand on it.`;
+      } else {
+        query = `Please analyze the current project and create an OCTO.md file. 
+
+You should:
+1. First, explore the project structure using the list tool to understand the codebase
+2. Read key files like package.json, README.md, or similar to understand the project's purpose, dependencies, and architecture
+3. Create an OCTO.md file with helpful context including:
+   - What this project is about
+   - Tech stack and key dependencies
+   - Project structure overview
+   - Build/test/development commands
+   - Any coding conventions or guidelines specific to this project
+   - Helpful tips for working effectively with this codebase
+
+The OCTO.md should be useful for an AI assistant like me to help with future tasks in this project. Focus on actionable, specific guidance rather than generic advice.`;
+      }
+    }
+
     const userMessage: UserItem = {
       type: "user",
       id: sequenceId(),


### PR DESCRIPTION
Users can now create or update OCTO.md files directly from the menu.

## Changes

- Added new menu option (key "i") to create or update OCTO.md files
- Automatically detects existing OCTO.md and prompts user whether to update or create new
- Uses AI to analyze project structure and generate contextual documentation
- Adds optional title/message props to ConfirmDialog for better UX
- Exports TransportContext for menu component access

## How it works

1. Press Ctrl+p to open the menu
2. Press "i" to select "◎ Create OCTO.md"
3. Confirmation dialog appears:
   - If OCTO.md exists: asks if you want to update it
   - If OCTO.md doesn't exist: confirms creation
4. Octo analyzes the project using tools (list, read, etc.)
5. Creates or updates OCTO.md with helpful context

## Technical details

- The menu option triggers an internal "/init" command
- state.ts intercepts this and transforms it into a detailed AI prompt
- The AI explores the codebase and generates project-specific documentation
- Similar to how OpenCode handles /init