### PR TITLE
Allow configuring a setting that runs after a prompt completes

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,12 @@ OCTO_VERBOSE=1 octofriend
 ## Notify Finish Command
 
 You can configure a command to run whenever Octo finishes responding to a prompt.
-This is useful for desktop notifications, sounds, or other integrations. Add a
-`notifyFinishCommand` to your `~/.config/octofriend/octofriend.json5`:
+This is useful for desktop notifications, sounds, or other integrations.
+
+This command will **not** run for tool call confirmations. It will only run when
+Octo is ready for a new prompt (eg. after responding to a prompt in unchained mode)
+
+Add a `notifyFinishCommand` to your `~/.config/octofriend/octofriend.json5`:
 
 ```json5
 notifyFinishCommand: "notify-send Octo 'Finished responding!'",

--- a/README.md
+++ b/README.md
@@ -257,6 +257,22 @@ underlying error messages from APIs or tool calls, run Octo with the
 OCTO_VERBOSE=1 octofriend
 ```
 
+## Notify Command
+
+You can configure a command to run whenever Octo finishes responding to a prompt.
+This is useful for desktop notifications, sounds, or other integrations. Add a
+`notifyCommand` to your `~/.config/octofriend/octofriend.json5`:
+
+```json5
+notifyCommand: "notify-send Octo 'Finished responding!'",
+```
+
+Or for macOS:
+
+```json5
+notifyCommand: 'osascript -e \'display notification "Octo finished!"\'',
+```
+
 ## Opting into canary versions
 
 If you want to use unreleased versions of Octo, clone this repo and read the

--- a/README.md
+++ b/README.md
@@ -257,20 +257,20 @@ underlying error messages from APIs or tool calls, run Octo with the
 OCTO_VERBOSE=1 octofriend
 ```
 
-## Notify Command
+## Notify Finish Command
 
 You can configure a command to run whenever Octo finishes responding to a prompt.
 This is useful for desktop notifications, sounds, or other integrations. Add a
-`notifyCommand` to your `~/.config/octofriend/octofriend.json5`:
+`notifyFinishCommand` to your `~/.config/octofriend/octofriend.json5`:
 
 ```json5
-notifyCommand: "notify-send Octo 'Finished responding!'",
+notifyFinishCommand: "notify-send Octo 'Finished responding!'",
 ```
 
 Or for macOS:
 
 ```json5
