### PR TITLE
fix: clear performance measures after streamText to prevent memory leak

### DIFF
--- a/source/compilers/responses.ts
+++ b/source/compilers/responses.ts
@@ -1,6 +1,7 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { streamText, tool, ModelMessage, jsonSchema } from "ai";
 import { t, toJSONSchema } from "structural";
+import { performance } from "node:perf_hooks";
 import { Compiler } from "./compiler-interface.ts";
 import { LlmIR, ToolCallRequest, AssistantMessage } from "../ir/llm-ir.ts";
 import { tryexpr } from "../tryexpr.ts";
@@ -424,6 +425,9 @@ export const runResponsesAgent: Compiler = async ({
           break;
       }
     }
+
+    // Clear performance measures to prevent memory leak from accumulating entries
+    performance.clearMeasures();
 
     // Track usage
     if (usage.input !== 0 || usage.output !== 0) {


### PR DESCRIPTION
Fixes Node.js MaxPerformanceEntryBufferExceededWarning by clearing performance measures after each streamText call. The AI SDK telemetry creates performance entries that accumulate without being cleared, eventually exceeding the 1,000,001 entry limit.