### PR TITLE
Retain pre-menu vim mode on menu exit

### DIFF
--- a/source/menu.tsx
+++ b/source/menu.tsx
@@ -79,10 +79,11 @@ function AutofixToggle({
       setMenuMode: state.setMenuMode,
     })),
   );
-  const { toggleMenu, notify } = useAppStore(
+  const { toggleMenu, notify, resetPreMenuVimMode } = useAppStore(
     useShallow(state => ({
       toggleMenu: state.toggleMenu,
       notify: state.notify,
+      resetPreMenuVimMode: state.resetPreMenuVimMode,
     })),
   );
 
@@ -327,10 +328,11 @@ function filterSettings(config: Config) {
 }
 
 function MainMenu() {
-  const { toggleMenu, notify } = useAppStore(
+  const { toggleMenu, notify, resetPreMenuVimMode } = useAppStore(
     useShallow(state => ({
       toggleMenu: state.toggleMenu,
       notify: state.notify,
+      resetPreMenuVimMode: state.resetPreMenuVimMode,
     })),
   );
 
@@ -442,6 +444,11 @@ function MainMenu() {
 
         // Write ONLY to config - single source of truth
         await setConfig({ ...config, vimEmulation: { enabled: !wasEnabled } });
+
+        // When switching from Emacs to Vim, default to INSERT mode
+        if (!wasEnabled) {
+          resetPreMenuVimMode();
+        }
 
         // Notify user
         notify(`Switched to ${wasEnabled ? "Emacs" : "Vim"} mode`);

--- a/source/state.ts
+++ b/source/state.ts
@@ -96,6 +96,7 @@ export type UiState = {
   openMenu: () => void;
   closeMenu: () => void;
   setVimMode: (vimMode: "INSERT" | "NORMAL") => void;
+  resetPreMenuVimMode: () => void;
   setModelOverride: (m: string) => void;
   setQuery: (query: string) => void;
   retryFrom: (
@@ -249,6 +250,10 @@ export const useAppStore = create<UiState>((set, get) => ({
         modeData: { mode: "input", vimMode },
       });
     }
+  },
+
+  resetPreMenuVimMode: () => {
+    set({ preMenuVimMode: "INSERT" });
   },
 
   setQuery: query => {


### PR DESCRIPTION
When entering then exiting the menu, return to input mode in the same vim mode as it was in before the menu was opened.  So for example:

1. vim insert mode
2. open menu with ctrl+p
3. change model
4. return to input mode still in vim insert mode

Or:

1. vim insert mode
2. open menu with ctrl+p
3. exit menu
4. return to input mode still in vim insert mode

Additionally, when switching from emacs mode to vim mode, always enter vim mode in vim insert mode.  This keeps consistency with how vim mode goes into insert mode upon return from all model interactions and so the user can keep typing after the switch from emacs to vim mode, plus there's the nice `-- INSERT --` indicator so it's clear what mode you're in.

Fixes: https://github.com/synthetic-lab/octofriend/issues/120