### PR TITLE
Fix broken randomness mock in JSON fuzzing tests

### DIFF
--- a/training/fix-json/generate-broken-json.test.ts
+++ b/training/fix-json/generate-broken-json.test.ts
@@ -26,7 +26,7 @@ describe('JSON fuzzing functions', () => {
   const mockRandom = (returnValues: number[]) => {
     let index = 0;
     return () => {
-      return returnValues[index++] || 0.5;
+      return returnValues[index++] ?? 0.5;
     };
   };
 
@@ -69,7 +69,7 @@ describe('JSON fuzzing functions', () => {
         });
 
         expect(result).toBeDefined();
-        expect(result?.broken).toEqual("numll");
+        expect(result?.broken).toEqual("nuall");
       });
     });
   });
@@ -113,7 +113,7 @@ describe('JSON fuzzing functions', () => {
         });
         
         expect(result).toBeDefined();
-        expect(result?.broken).toMatch("famlse");
+        expect(result?.broken).toMatch("faalse");
       });
     });
   });


### PR DESCRIPTION
The mockRandom helper used || to provide a fallback value, which caused the mock to return 0.5 instead of 0 when 0 was explicitly specified in the test values array. This happened because 0 is falsy in JavaScript.

When commit de5250b ("Fix randomness functions") corrected the zeroToN function to no longer subtract 1 from its result, the interaction with the buggy mock changed: what previously produced 'm' now produced 'n'.

The tests were likely written to match observed behavior rather than correct behavior, since both the mock and zeroToN were buggy when the tests were introduced. Using ?? instead of || ensures 0 is treated as a valid return value, and the expectations are updated to reflect the actual character produced when the mock returns 0 ('a', not 'm' or 'n').

Fixes: https://github.com/synthetic-lab/octofriend/issues/125