### PR TITLE
Make cwd a string property in Transport

### DIFF
--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -73,7 +73,7 @@ docker
   .option("--unchained", "Skips confirmation for all tools, running them immediately. Dangerous.")
   .argument("<target>", "The Docker container")
   .action(async (target, opts) => {
-    const transport = new DockerTransport({ type: "container", container: target });
+    const transport = await DockerTransport.create({ type: "container", container: target });
 
     try {
       await runMain({
@@ -95,7 +95,7 @@ docker
   .option("--unchained", "Skips confirmation for all tools, running them immediately. Dangerous.")
   .argument("[args...]", "The args to pass to `docker run`")
   .action(async (args, opts) => {
-    const transport = new DockerTransport({
+    const transport = await DockerTransport.create({
       type: "image",
       image: await manageContainer(args),
     });
@@ -137,7 +137,7 @@ async function runMain(opts: { config?: string; unchained?: boolean; transport: 
     }
 
     const skills = await discoverSkills(opts.transport, timeout(5000), config);
-    const cwd = await opts.transport.cwd(timeout(5000));
+    const cwd = opts.transport.cwd;
 
     const { waitUntilExit } = render(
       <App

--- a/source/components/file-suggestions/use-file-search.ts
+++ b/source/components/file-suggestions/use-file-search.ts
@@ -84,7 +84,7 @@ async function getCachedFileList(
   transport: ReturnType<typeof useTransport>,
   signal: AbortSignal,
 ): Promise<string[]> {
-  const cwd = await transport.cwd(signal);
+  const cwd = transport.cwd;
   const now = Date.now();
   const cached = fileCache.get(cwd);
 

--- a/source/skills/skills.ts
+++ b/source/skills/skills.ts
@@ -225,7 +225,7 @@ async function getDefaultSkillsPaths(transport: Transport, signal: AbortSignal):
   const paths: string[] = [];
   const home = await getEnvVar(signal, transport, "HOME", 5000);
   paths.push(path.join(home, ".config/agents/skills"));
-  const pwd = await transport.cwd(signal);
+  const pwd = transport.cwd;
   paths.push(path.join(pwd, ".agents", "skills"));
   return paths;
 }

--- a/source/tools/tool-defs/list.ts
+++ b/source/tools/tool-defs/list.ts
@@ -30,7 +30,7 @@ export default defineTool<t.GetType<typeof Schema>>(async () => ({
   ArgumentsSchema,
   validate,
   async run(abortSignal, transport, call) {
-    const dirpath = call.arguments?.dirPath || (await transport.cwd(abortSignal));
+    const dirpath = call.arguments?.dirPath || transport.cwd;
     await validate(abortSignal, transport, call);
     return attempt(`No such directory: ${dirpath}`, async () => {
       const entries = await transport.readdir(abortSignal, dirpath);

--- a/source/transports/docker.ts
+++ b/source/transports/docker.ts
@@ -50,24 +50,42 @@ type DockerTarget =
       type: "image";
       image: Awaited<ReturnType<typeof manageContainer>>;
     };
+
 export class DockerTransport implements Transport {
   private readonly _container: string;
+  cwd: string;
 
-  constructor(private readonly _target: DockerTarget) {
+  private constructor(
+    private readonly _target: DockerTarget,
+    cwd: string,
+  ) {
     if (this._target.type === "image") this._container = this._target.image.container;
     else this._container = this._target.container;
+    this.cwd = cwd;
+  }
+
+  static async create(target: DockerTarget): Promise<DockerTransport> {
+    const container = target.type === "image" ? target.image.container : target.container;
+    const cwd = await DockerTransport.runDockerCommand(
+      container,
+      ["pwd"],
+      5000,
+      new AbortController().signal,
+    );
+    return new DockerTransport(target, cwd.trim());
   }
 
   async close() {
     if (this._target.type === "image") await this._target.image.close();
   }
 
-  private async dockerExec(
-    signal: AbortSignal,
+  private static runDockerCommand(
+    container: string,
     command: string[],
     timeout: number,
+    signal: AbortSignal,
   ): Promise<string> {
-    const dockerCmd = ["docker", "exec", this._container, "/bin/sh", "-c", command.join(" ")];
+    const dockerCmd = ["docker", "exec", container, "/bin/sh", "-c", command.join(" ")];
 
     return new Promise<string>((resolve, reject) => {
       const child = spawn(dockerCmd[0], dockerCmd.slice(1), {
@@ -143,17 +161,22 @@ output: ${output}`,
     });
   }
 
+  private async dockerExec(
+    signal: AbortSignal,
+    command: string[],
+    timeout: number,
+  ): Promise<string> {
+    return DockerTransport.runDockerCommand(this._container, command, timeout, signal);
+  }
+
   async writeFile(signal: AbortSignal, file: string, contents: string): Promise<void> {
     // Create a temporary file with the contents
     const tempFile = `/tmp/octo_write_${randomSuffix()}`;
 
     // First, write the contents to the temp file using a base64 to avoid shellescape issues
     const base64Contents = Buffer.from(contents).toString("base64");
-    await this.dockerExec(
-      signal,
-      ["/bin/sh", "-c", `echo '${base64Contents}' | base64 -d > '${tempFile}'`],
-      5000,
-    );
+
+    await this.dockerExec(signal, [`echo '${base64Contents}' | base64 -d > '${tempFile}'`], 5000);
 
     try {
       // Ensure directory exists
@@ -258,10 +281,5 @@ output: ${output}`,
 
   async shell(signal: AbortSignal, command: string, timeout: number): Promise<string> {
     return await this.dockerExec(signal, [command], timeout);
-  }
-
-  async cwd(signal: AbortSignal) {
-    const output = await this.dockerExec(signal, ["pwd"], 5000);
-    return output.trim();
   }
 }

--- a/source/transports/docker.ts
+++ b/source/transports/docker.ts
@@ -41,6 +41,88 @@ function randomSuffix() {
   return `${Date.now()}_${Math.random().toString(16)}`;
 }
 
+async function runDockerCommand(
+  container: string,
+  command: string[],
+  timeout: number,
+  signal: AbortSignal,
+): Promise<string> {
+  const dockerCmd = ["docker", "exec", container, "/bin/sh", "-c", command.join(" ")];
+
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn(dockerCmd[0], dockerCmd.slice(1), {
+      timeout,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let output = "";
+    let aborted = false;
+
+    const onAbort = () => {
+      aborted = true;
+      // Try graceful termination first
+      child.kill("SIGTERM");
+      // Fallback to SIGKILL if it doesn't exit quickly
+      setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {}
+      }, 500).unref?.();
+    };
+
+    if (signal.aborted) onAbort();
+    signal.addEventListener("abort", onAbort);
+
+    const cleanup = () => {
+      signal.removeEventListener("abort", onAbort);
+    };
+
+    child.stdout.on("data", data => {
+      output += data.toString();
+    });
+
+    child.stderr.on("data", data => {
+      output += data.toString();
+    });
+
+    child.on("close", code => {
+      cleanup();
+      if (aborted) {
+        reject(new AbortError());
+        return;
+      }
+      if (code === 0) {
+        resolve(output);
+      } else {
+        if (code == null) {
+          reject(
+            new CommandFailedError(
+              `Command timed out.
+output: ${output}`,
+            ),
+          );
+        } else {
+          reject(
+            new CommandFailedError(
+              `Command exited with code: ${code}
+output: ${output}`,
+            ),
+          );
+        }
+      }
+    });
+
+    child.on("error", err => {
+      cleanup();
+      if (aborted) {
+        reject(new AbortError());
+        return;
+      }
+      reject(new CommandFailedError(`Command failed: ${err.message}`));
+    });
+  });
+}
+
 type DockerTarget =
   | {
       type: "container";
@@ -66,12 +148,7 @@ export class DockerTransport implements Transport {
 
   static async create(target: DockerTarget): Promise<DockerTransport> {
     const container = target.type === "image" ? target.image.container : target.container;
-    const cwd = await DockerTransport.runDockerCommand(
-      container,
-      ["pwd"],
-      5000,
-      new AbortController().signal,
-    );
+    const cwd = await runDockerCommand(container, ["pwd"], 5000, new AbortController().signal);
     return new DockerTransport(target, cwd.trim());
   }
 
@@ -79,94 +156,12 @@ export class DockerTransport implements Transport {
     if (this._target.type === "image") await this._target.image.close();
   }
 
-  private static runDockerCommand(
-    container: string,
-    command: string[],
-    timeout: number,
-    signal: AbortSignal,
-  ): Promise<string> {
-    const dockerCmd = ["docker", "exec", container, "/bin/sh", "-c", command.join(" ")];
-
-    return new Promise<string>((resolve, reject) => {
-      const child = spawn(dockerCmd[0], dockerCmd.slice(1), {
-        timeout,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-
-      let output = "";
-      let aborted = false;
-
-      const onAbort = () => {
-        aborted = true;
-        // Try graceful termination first
-        child.kill("SIGTERM");
-        // Fallback to SIGKILL if it doesn't exit quickly
-        setTimeout(() => {
-          try {
-            child.kill("SIGKILL");
-          } catch {}
-        }, 500).unref?.();
-      };
-
-      if (signal.aborted) onAbort();
-      signal.addEventListener("abort", onAbort);
-
-      const cleanup = () => {
-        signal.removeEventListener("abort", onAbort);
-      };
-
-      child.stdout.on("data", data => {
-        output += data.toString();
-      });
-
-      child.stderr.on("data", data => {
-        output += data.toString();
-      });
-
-      child.on("close", code => {
-        cleanup();
-        if (aborted) {
-          reject(new AbortError());
-          return;
-        }
-        if (code === 0) {
-          resolve(output);
-        } else {
-          if (code == null) {
-            reject(
-              new CommandFailedError(
-                `Command timed out.
-output: ${output}`,
-              ),
-            );
-          } else {
-            reject(
-              new CommandFailedError(
-                `Command exited with code: ${code}
-output: ${output}`,
-              ),
-            );
-          }
-        }
-      });
-
-      child.on("error", err => {
-        cleanup();
-        if (aborted) {
-          reject(new AbortError());
-          return;
-        }
-        reject(new CommandFailedError(`Command failed: ${err.message}`));
-      });
-    });
-  }
-
   private async dockerExec(
     signal: AbortSignal,
     command: string[],
     timeout: number,
   ): Promise<string> {
-    return DockerTransport.runDockerCommand(this._container, command, timeout, signal);
+    return runDockerCommand(this._container, command, timeout, signal);
   }
 
   async writeFile(signal: AbortSignal, file: string, contents: string): Promise<void> {

--- a/source/transports/local.ts
+++ b/source/transports/local.ts
@@ -4,9 +4,7 @@ import { spawn } from "child_process";
 import { Transport, AbortError, CommandFailedError, TransportError } from "./transport-common.ts";
 
 export class LocalTransport implements Transport {
-  async cwd() {
-    return process.cwd();
-  }
+  cwd = process.cwd();
 
   async close() {}
 

--- a/source/transports/transport-common.ts
+++ b/source/transports/transport-common.ts
@@ -1,6 +1,7 @@
 import { quote } from "shell-quote";
 
 export interface Transport {
+  readonly cwd: string;
   writeFile: (signal: AbortSignal, file: string, contents: string) => Promise<void>;
   readFile: (signal: AbortSignal, file: string) => Promise<string>;
   pathExists: (signal: AbortSignal, file: string) => Promise<boolean>;
@@ -18,7 +19,6 @@ export interface Transport {
   modTime: (signal: AbortSignal, file: string) => Promise<number>;
   resolvePath: (signal: AbortSignal, path: string) => Promise<string>;
   shell: (signal: AbortSignal, command: string, timeout: number) => Promise<string>;
-  cwd: (signal: AbortSignal) => Promise<string>;
   close: () => Promise<void>;
 }
 
@@ -63,7 +63,7 @@ export async function findFiles(
     type?: "f" | "d"; // -type f or -type d
   } = {},
 ): Promise<string[]> {
-  const cwd = options.cwd || (await transport.cwd(signal));
+  const cwd = options.cwd || transport.cwd;
 
   // Build find command with directory pruning
   const pruneArgs = EXCLUDED_DIRS.map(d => `-name ${quote([d])} -prune`).join(" -o ");


### PR DESCRIPTION
Separated this out into its own PR since it was required for LSP to work without relying on an async cwd() function. 

Instead of having `cwd` be a function in `transport`, it's now a `string` which gets initialized on app start.