### PR TITLE
Providers cleanup: Synthetic & Anthropic

### DIFF
--- a/source/providers.ts
+++ b/source/providers.ts
@@ -85,19 +85,19 @@ export const PROVIDERS = {
       {
         model: "claude-sonnet-4-5-20250929",
         nickname: "Claude 4.5 Sonnet",
-        context: 200 * 1024,
+        context: 200 * 1000,
         reasoning: "medium",
       },
       {
         model: "claude-opus-4-6",
         nickname: "Claude 4.6 Opus",
-        context: 200 * 1024,
+        context: 200 * 1000,
         reasoning: "medium",
       },
       {
         model: "claude-haiku-4-5-20251001",
         nickname: "Claude 4.5 Haiku",
-        context: 200 * 1024,
+        context: 200 * 1000,
         reasoning: "medium",
       },
     ],


### PR DESCRIPTION
Cleanup the context lengths and default list of models for the Synthetic and Anthropic providers.

Note: Anthropic use "k" to mean 1000 while Hugging Face models generally use "k" to mean 1024.

Refs: https://github.com/synthetic-lab/octofriend/issues/129
Fixes: https://github.com/synthetic-lab/octofriend/issues/127