### PR TITLE
Add a canary-octo shell file to optionally source for unreleased builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,8 @@ underlying error messages from APIs or tool calls, run Octo with the
 ```bash
 OCTO_VERBOSE=1 octofriend
 ```
+
+## Opting into canary versions
+
+If you want to use unreleased versions of Octo, clone this repo and read the
+instructions in `canary.sh` to install `canary-octo` in your shell.

--- a/canary.sh
+++ b/canary.sh
@@ -1,0 +1,20 @@
+# To opt into canary builds, source this file in your .zshrc or .bashrc
+# Usage: source /path/to/canary.sh
+#
+# This creates a canary-octo function that will build whatever you have in your
+# current octofriend checkout and run it, allowing you to use the main branch
+# without waiting for new octo releases, or to use an in-development branch
+# easily.
+if [ -n "$ZSH_VERSION" ]; then
+  _OCTOFRIEND_DIR="${0:A:h}"
+elif [ -n "$BASH_VERSION" ]; then
+  _OCTOFRIEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+  echo "Unsupported shell. Please use bash or zsh."
+  return 1
+fi
+
+function canary-octo() {
+  (cd "$_OCTOFRIEND_DIR" && npm run build) || return 1
+  node "$_OCTOFRIEND_DIR/dist/source/cli.js" "$@"
+}


### PR DESCRIPTION
Adds a script you can optionally source from the repo, which will define a function called `canary-octo` if you source it in your bashrc/bash profile/zshrc. `canary-octo` auto-rebuilds whatever you have checked out in your `octofriend` repo and runs that version of Octo; it's effectively  a canary build of Octo for folks who want to play around with unreleased features (e.g. contributors!).

This was a feature request from Discord!