### PR TITLE
Add "Edit & retry" option to error handling

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -458,9 +458,10 @@ function RequestErrorScreen({
 }) {
   const config = useConfig();
   const transport = useContext(TransportContext);
-  const { retryFrom } = useAppStore(
+  const { retryFrom, editAndRetryFrom } = useAppStore(
     useShallow(state => ({
       retryFrom: state.retryFrom,
+      editAndRetryFrom: state.editAndRetryFrom,
     })),
   );
   const { exit } = useApp();
@@ -469,7 +470,7 @@ function RequestErrorScreen({
   const [copiedCurl, setCopiedCurl] = useState(false);
   const [clipboardError, setClipboardError] = useState<string | null>(null);
 
-  const mapping: Record<string, Item<"view" | "copy-curl" | "retry" | "quit">> = {};
+  const mapping: Record<string, Item<"view" | "copy-curl" | "retry" | "edit-retry" | "quit">> = {};
 
   if (!viewError) {
     mapping["v"] = {
@@ -490,12 +491,17 @@ function RequestErrorScreen({
     value: "retry",
   };
 
+  mapping["e"] = {
+    label: "Edit & retry",
+    value: "edit-retry",
+  };
+
   mapping["q"] = {
     label: "Quit Octo",
     value: "quit",
   };
 
-  const shortcutItems: ShortcutArray<"view" | "copy-curl" | "retry" | "quit"> = [
+  const shortcutItems: ShortcutArray<"view" | "copy-curl" | "retry" | "edit-retry" | "quit"> = [
     {
       type: "key" as const,
       mapping,
@@ -503,7 +509,7 @@ function RequestErrorScreen({
   ];
 
   const onSelect = useCallback(
-    (item: Item<"view" | "copy-curl" | "retry" | "quit">) => {
+    (item: Item<"view" | "copy-curl" | "retry" | "edit-retry" | "quit">) => {
       if (item.value === "view") {
         setViewError(true);
       } else if (item.value === "copy-curl") {
@@ -515,6 +521,8 @@ function RequestErrorScreen({
         }
       } else if (item.value === "retry") {
         retryFrom(mode, { config, transport });
+      } else if (item.value === "edit-retry") {
+        editAndRetryFrom(mode, { config, transport });
       } else {
         const _: "quit" = item.value;
         exit();


### PR DESCRIPTION
When a request encounters an error from the server, allow the user to edit their last prompt in order to try again.  This allows more flexibility for working around server or model issues without forcing the user to blindly retry or exit and lose all their context.

When performing an "Edit & retry" operation, fully remove the failing request and any partial results returned by the model so that the failed request doesn't show up in context.

If the user wants to change models, that can be done when editing the request just like normal.

Fixes: https://github.com/synthetic-lab/octofriend/issues/115