### PR TITLE
Ensure all known API keys save to config file

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -301,15 +301,9 @@ export async function writeKeyForModel(model: { baseUrl: string }, apiKey: strin
   const keys = await readKeys();
   keys[model.baseUrl] = apiKey;
   await fs.mkdir(CONFIG_DIR, { recursive: true });
-  await fs.writeFile(
-    KEY_FILE,
-    json5.stringify({
-      [model.baseUrl]: apiKey,
-    }),
-    {
-      mode: 0o600,
-    },
-  );
+  await fs.writeFile(KEY_FILE, json5.stringify(keys), {
+    mode: 0o600,
+  });
 }
 
 async function readKeys() {


### PR DESCRIPTION
When adding a new base URL provider with a new API key value, make sure that we preserve all existing API keys and not just write out the newest one to the keys config file.

Fixes: https://github.com/synthetic-lab/octofriend/issues/103