-notifyCommand: 'osascript -e \'display notification "Octo finished!"\'',
+notifyFinishCommand: 'osascript -e \'display notification "Octo finished!"\'',
 ```
 
 ## Opting into canary versions

--- a/source/config.ts
+++ b/source/config.ts
@@ -8,6 +8,7 @@ import json5 from "json5";
 import { execFile } from "child_process";
 import { fileExists } from "./fs-utils.ts";
 import { providerForBaseUrl, keyFromName, ProviderConfig } from "./providers.ts";
+import { spawn } from "child_process";
 
 const __dir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -132,6 +133,7 @@ const ConfigSchema = t.exact({
       paths: t.optional(t.array(t.str)),
     }),
   ),
+  notifyCommand: t.optional(t.str),
 });
 export type Config = t.GetType<typeof ConfigSchema>;
 export const AUTOFIX_KEYS = ["diffApply", "fixJson"] as const;
@@ -141,6 +143,32 @@ const authCommandCache = new Map<string, string>();
 
 const AUTH_COMMAND_TIMEOUT_MS = 15_000;
 const AUTH_COMMAND_MAX_OUTPUT_BYTES = 16 * 1024;
+
+const NOTIFY_COMMAND_TIMEOUT_MS = 15_000;
+
+export async function runNotifyCommand(config: Config): Promise<void> {
+  const cmd = config.notifyCommand;
+  if (!cmd || cmd.trim() === "") return;
+  const shell = process.env["SHELL"] || "/bin/sh";
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(shell, ["-c", cmd], {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: NOTIFY_COMMAND_TIMEOUT_MS,
+      env: process.env,
+    });
+
+    child.on("close", (code: number | null) => {
+      if (code !== 0) {
+        reject(new Error(`notifyCommand exited with code ${code}`));
+        return;
+      }
+      resolve();
+    });
+
+    child.on("error", reject);
+  });
+}
 
 /**
  * Resolves an Auth config to an API key.

--- a/source/config.ts
+++ b/source/config.ts
@@ -133,7 +133,7 @@ const ConfigSchema = t.exact({
       paths: t.optional(t.array(t.str)),
     }),
   ),
-  notifyCommand: t.optional(t.str),
+  notifyFinishCommand: t.optional(t.str),
 });
 export type Config = t.GetType<typeof ConfigSchema>;
 export const AUTOFIX_KEYS = ["diffApply", "fixJson"] as const;
@@ -147,7 +147,7 @@ const AUTH_COMMAND_MAX_OUTPUT_BYTES = 16 * 1024;
 const NOTIFY_COMMAND_TIMEOUT_MS = 15_000;
 
 export async function runNotifyCommand(config: Config): Promise<void> {
-  const cmd = config.notifyCommand;
+  const cmd = config.notifyFinishCommand;
   if (!cmd || cmd.trim() === "") return;
   const shell = process.env["SHELL"] || "/bin/sh";
 
@@ -160,7 +160,7 @@ export async function runNotifyCommand(config: Config): Promise<void> {
 
     child.on("close", (code: number | null) => {
       if (code !== 0) {
-        reject(new Error(`notifyCommand exited with code ${code}`));
+        reject(new Error(`notifyFinishCommand exited with code ${code}`));
         return;
       }
       resolve();

--- a/source/config.ts
+++ b/source/config.ts
@@ -5,10 +5,9 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import json5 from "json5";
-import { execFile } from "child_process";
+import { execFile, spawn } from "child_process";
 import { fileExists } from "./fs-utils.ts";
 import { providerForBaseUrl, keyFromName, ProviderConfig } from "./providers.ts";
-import { spawn } from "child_process";
 
 const __dir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -144,7 +143,7 @@ const authCommandCache = new Map<string, string>();
 const AUTH_COMMAND_TIMEOUT_MS = 15_000;
 const AUTH_COMMAND_MAX_OUTPUT_BYTES = 16 * 1024;
 
-const NOTIFY_COMMAND_TIMEOUT_MS = 15_000;
+const NOTIFY_COMMAND_TIMEOUT_MS = 10_000;
 
 export async function runNotifyCommand(config: Config): Promise<void> {
   const cmd = config.notifyFinishCommand;
@@ -153,7 +152,7 @@ export async function runNotifyCommand(config: Config): Promise<void> {
 
   await new Promise<void>((resolve, reject) => {
     const child = spawn(shell, ["-c", cmd], {
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", "ignore", "ignore"],
       timeout: NOTIFY_COMMAND_TIMEOUT_MS,
       env: process.env,
     });

--- a/source/state.ts
+++ b/source/state.ts
@@ -1,4 +1,10 @@
-import { Config, useConfig, getModelFromConfig, assertKeyForModel } from "./config.ts";
+import {
+  Config,
+  useConfig,
+  getModelFromConfig,
+  assertKeyForModel,
+  runNotifyCommand,
+} from "./config.ts";
 import {
   HistoryItem,
   UserItem,
@@ -489,6 +495,9 @@ export const useAppStore = create<UiState>((set, get) => ({
       const finishReason = finish.reason;
       if (finishReason.type === "abort" || finishReason.type === "needs-response") {
         set({ modeData: { mode: "input", vimMode: "INSERT" } });
+        if (finishReason.type === "needs-response") {
+          runNotifyCommand(config).catch(() => {});
+        }
         return;
       }
 


### PR DESCRIPTION
Adds a `notifyFinishCommand` config setting that allows specifying a command that runs after a prompt is complete and octo is waiting for input.

Useful for getting notified after long prompts.

This impl only notifies on finish, not every time Octo requires input (eg. for tool confirmations).

Was inspired to add this feature since I recently switched to a ghostty fork that listens for [OSC sequences](https://ghostty.org/docs/vt/concepts/sequences#osc) to present notifications. 

https://github.com/user-attachments/assets/db6b4fb9-83e4-437a-9b52-a7a7febba017

