### PR TITLE
Remove left/right borders from input field

### DIFF
--- a/source/components/input-with-history.tsx
+++ b/source/components/input-with-history.tsx
@@ -78,7 +78,14 @@ export const InputWithHistory = React.memo((props: Props) => {
   };
 
   return (
-    <Box width="100%" borderStyle="round" borderColor={themeColor} gap={1}>
+    <Box
+      width="100%"
+      borderLeft={false}
+      borderRight={false}
+      borderStyle="single"
+      borderColor={themeColor}
+      gap={1}
+    >
       <Text color="gray">&gt;</Text>
       <TextInput
         value={props.value}


### PR DESCRIPTION
**Before:**
<img width="727" height="172" alt="Screenshot 2026-02-02 at 5 56 02 PM" src="https://github.com/user-attachments/assets/8378027b-27e2-4ff5-b8b2-397019dfef30" />

**After:**
<img width="730" height="140" alt="Screenshot 2026-02-02 at 5 56 29 PM" src="https://github.com/user-attachments/assets/b9b08016-4309-4f64-8174-99fb356e4eff" />

This gets rid of a lot of copy/paste funkiness where users would select in addition to their desired text a bunch of `|` characters.