### PR TITLE
Prevent Ctrl+p typing "p" into text input

### DIFF
--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -154,6 +154,11 @@ export default function TextInput({
     (input, key) => {
       if (isInitializing) return;
 
+      // Prevent Ctrl+p from being typed into input (it opens the menu)
+      if (key.ctrl && input === "p") {
+        return;
+      }
+
       const currentValue = valueRef.current;
       const previousCursorOffset = cursorOffsetRef.current;
       const previousCursorWidth = cursorWidthRef.current;


### PR DESCRIPTION
Introduced in a6af3a003b1b812eb9d0bc3e5e1d6739c49ed2a0 "Move query state to state.ts to prevent prompts from being wiped on re-render" we need to make sure that when the user inputs Ctrl+p to open the menu that a "p" is not inserted into the text input box.

Fixes: https://github.com/synthetic-lab/octofriend/issues/106