### PR TITLE
Parallel tool calls

### DIFF
--- a/canary.fish
+++ b/canary.fish
@@ -16,5 +16,6 @@ function canary-octo
         return 1
     end
     cd "$old_dir"
+    set -gx CANARY_OCTO 1
     node "$_OCTOFRIEND_DIR/dist/source/cli.js" $argv
 end

--- a/canary.sh
+++ b/canary.sh
@@ -16,5 +16,5 @@ fi
 
 function canary-octo() {
   (cd "$_OCTOFRIEND_DIR" && npm run build) || return 1
-  node "$_OCTOFRIEND_DIR/dist/source/cli.js" "$@"
+  CANARY_OCTO=1 node "$_OCTOFRIEND_DIR/dist/source/cli.js" "$@"
 }

--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -256,6 +256,15 @@ export async function trajectoryArc({
   for (const toolCall of wellformedToolCalls) {
     try {
       await validateTool(abortSignal, transport, tools, toolCall.call, config);
+
+      // If we got this far, the tool validated successfully. Proactively push a tool-skip IR for
+      // it, in case other tool calls fail to validate (since all tool calls will be skipped if any
+      // are invalid).
+      retryIrs.push({
+        role: "tool-skip",
+        toolCall: toolCall,
+        reason: "One of your other tool calls was invalid, so no tool calls were run",
+      });
     } catch (e) {
       if (e instanceof FileOutdatedError) {
         const errorIr: TrajectoryOutputIR = await tryTransformFileOutdatedError(
@@ -317,6 +326,14 @@ export async function trajectoryArc({
               ...fn.arguments,
               ...fix,
             };
+
+            // Push a tool skip proactively
+            retryIrs.push({
+              role: "tool-skip",
+              toolCall: toolCall,
+              reason: "One of your other tool calls was invalid, so no tool calls were run",
+            });
+
             continue;
           }
         } catch {}
@@ -335,7 +352,14 @@ export async function trajectoryArc({
   }
 
   // If you have any IRs that need to be retried, retry them
-  if (retryIrs.length > 0) {
+  let needsRetry = false;
+  for (const ir of retryIrs) {
+    if (ir.role !== "tool-skip") {
+      needsRetry = true;
+      break;
+    }
+  }
+  if (needsRetry) {
     const fullRetryTrajectory = [...irs, ...retryIrs];
     handler.retryTool({ irs: fullRetryTrajectory });
     const retried = await trajectoryArc({
@@ -349,7 +373,7 @@ export async function trajectoryArc({
     });
     return {
       type: "finish",
-      irs: [...irs, ...retried.irs],
+      irs: [...fullRetryTrajectory, ...retried.irs],
       reason: retried.reason,
     };
   }

--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -67,7 +67,7 @@ type Finish = {
       }
     | {
         type: "request-tool";
-        toolCall: ToolCallRequest;
+        toolCalls: ToolCallRequest[];
       }
     | {
         type: "request-error";
@@ -110,6 +110,7 @@ export async function trajectoryArc({
     apiKey,
     model,
     abortSignal,
+    transport,
     autofixJson,
     messages: messagesCopy,
     handler: {
@@ -133,6 +134,7 @@ export async function trajectoryArc({
     model,
     autofixJson,
     abortSignal,
+    transport,
     tools,
     messages: messagesCopy,
     handlers: {
@@ -224,9 +226,9 @@ export async function trajectoryArc({
     };
   }
 
-  const { toolCall } = lastIr;
+  const { toolCalls } = lastIr;
 
-  if (toolCall == null) {
+  if (toolCalls == null) {
     return {
       type: "finish",
       reason: {
@@ -236,112 +238,110 @@ export async function trajectoryArc({
     };
   }
 
-  try {
-    await validateTool(abortSignal, transport, tools, toolCall.function, config);
-    return {
-      type: "finish",
-      reason: {
-        type: "request-tool",
-        toolCall,
-      },
-      irs,
-    };
-  } catch (e) {
-    if (e instanceof FileOutdatedError) {
-      const errorIrs: TrajectoryOutputIR = await tryTransformFileOutdatedError(
-        abortSignal,
-        transport,
-        toolCall,
-        e,
+  let retryIrs: TrajectoryOutputIR[] = [];
+  const wellformedToolCalls: Array<ToolCallRequest> = [];
+  for (const toolCall of toolCalls) {
+    if (toolCall.type === "malformed-request") {
+      throw new Error(
+        "Impossible tool ordering: encountered a malformed tool with no malformed response",
       );
-      const retryIrs = [...irs, errorIrs];
-      handler.retryTool({ irs: retryIrs });
-      const retried = await trajectoryArc({
-        apiKey,
-        model,
-        config,
-        transport,
-        abortSignal,
-        messages: messagesCopy.concat(retryIrs),
-        handler,
-      });
-      return {
-        type: "finish",
-        irs: [...irs, ...retried.irs],
-        reason: retried.reason,
-      };
     }
+    wellformedToolCalls.push(toolCall);
+  }
 
-    if (!(e instanceof ToolError)) throw e;
+  // TODO: use Promise.all to do this in parallel
+  // Requires changing the signature somewhat; currently we expect that the handlers are called
+  // sequentially (i.e. we only autofix one tool at a time), but this would imply we could call the
+  // handlers multiple times within a single validation step
+  for (const toolCall of wellformedToolCalls) {
+    try {
+      await validateTool(abortSignal, transport, tools, toolCall.call, config);
+    } catch (e) {
+      if (e instanceof FileOutdatedError) {
+        const errorIr: TrajectoryOutputIR = await tryTransformFileOutdatedError(
+          abortSignal,
+          transport,
+          toolCall,
+          e,
+        );
+        retryIrs = [...retryIrs, errorIr];
+        continue;
+      }
 
-    const fn = toolCall.function;
-    if (fn.name === "edit") {
-      handler.autofixingDiff(null);
-      const path = fn.arguments.filePath;
-      try {
-        const file = await fs.readFile(path, "utf8");
-        const fix = await autofixEdit(config, file, fn.arguments, abortSignal);
+      if (!(e instanceof ToolError)) throw e;
 
-        // If we aborted the autofix, slice off the messed up tool call and replace it with a failed
-        // tool call
-        if (abortSignal.aborted) {
-          return abort([
-            ...irs.slice(0, -1),
-            {
-              role: "tool-error",
-              toolCallId: toolCall.toolCallId,
-              toolName: toolCall.function.name,
-              error: e.message,
-            },
-          ]);
-        }
+      const fn = toolCall.call.parsed;
+      if (fn.name === "edit") {
+        handler.autofixingDiff(null);
+        const path = fn.arguments.filePath;
+        try {
+          const file = await fs.readFile(path, "utf8");
+          const fix = await autofixEdit(config, file, fn.arguments, abortSignal);
 
-        if (fix) {
-          // Validate that the edit applies before marking as fixed
-          await validateTool(
-            abortSignal,
-            transport,
-            tools,
-            {
+          // If we aborted the autofix, slice off the messed up tool call and replace it with a failed
+          // tool call
+          if (abortSignal.aborted) {
+            return abort([
+              ...irs.slice(0, -1),
+              {
+                role: "tool-error",
+                toolCall: toolCall,
+                error: e.message,
+              },
+            ]);
+          }
+
+          if (fix) {
+            // Validate that the edit applies before marking as fixed
+            const fixed = {
               name: "edit",
               arguments: fix,
-            },
-            config,
-          );
-          // If we got this far, it's valid: update the state and return
-          fn.arguments = {
-            ...fn.arguments,
-            ...fix,
-          };
-          return {
-            type: "finish",
-            reason: {
-              type: "request-tool",
-              toolCall,
-            },
-            irs,
-          };
-        }
-      } catch {}
-    }
+            } as const;
 
-    const retryIrs = [
-      ...irs,
-      {
-        role: "tool-error" as const,
-        toolCallId: toolCall.toolCallId,
-        toolName: toolCall.function.name,
-        error: e.message,
-      },
-    ];
-    handler.retryTool({ irs: retryIrs });
+            await validateTool(
+              abortSignal,
+              transport,
+              tools,
+              {
+                original: fixed,
+                parsed: fixed,
+              },
+              config,
+            );
+
+            // If we got this far, it's valid: update the state and keep going
+            fn.arguments = {
+              ...fn.arguments,
+              ...fix,
+            };
+            continue;
+          }
+        } catch {}
+      }
+
+      retryIrs = [
+        ...retryIrs,
+        {
+          role: "tool-error" as const,
+          toolCall: toolCall,
+          error: e.message,
+        },
+      ];
+      continue;
+    }
+  }
+
+  // If you have any IRs that need to be retried, retry them
+  if (retryIrs.length > 0) {
+    const fullRetryTrajectory = [...irs, ...retryIrs];
+    handler.retryTool({ irs: fullRetryTrajectory });
     const retried = await trajectoryArc({
       apiKey,
       model,
       config,
       transport,
       abortSignal,
-      messages: messagesCopy.concat(retryIrs),
+      messages: messagesCopy.concat(fullRetryTrajectory),
       handler,
     });
     return {
@@ -350,6 +350,16 @@ export async function trajectoryArc({
       reason: retried.reason,
     };
   }
+
+  // Got this far? Everything validated. Return the tool calls
+  return {
+    type: "finish",
+    reason: {
+      type: "request-tool",
+      toolCalls: wellformedToolCalls,
+    },
+    irs,
+  };
 }
 
 async function maybeAutocompact({
@@ -357,6 +367,7 @@ async function maybeAutocompact({
   model,
   messages,
   abortSignal,
+  transport,
   handler,
   autofixJson,
 }: {
@@ -364,6 +375,7 @@ async function maybeAutocompact({
   model: ModelConfig;
   messages: LlmIR[];
   abortSignal: AbortSignal;
+  transport: Transport;
   autofixJson: (badJson: string, signal: AbortSignal) => Promise<JsonFixResponse>;
   handler: {
     startCompaction: () => void;
@@ -380,6 +392,7 @@ async function maybeAutocompact({
     model,
     messages,
     abortSignal,
+    transport,
     autofixJson,
     handlers: {
       onTokens: (tokens, type) => {

--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -1,11 +1,5 @@
 import fs from "fs/promises";
-import {
-  LlmIR,
-  TrajectoryOutputIR,
-  CompactionCheckpoint,
-  ToolCallRequest,
-  ToolMalformedMessage,
-} from "../ir/llm-ir.ts";
+import { LlmIR, TrajectoryOutputIR, CompactionCheckpoint, ToolCallRequest } from "../ir/llm-ir.ts";
 import { QuotaData } from "../utils/quota.ts";
 import { Config, ModelConfig } from "../config.ts";
 import { Transport } from "../transports/transport-common.ts";

--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -13,6 +13,8 @@ import { makeAutofixJson } from "../compilers/autofix.ts";
 import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import { loadTools } from "../tools/index.ts";
 
+const SKIP_INVALID_REASON = "One of your other tool calls was invalid, so no tool calls were run";
+
 type AllTokenTypes = "reasoning" | "content" | "tool";
 
 type AssistantBuffer<AllowedType extends string> = {
@@ -277,7 +279,7 @@ export async function trajectoryArc({
       retryIrs.push({
         role: "tool-skip",
         toolCall: toolCall,
-        reason: "One of your other tool calls was invalid, so no tool calls were run",
+        reason: SKIP_INVALID_REASON,
       });
     } catch (e) {
       if (e instanceof FileOutdatedError) {
@@ -345,7 +347,7 @@ export async function trajectoryArc({
             retryIrs.push({
               role: "tool-skip",
               toolCall: toolCall,
-              reason: "One of your other tool calls was invalid, so no tool calls were run",
+              reason: SKIP_INVALID_REASON,
             });
 
             continue;

--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -295,7 +295,10 @@ export async function trajectoryArc({
             // Validate that the edit applies before marking as fixed
             const fixed = {
               name: "edit",
-              arguments: fix,
+              arguments: {
+                ...fn.arguments,
+                ...fix,
+              },
             } as const;
 
             await validateTool(

--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -1,5 +1,11 @@
 import fs from "fs/promises";
-import { LlmIR, TrajectoryOutputIR, CompactionCheckpoint, ToolCallRequest } from "../ir/llm-ir.ts";
+import {
+  LlmIR,
+  TrajectoryOutputIR,
+  CompactionCheckpoint,
+  ToolCallRequest,
+  ToolMalformedMessage,
+} from "../ir/llm-ir.ts";
 import { QuotaData } from "../utils/quota.ts";
 import { Config, ModelConfig } from "../config.ts";
 import { Transport } from "../transports/transport-common.ts";
@@ -203,11 +209,35 @@ export async function trajectoryArc({
     };
   }
 
-  irs = [...irs, ...result.output];
   let lastIr = result.output[result.output.length - 1];
 
   // Retry malformed tool calls
   if (lastIr.role === "tool-malformed") {
+    // Insert tool skips for all of the non-malformed tool call IRs, and ensure the original order
+    // is kept in terms of input ordering vs output message ordering
+    irs = [...irs];
+    const malformed = new Map<string, ToolMalformedMessage>();
+    for (const ir of result.output) {
+      if (ir.role === "tool-malformed") {
+        malformed.set(ir.toolCallId, ir);
+      }
+    }
+    const wellformed = result.output.filter(ir => ir.role === "assistant");
+    for (const ir of wellformed) {
+      irs.push(ir);
+      for (const call of ir.toolCalls || []) {
+        if (call.type === "tool-request") {
+          irs.push({
+            role: "tool-skip",
+            toolCall: call,
+            reason: "Another tool call in this batch was malformed, so this tool call was skipped",
+          });
+        } else {
+          irs.push(malformed.get(call.toolCallId)!);
+        }
+      }
+    }
+
     handler.retryTool({ irs });
     const retried = await trajectoryArc({
       apiKey,
@@ -226,6 +256,7 @@ export async function trajectoryArc({
     };
   }
 
+  irs = [...irs, ...result.output];
   const { toolCalls } = lastIr;
 
   if (toolCalls == null) {

--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -197,44 +197,34 @@ export async function trajectoryArc({
     };
   }
 
-  if (result.output.length === 0) {
-    return {
-      type: "finish",
-      irs: maybeBufferedMessage(),
-      reason: {
-        type: "request-error",
-        requestError: "No response from backend",
-        curl: result.curl,
-      },
-    };
-  }
-
-  let lastIr = result.output[result.output.length - 1];
+  let assistantMessage = result.output;
+  irs = [...irs, assistantMessage];
 
   // Retry malformed tool calls
-  if (lastIr.role === "tool-malformed") {
+  let malformedRequests = false;
+  for (const call of assistantMessage.toolCalls || []) {
+    if (call.type === "malformed-request") {
+      malformedRequests = true;
+      break;
+    }
+  }
+
+  if (malformedRequests) {
     // Insert tool skips for all of the non-malformed tool call IRs, and ensure the original order
     // is kept in terms of input ordering vs output message ordering
-    irs = [...irs];
-    const malformed = new Map<string, ToolMalformedMessage>();
-    for (const ir of result.output) {
-      if (ir.role === "tool-malformed") {
-        malformed.set(ir.toolCallId, ir);
-      }
-    }
-    const wellformed = result.output.filter(ir => ir.role === "assistant");
-    for (const ir of wellformed) {
-      irs.push(ir);
-      for (const call of ir.toolCalls || []) {
-        if (call.type === "tool-request") {
-          irs.push({
-            role: "tool-skip",
-            toolCall: call,
-            reason: "Another tool call in this batch was malformed, so this tool call was skipped",
-          });
-        } else {
-          irs.push(malformed.get(call.toolCallId)!);
-        }
+    for (const call of assistantMessage.toolCalls || []) {
+      if (call.type === "tool-request") {
+        irs.push({
+          role: "tool-skip",
+          toolCall: call,
+          reason: "Another tool call in this batch was malformed, so this tool call was skipped",
+        });
+      } else {
+        const _: "malformed-request" = call.type;
+        irs.push({
+          role: "tool-malformed",
+          malformedRequest: call,
+        });
       }
     }
 
@@ -256,8 +246,7 @@ export async function trajectoryArc({
     };
   }
 
-  irs = [...irs, ...result.output];
-  const { toolCalls } = lastIr;
+  const { toolCalls } = assistantMessage;
 
   if (toolCalls == null) {
     return {

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -964,12 +964,11 @@ const MessageDisplayInner = React.memo(({ item }: { item: HistoryItem | Inflight
   if (item.type === "tool-failed") {
     return (
       <Box flexDirection="column">
-        <ToolMessageRenderer item={item.toolCall} />
         <Box marginLeft={2}>
           <Text color="red">
             {displayLog({
               verbose: `Error: ${item.error}`,
-              info: "Tool returned an error...",
+              info: "Tool validation failed...",
             })}
           </Text>
         </Box>

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -30,7 +30,7 @@ import skill from "./tools/tool-defs/skill.ts";
 import webSearch from "./tools/tool-defs/web-search.ts";
 import glob from "./tools/tool-defs/glob.ts";
 import { ALWAYS_REQUEST_PERMISSION_TOOLS, SKIP_CONFIRMATION_TOOLS } from "./tools/index.ts";
-import { ArgumentsSchema as EditArgumentSchema } from "./tools/tool-defs/edit.ts";
+import { ParsedSchema as EditParsedSchema } from "./tools/tool-defs/edit.ts";
 import { ParsedToolSchemaFrom } from "./tools/common.ts";
 import { useShallow } from "zustand/react/shallow";
 import { KbShortcutPanel } from "./components/kb-select/kb-shortcut-panel.tsx";
@@ -176,7 +176,7 @@ export default function App({
   }
 
   const staticItems: StaticItem[] = useMemo(() => {
-    const items = [
+    let items = [
       { type: "header" as const },
       { type: "version" as const, metadata, config: currConfig },
       ...skillNotifs.map(s => ({ type: "boot-notification" as const, content: s })),
@@ -185,22 +185,8 @@ export default function App({
       ...toStaticItems(history),
     ];
 
-    if (modeData.mode === "tool-request") {
-      let toolCallsIdx = -1;
-      for (let i = items.length - 1; i >= 0; i--) {
-        const item = items[i];
-        if (item.type === "history-item" && item.item.type === "tool-calls") {
-          toolCallsIdx = i;
-          break;
-        }
-      }
-      if (toolCallsIdx !== -1) {
-        items.splice(toolCallsIdx);
-      }
-    }
-
     return items;
-  }, [history]);
+  }, [history, currConfig, skillNotifs, updates]);
 
   return (
     <InputPriorityProvider>
@@ -668,7 +654,6 @@ function ToolRequestsRenderer({
   toolReqs: ToolCallRequest[];
 } & RunArgs) {
   const runAgent = useAppStore(state => state.runAgent);
-  const history = useAppStore(state => state.history);
   const [currentIndex, setCurrentIndex] = useState(0);
 
   if (currentIndex >= toolReqs.length) {
@@ -677,26 +662,16 @@ function ToolRequestsRenderer({
 
   const currentToolReq = toolReqs[currentIndex];
 
-  let toolCallsIdx = -1;
-  for (let i = history.length - 1; i >= 0; i--) {
-    if (history[i].type === "tool-calls") {
-      toolCallsIdx = i;
-      break;
-    }
-  }
-  const historyAfterToolCalls = toolCallsIdx !== -1 ? history.slice(toolCallsIdx + 1) : [];
-
   return (
     <Box flexDirection="column">
-      {historyAfterToolCalls.map((item, index) => (
-        <MessageDisplay key={`accepted-${index}`} item={item} />
-      ))}
       <ToolMessageRenderer item={currentToolReq} />
       <ToolRequestRenderer
         toolReq={currentToolReq}
         config={config}
         transport={transport}
-        onDone={() => setCurrentIndex(i => i + 1)}
+        onDone={() => {
+          setCurrentIndex(i => i + 1);
+        }}
       />
     </Box>
   );
@@ -858,7 +833,7 @@ function ToolRequestRenderer({
     if (noConfirmationNeeded) {
       runTool({ toolReq, config, transport }).then(onDone);
     }
-  }, [toolReq, noConfirmationNeeded, config, transport]);
+  }, [toolReq, noConfirmationNeeded, config, transport, onDone]);
 
   if (noConfirmationNeeded || isRunning) {
     return (
@@ -1244,7 +1219,12 @@ function RewriteToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof rewri
   return (
     <Box flexDirection="column" gap={1}>
       <Text>Octo wants to rewrite the file:</Text>
-      <DiffRenderer oldText={originalFileContents} newText={text} filepath={filePath} />
+      <DiffRenderer
+        oldText={originalFileContents}
+        newText={text}
+        fileContents={originalFileContents}
+        filepath={filePath}
+      />
     </Box>
   );
 }
@@ -1253,13 +1233,18 @@ function DiffEditRenderer({
   item,
   filePath,
 }: {
-  item: t.GetType<typeof EditArgumentSchema>;
+  item: t.GetType<typeof EditParsedSchema>;
   filePath: string;
 }) {
   return (
     <Box flexDirection="column">
       <Text>Octo wants to make the following changes:</Text>
-      <DiffRenderer oldText={item.search} newText={item.replace} filepath={filePath} />
+      <DiffRenderer
+        oldText={item.search}
+        newText={item.replace}
+        fileContents={item.originalFileContents}
+        filepath={filePath}
+      />
     </Box>
   );
 }

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -655,6 +655,9 @@ function ToolRequestsRenderer({
 } & RunArgs) {
   const runAgent = useAppStore(state => state.runAgent);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const onDone = useCallback(() => {
+    setCurrentIndex(i => i + 1);
+  }, []);
 
   if (currentIndex >= toolReqs.length) {
     return <FinishToolRequests runAgent={runAgent} config={config} transport={transport} />;
@@ -669,9 +672,7 @@ function ToolRequestsRenderer({
         toolReq={currentToolReq}
         config={config}
         transport={transport}
-        onDone={() => {
-          setCurrentIndex(i => i + 1);
-        }}
+        onDone={onDone}
       />
     </Box>
   );

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -10,7 +10,7 @@ import {
   SetConfigContext,
   useConfig,
 } from "./config.ts";
-import { HistoryItem, ToolCallItem } from "./history.ts";
+import { HistoryItem, ToolCallItems } from "./history.ts";
 import Loading from "./components/loading.tsx";
 import { Header } from "./header.tsx";
 import { UnchainedContext, useColor, useUnchained } from "./theme.ts";
@@ -31,7 +31,7 @@ import webSearch from "./tools/tool-defs/web-search.ts";
 import glob from "./tools/tool-defs/glob.ts";
 import { ALWAYS_REQUEST_PERMISSION_TOOLS, SKIP_CONFIRMATION_TOOLS } from "./tools/index.ts";
 import { ArgumentsSchema as EditArgumentSchema } from "./tools/tool-defs/edit.ts";
-import { ToolSchemaFrom } from "./tools/common.ts";
+import { ParsedToolSchemaFrom } from "./tools/common.ts";
 import { useShallow } from "zustand/react/shallow";
 import { KbShortcutPanel } from "./components/kb-select/kb-shortcut-panel.tsx";
 import { Item, ShortcutArray } from "./components/kb-select/kb-shortcut-select.tsx";
@@ -43,7 +43,6 @@ import { IndicatorComponent } from "./components/select.tsx";
 import { displayLog } from "./logger.ts";
 import { CenteredBox } from "./components/centered-box.tsx";
 import { Transport } from "./transports/transport-common.ts";
-import { LocalTransport } from "./transports/local.ts";
 import { TransportContext } from "./transport-context.ts";
 import { markUpdatesSeen } from "./update-notifs/update-notifs.ts";
 import {
@@ -60,6 +59,7 @@ import { VimModeIndicator } from "./components/vim-mode.tsx";
 import { ScrollView, IsScrollableContext } from "./components/scroll-view.tsx";
 import { TerminalSizeTracker, useTerminalSize } from "./components/terminal-size.tsx";
 import { ToolCallRequest } from "./ir/llm-ir.ts";
+import { ToolResult } from "./tools/common.ts";
 import {
   InputPriorityProvider,
   usePriorityInput,
@@ -176,14 +176,30 @@ export default function App({
   }
 
   const staticItems: StaticItem[] = useMemo(() => {
-    return [
-      { type: "header" },
-      { type: "version", metadata, config: currConfig },
+    const items = [
+      { type: "header" as const },
+      { type: "version" as const, metadata, config: currConfig },
       ...skillNotifs.map(s => ({ type: "boot-notification" as const, content: s })),
       ...(updates ? [{ type: "updates" as const, updates }] : []),
-      { type: "slogan" },
+      { type: "slogan" as const },
       ...toStaticItems(history),
     ];
+
+    if (modeData.mode === "tool-request") {
+      let toolCallsIdx = -1;
+      for (let i = items.length - 1; i >= 0; i--) {
+        const item = items[i];
+        if (item.type === "history-item" && item.item.type === "tool-calls") {
+          toolCallsIdx = i;
+          break;
+        }
+      }
+      if (toolCallsIdx !== -1) {
+        items.splice(toolCallsIdx);
+      }
+    }
+
+    return items;
   }, [history]);
 
   return (
@@ -414,13 +430,6 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
   if (modeData.mode === "fix-json") {
     return <Loading overrideStrings={["Auto-fixing JSON"]} />;
   }
-  if (modeData.mode === "tool-waiting") {
-    return (
-      <Loading
-        overrideStrings={["Waiting", "Watching", "Smiling", "Hungering", "Splashing", "Writhing"]}
-      />
-    );
-  }
   if (modeData.mode === "payment-error") {
     return <PaymentErrorScreen error={modeData.error} />;
   }
@@ -449,7 +458,9 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
   }
 
   if (modeData.mode === "tool-request") {
-    return <ToolRequestRenderer toolReq={modeData.toolReq} config={config} transport={transport} />;
+    return (
+      <ToolRequestsRenderer toolReqs={modeData.toolReqs} config={config} transport={transport} />
+    );
   }
 
   const _: "menu" | "input" = modeData.mode;
@@ -649,12 +660,69 @@ const ToolRequestItem = React.memo(
   },
 );
 
+function ToolRequestsRenderer({
+  toolReqs,
+  config,
+  transport,
+}: {
+  toolReqs: ToolCallRequest[];
+} & RunArgs) {
+  const runAgent = useAppStore(state => state.runAgent);
+  const history = useAppStore(state => state.history);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  if (currentIndex >= toolReqs.length) {
+    return <FinishToolRequests runAgent={runAgent} config={config} transport={transport} />;
+  }
+
+  const currentToolReq = toolReqs[currentIndex];
+
+  let toolCallsIdx = -1;
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i].type === "tool-calls") {
+      toolCallsIdx = i;
+      break;
+    }
+  }
+  const historyAfterToolCalls = toolCallsIdx !== -1 ? history.slice(toolCallsIdx + 1) : [];
+
+  return (
+    <Box flexDirection="column">
+      {historyAfterToolCalls.map((item, index) => (
+        <MessageDisplay key={`accepted-${index}`} item={item} />
+      ))}
+      <ToolMessageRenderer item={currentToolReq} />
+      <ToolRequestRenderer
+        toolReq={currentToolReq}
+        config={config}
+        transport={transport}
+        onDone={() => setCurrentIndex(i => i + 1)}
+      />
+    </Box>
+  );
+}
+
+function FinishToolRequests({
+  runAgent,
+  config,
+  transport,
+}: {
+  runAgent: (args: RunArgs) => Promise<void>;
+} & RunArgs) {
+  useEffect(() => {
+    runAgent({ config, transport });
+  }, [runAgent, config, transport]);
+  return <Loading />;
+}
+
 function ToolRequestRenderer({
   toolReq,
   config,
   transport,
+  onDone,
 }: {
   toolReq: ToolCallRequest;
+  onDone: () => void;
 } & RunArgs) {
   const themeColor = useColor();
   const { runTool, rejectTool, isWhitelisted, addToWhitelist } = useAppStore(
@@ -668,7 +736,7 @@ function ToolRequestRenderer({
   const unchained = useUnchained();
 
   const whitelistKey = (() => {
-    const fn = toolReq.function;
+    const fn = toolReq.call.parsed;
     switch (fn.name) {
       case "read":
       case "list":
@@ -690,7 +758,7 @@ function ToolRequestRenderer({
     }
   })();
   const prompt = (() => {
-    const fn = toolReq.function;
+    const fn = toolReq.call.parsed;
     switch (fn.name) {
       case "create":
         return (
@@ -723,7 +791,7 @@ function ToolRequestRenderer({
     }
   })();
 
-  const toolName = toolReq.function.name;
+  const toolName = toolReq.call.parsed.name;
 
   const [isToolWhitelisted, setIsToolWhitelisted] = useState<boolean | null>(null);
 
@@ -764,29 +832,41 @@ function ToolRequestRenderer({
   const onSelect = useCallback(
     async (item: (typeof items)[number]) => {
       if (item.value === "no") {
-        rejectTool(toolReq.toolCallId);
+        rejectTool(toolReq);
       } else if (item.value === "yes-whitelist") {
         await addToWhitelist(whitelistKey);
         await runTool({ toolReq, config, transport });
+        onDone();
       } else {
         await runTool({ toolReq, config, transport });
+        onDone();
       }
     },
-    [toolReq, config, transport, addToWhitelist, runTool, rejectTool, whitelistKey],
+    [toolReq, config, transport, addToWhitelist, runTool, rejectTool, whitelistKey, onDone],
   );
+
+  const { modeData } = useAppStore(useShallow(state => ({ modeData: state.modeData })));
+  const isRunning =
+    modeData.mode === "tool-request" && modeData.runningToolCallId === toolReq.toolCallId;
 
   const noConfirmationNeeded =
     unchained ||
-    SKIP_CONFIRMATION_TOOLS.includes(toolReq.function.name) ||
+    SKIP_CONFIRMATION_TOOLS.includes(toolReq.call.parsed.name) ||
     isToolWhitelisted === true;
 
   useEffect(() => {
     if (noConfirmationNeeded) {
-      runTool({ toolReq, config, transport });
+      runTool({ toolReq, config, transport }).then(onDone);
     }
   }, [toolReq, noConfirmationNeeded, config, transport]);
 
-  if (noConfirmationNeeded) return <Loading />;
+  if (noConfirmationNeeded || isRunning) {
+    return (
+      <Loading
+        overrideStrings={["Waiting", "Watching", "Smiling", "Hungering", "Splashing", "Writhing"]}
+      />
+    );
+  }
 
   return (
     <Box flexDirection="column" gap={1}>
@@ -884,23 +964,15 @@ const MessageDisplayInner = React.memo(({ item }: { item: HistoryItem | Inflight
       </Box>
     );
   }
-  if (item.type === "tool") {
-    return (
-      <Box marginTop={1}>
-        <ToolMessageRenderer item={item} />
-      </Box>
-    );
+  if (item.type === "tool-calls") {
+    // Tool calls don't need to be rendered: the tool output will handle rendering
+    return null;
   }
   if (item.type === "tool-output") {
-    const lines = (() => {
-      if (item.result.lines == null) return item.result.content.split("\n").length;
-      return item.result.lines;
-    })();
     return (
-      <Box marginBottom={1}>
-        <Text color="gray">
-          Got <Text>{lines}</Text> lines of output
-        </Text>
+      <Box flexDirection="column" marginBottom={1}>
+        <ToolMessageRenderer item={item.toolCall} />
+        <ToolOutputContentRenderer result={item.result} />
       </Box>
     );
   }
@@ -916,28 +988,46 @@ const MessageDisplayInner = React.memo(({ item }: { item: HistoryItem | Inflight
   }
   if (item.type === "tool-failed") {
     return (
-      <Text color="red">
-        {displayLog({
-          verbose: `Error: ${item.error}`,
-          info: "Tool returned an error...",
-        })}
-      </Text>
+      <Box flexDirection="column">
+        <ToolMessageRenderer item={item.toolCall} />
+        <Box marginLeft={2}>
+          <Text color="red">
+            {displayLog({
+              verbose: `Error: ${item.error}`,
+              info: "Tool returned an error...",
+            })}
+          </Text>
+        </Box>
+      </Box>
     );
   }
   if (item.type === "tool-reject") {
-    return <Text>Tool rejected; tell Octo what to do instead:</Text>;
+    return (
+      <Box flexDirection="column">
+        <ToolMessageRenderer item={item.toolCall} />
+        <Box marginLeft={2}>
+          <Text>Tool rejected; tell Octo what to do instead:</Text>
+        </Box>
+      </Box>
+    );
   }
   if (item.type === "file-outdated") {
     return (
       <Box flexDirection="column">
-        <Text>File was modified since it was last read; re-reading...</Text>
+        <ToolMessageRenderer item={item.toolCall} />
+        <Box marginLeft={2}>
+          <Text>File was modified since it was last read; re-reading...</Text>
+        </Box>
       </Box>
     );
   }
   if (item.type === "file-unreadable") {
     return (
       <Box flexDirection="column">
-        <Text>File could not be read — has it been deleted?</Text>
+        <ToolMessageRenderer item={item.toolCall} />
+        <Box marginLeft={2}>
+          <Text>File could not be read — has it been deleted?</Text>
+        </Box>
       </Box>
     );
   }
@@ -987,38 +1077,41 @@ function CompactionSummaryRenderer({ summary }: { summary: string }) {
   );
 }
 
-function ToolMessageRenderer({ item }: { item: ToolCallItem }) {
-  switch (item.tool.function.name) {
+function ToolMessageRenderer({ item }: { item: ToolCallItems["tools"][number] }) {
+  if (item.type === "malformed-request") {
+    return null;
+  }
+  switch (item.call.parsed.name) {
     case "read":
-      return <ReadToolRenderer item={item.tool.function} />;
+      return <ReadToolRenderer item={item.call.parsed} />;
     case "list":
-      return <ListToolRenderer item={item.tool.function} />;
+      return <ListToolRenderer item={item.call.parsed} />;
     case "shell":
-      return <ShellToolRenderer item={item.tool.function} />;
+      return <ShellToolRenderer item={item.call.parsed} />;
     case "edit":
-      return <EditToolRenderer item={item.tool.function} />;
+      return <EditToolRenderer item={item.call.parsed} />;
     case "create":
-      return <CreateToolRenderer item={item.tool.function} />;
+      return <CreateToolRenderer item={item.call.parsed} />;
     case "mcp":
-      return <McpToolRenderer item={item.tool.function} />;
+      return <McpToolRenderer item={item.call.parsed} />;
     case "fetch":
-      return <FetchToolRenderer item={item.tool.function} />;
+      return <FetchToolRenderer item={item.call.parsed} />;
     case "append":
-      return <AppendToolRenderer item={item.tool.function} />;
+      return <AppendToolRenderer item={item.call.parsed} />;
     case "prepend":
-      return <PrependToolRenderer item={item.tool.function} />;
+      return <PrependToolRenderer item={item.call.parsed} />;
     case "rewrite":
-      return <RewriteToolRenderer item={item.tool.function} />;
+      return <RewriteToolRenderer item={item.call.parsed} />;
     case "skill":
-      return <SkillToolRenderer item={item.tool.function} />;
+      return <SkillToolRenderer item={item.call.parsed} />;
     case "web-search":
-      return <WebSearchToolRenderer item={item.tool.function} />;
+      return <WebSearchToolRenderer item={item.call.parsed} />;
     case "glob":
-      return <GlobRenderer item={item.tool.function} />;
+      return <GlobRenderer item={item.call.parsed} />;
   }
 }
 
-function GlobRenderer({ item }: { item: ToolSchemaFrom<typeof glob> }) {
+function GlobRenderer({ item }: { item: ParsedToolSchemaFrom<typeof glob> }) {
   return (
     <Box flexDirection="column">
       <Text color="gray">Octo searched for files using a glob pattern:</Text>
@@ -1038,7 +1131,7 @@ function GlobArg({ name, arg }: { name: string; arg: string | number | undefined
     </Text>
   );
 }
-function WebSearchToolRenderer(_: { item: ToolSchemaFrom<typeof webSearch> }) {
+function WebSearchToolRenderer(_: { item: ParsedToolSchemaFrom<typeof webSearch> }) {
   return (
     <Box>
       <Text color="gray">Octo searched the web</Text>
@@ -1046,7 +1139,7 @@ function WebSearchToolRenderer(_: { item: ToolSchemaFrom<typeof webSearch> }) {
   );
 }
 
-function SkillToolRenderer({ item }: { item: ToolSchemaFrom<typeof skill> }) {
+function SkillToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof skill> }) {
   return (
     <Box>
       <Text color="gray">Octo read the {item.arguments.skillName} skill</Text>
@@ -1054,7 +1147,7 @@ function SkillToolRenderer({ item }: { item: ToolSchemaFrom<typeof skill> }) {
   );
 }
 
-function AppendToolRenderer({ item }: { item: ToolSchemaFrom<typeof append> }) {
+function AppendToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof append> }) {
   const { filePath, text } = item.arguments;
 
   let startLineNr = 1;
@@ -1079,7 +1172,7 @@ function AppendToolRenderer({ item }: { item: ToolSchemaFrom<typeof append> }) {
   );
 }
 
-function FetchToolRenderer({ item }: { item: ToolSchemaFrom<typeof fetchTool> }) {
+function FetchToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof fetchTool> }) {
   const themeColor = useColor();
   return (
     <Box>
@@ -1089,7 +1182,7 @@ function FetchToolRenderer({ item }: { item: ToolSchemaFrom<typeof fetchTool> })
   );
 }
 
-function ShellToolRenderer({ item }: { item: ToolSchemaFrom<typeof shell> }) {
+function ShellToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof shell> }) {
   const themeColor = useColor();
   return (
     <Box flexDirection="column">
@@ -1102,7 +1195,7 @@ function ShellToolRenderer({ item }: { item: ToolSchemaFrom<typeof shell> }) {
   );
 }
 
-function ReadToolRenderer({ item }: { item: ToolSchemaFrom<typeof read> }) {
+function ReadToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof read> }) {
   const themeColor = useColor();
   return (
     <Box>
@@ -1112,7 +1205,7 @@ function ReadToolRenderer({ item }: { item: ToolSchemaFrom<typeof read> }) {
   );
 }
 
-function ListToolRenderer({ item }: { item: ToolSchemaFrom<typeof list> }) {
+function ListToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof list> }) {
   const themeColor = useColor();
   return (
     <Box>
@@ -1122,7 +1215,7 @@ function ListToolRenderer({ item }: { item: ToolSchemaFrom<typeof list> }) {
   );
 }
 
-function EditToolRenderer({ item }: { item: ToolSchemaFrom<typeof edit> }) {
+function EditToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof edit> }) {
   const themeColor = useColor();
   return (
     <Box flexDirection="column">
@@ -1135,7 +1228,7 @@ function EditToolRenderer({ item }: { item: ToolSchemaFrom<typeof edit> }) {
   );
 }
 
-function PrependToolRenderer({ item }: { item: ToolSchemaFrom<typeof prepend> }) {
+function PrependToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof prepend> }) {
   const { text, filePath } = item.arguments;
   return (
     <Box flexDirection="column" gap={1}>
@@ -1145,13 +1238,13 @@ function PrependToolRenderer({ item }: { item: ToolSchemaFrom<typeof prepend> })
   );
 }
 
-function RewriteToolRenderer({ item }: { item: ToolSchemaFrom<typeof rewrite> }) {
-  const { text, filePath } = item.arguments;
+function RewriteToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof rewrite> }) {
+  const { text, filePath, originalFileContents } = item.arguments;
 
   return (
     <Box flexDirection="column" gap={1}>
       <Text>Octo wants to rewrite the file:</Text>
-      <DiffRenderer newText={text} filepath={filePath} />
+      <DiffRenderer oldText={originalFileContents} newText={text} filepath={filePath} />
     </Box>
   );
 }
@@ -1171,7 +1264,7 @@ function DiffEditRenderer({
   );
 }
 
-function CreateToolRenderer({ item }: { item: ToolSchemaFrom<typeof createTool> }) {
+function CreateToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof createTool> }) {
   const themeColor = useColor();
   return (
     <Box flexDirection="column" gap={1}>
@@ -1187,7 +1280,7 @@ function CreateToolRenderer({ item }: { item: ToolSchemaFrom<typeof createTool> 
   );
 }
 
-function McpToolRenderer({ item }: { item: ToolSchemaFrom<typeof mcp> }) {
+function McpToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof mcp> }) {
   const themeColor = useColor();
   return (
     <Box flexDirection="column">
@@ -1202,8 +1295,19 @@ function McpToolRenderer({ item }: { item: ToolSchemaFrom<typeof mcp> }) {
   );
 }
 
+function ToolOutputContentRenderer({ result }: { result: ToolResult }) {
+  const lines = result.lines ?? result.content.split("\n").length;
+  return (
+    <Box marginLeft={2}>
+      <Text color="gray">
+        Got <Text>{lines}</Text> lines of output
+      </Text>
+    </Box>
+  );
+}
+
 function WhitelistAllowDescription({ toolCallRequest }: { toolCallRequest: ToolCallRequest }) {
-  const fn = toolCallRequest.function;
+  const fn = toolCallRequest.call.parsed;
   const cwd = useCwd();
   switch (fn.name) {
     case "glob":

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -956,7 +956,7 @@ const MessageDisplayInner = React.memo(({ item }: { item: HistoryItem | Inflight
     return (
       <Text color="red">
         {displayLog({
-          verbose: `Error: ${item.error}`,
+          verbose: `Error: ${item.malformedRequest.error}`,
           info: "Malformed tool call. Retrying...",
         })}
       </Text>

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -986,6 +986,12 @@ const MessageDisplayInner = React.memo(({ item }: { item: HistoryItem | Inflight
       </Box>
     );
   }
+
+  // Tool skips are tracked internally for explaining to LLMs, but are not shown to users
+  if (item.type === "tool-skip") {
+    return null;
+  }
+
   if (item.type === "file-outdated") {
     return (
       <Box flexDirection="column">

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -306,15 +306,7 @@ bench
       const ttft = (firstToken as Date).getTime() - start.getTime();
       const tokenElapsed = end.getTime() - (firstToken as Date).getTime();
 
-      const firstResult = result.output[0];
-      if (firstResult.role !== "assistant") {
-        return {
-          success: false,
-          error: "No assistant response",
-        };
-      }
-
-      const tokens = firstResult.outputTokens;
+      const tokens = result.output.outputTokens;
 
       const interTokenLatencies: number[] = [];
       for (let i = 1; i < tokenTimestamps.length; i++) {

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -218,6 +218,7 @@ bench
   .option("--concurrency <n>", "Concurrent requests to make. If omitted, defaults to 1")
   .action(async opts => {
     const { config } = await loadConfigWithoutReauth();
+    const transport = new LocalTransport();
     const model = opts.model
       ? config.models.find(m => m.nickname === opts.model)
       : config.models[0];
@@ -283,6 +284,7 @@ bench
           onAutofixJson: () => {},
         },
         abortSignal: abortController.signal,
+        transport,
       });
 
       if (!result.success) {
@@ -409,6 +411,7 @@ cli
   .argument("<prompt>", "The prompt you want to send to this model")
   .action(async (prompt, opts) => {
     const { config } = await loadConfig();
+    const transport = new LocalTransport();
     const model = opts.model
       ? config.models.find(m => m.nickname === opts.model)
       : config.models[0];
@@ -484,6 +487,7 @@ cli
         onAutofixJson: () => {},
       },
       abortSignal: abortController.signal,
+      transport,
     });
     if (!result.success) {
       console.error(result.requestError);

--- a/source/compilers/anthropic.ts
+++ b/source/compilers/anthropic.ts
@@ -176,6 +176,20 @@ function modelMessageFromIr(
     };
   }
 
+  if (ir.role === "tool-skip") {
+    return {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: ir.toolCall.toolCallId,
+          is_error: true,
+          content: irPrompts.toolSkip(ir.reason),
+        },
+      ],
+    };
+  }
+
   if (ir.role === "tool-error") {
     return {
       role: "user",

--- a/source/compilers/anthropic.ts
+++ b/source/compilers/anthropic.ts
@@ -2,7 +2,15 @@ import Anthropic from "@anthropic-ai/sdk";
 import { t, toJSONSchema } from "structural";
 import { Compiler } from "./compiler-interface.ts";
 import { sumAssistantTokens } from "../ir/count-ir-tokens.ts";
-import { AssistantMessage, LlmIR, ToolCallRequest, AnthropicAssistantData } from "../ir/llm-ir.ts";
+import {
+  AssistantMessage,
+  LlmIR,
+  ToolCallRequest,
+  MalformedRequest,
+  AnthropicAssistantData,
+  OutputIR,
+} from "../ir/llm-ir.ts";
+import { ToolDef } from "../tools/common.ts";
 import * as logger from "../logger.ts";
 import { tryexpr } from "../tryexpr.ts";
 import { trackTokens } from "../token-tracker.ts";
@@ -11,6 +19,7 @@ import { compactionCompilerExplanation } from "./autocompact.ts";
 import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
 import { canDisplayImage, MultimodalConfig } from "../providers.ts";
+import { Transport } from "../transports/transport-common.ts";
 
 const ThinkingBlockSchema = t.subtype({
   type: t.value("thinking"),
@@ -50,7 +59,7 @@ function modelMessageFromIr(
 ): Anthropic.MessageParam {
   if (ir.role === "assistant") {
     let thinkingBlocks = ir.anthropic?.thinkingBlocks || [];
-    const toolCalls = ir.toolCall ? [ir.toolCall] : [];
+    const toolCalls = ir.toolCalls || [];
     return {
       role: "assistant",
       content: [
@@ -60,8 +69,8 @@ function modelMessageFromIr(
           return {
             type: "tool_use" as const,
             id: t.toolCallId,
-            name: t.function.name,
-            input: t.function.arguments || {},
+            name: t.call.original.name,
+            input: t.call.original.arguments || {},
           };
         }),
       ],
@@ -167,7 +176,21 @@ function modelMessageFromIr(
     };
   }
 
-  if (ir.role === "tool-error" || ir.role === "tool-malformed") {
+  if (ir.role === "tool-error") {
+    return {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: ir.toolCall.toolCallId,
+          is_error: true,
+          content: `Error: ${ir.error}`,
+        },
+      ],
+    };
+  }
+
+  if (ir.role === "tool-malformed") {
     return {
       role: "user",
       content: [
@@ -233,7 +256,7 @@ function generateCurlFrom(params: {
     tools,
     tool_choice: {
       type: "auto",
-      disable_parallel_tool_use: true,
+      disable_parallel_tool_use: false,
     },
     max_tokens: maxTokens,
     stream: true,
@@ -258,6 +281,7 @@ export const runAnthropicAgent: Compiler = async ({
   irs,
   onTokens,
   abortSignal,
+  transport,
   systemPrompt,
   autofixJson,
   tools,
@@ -327,7 +351,7 @@ export const runAnthropicAgent: Compiler = async ({
       ...toolParams,
       tool_choice: {
         type: "auto",
-        disable_parallel_tool_use: true,
+        disable_parallel_tool_use: false,
       },
       max_tokens: maxTokens,
       ...thinking,
@@ -352,14 +376,15 @@ export const runAnthropicAgent: Compiler = async ({
           data: string;
         }
     > = [];
-    let inProgressTool:
-      | {
-          id: string;
-          index: number;
-          name: string;
-          partialJson: string;
-        }
-      | undefined = undefined;
+    let inProgressTools = new Map<
+      number,
+      {
+        id: string;
+        index: number;
+        name: string;
+        partialJson: string;
+      }
+    >();
 
     // Handle streaming chunks
     for await (const chunk of result) {
@@ -416,9 +441,12 @@ export const runAnthropicAgent: Compiler = async ({
               }
               break;
             case "input_json_delta":
-              if (inProgressTool != null && inProgressTool.index === chunk.index) {
-                onTokens(chunk.delta.partial_json, "tool");
-                inProgressTool.partialJson += chunk.delta.partial_json;
+              {
+                const tool = inProgressTools.get(chunk.index);
+                if (tool != null) {
+                  onTokens(chunk.delta.partial_json, "tool");
+                  tool.partialJson += chunk.delta.partial_json;
+                }
               }
               break;
           }
@@ -427,14 +455,12 @@ export const runAnthropicAgent: Compiler = async ({
           switch (chunk.content_block.type) {
             case "tool_use":
               onTokens(chunk.content_block.name, "tool");
-              if (inProgressTool == null) {
-                inProgressTool = {
-                  id: chunk.content_block.id,
-                  index: chunk.index,
-                  name: chunk.content_block.name,
-                  partialJson: "",
-                };
-              }
+              inProgressTools.set(chunk.index, {
+                id: chunk.content_block.id,
+                index: chunk.index,
+                name: chunk.content_block.name,
+                partialJson: "",
+              });
               break;
             case "redacted_thinking":
               thinkingBlocks.push({
@@ -503,36 +529,68 @@ export const runAnthropicAgent: Compiler = async ({
     }
 
     // No tools? Return
-    if (inProgressTool == null) {
+    if (inProgressTools.size === 0) {
       return { success: true, output: [assistantMessage], curl };
     }
 
-    // Get tool calls
-    const chatToolCall = {
-      toolCallId: inProgressTool.id,
-      toolName: inProgressTool.name,
-      args: inProgressTool.partialJson,
-    };
-    const parseResult = await parseTool(chatToolCall, toolDefs, autofixJson, abortSignal);
+    // Sort tool calls by their content block index to preserve ordering
+    const sortedTools = Array.from(inProgressTools.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([_, v]) => v);
 
-    if (parseResult.status === "error") {
+    const toolCalls: Array<ToolCallRequest | MalformedRequest> = [];
+    const malformedIrs: OutputIR[] = [];
+
+    for (const inProgressTool of sortedTools) {
+      const chatToolCall = {
+        toolCallId: inProgressTool.id,
+        toolName: inProgressTool.name,
+        args: inProgressTool.partialJson,
+      };
+      const parseResult = await parseTool(
+        chatToolCall,
+        toolDefs,
+        autofixJson,
+        abortSignal,
+        transport,
+      );
+
+      if (parseResult.status === "error") {
+        toolCalls.push({
+          type: "malformed-request",
+          toolCallId: inProgressTool.id,
+          call: {
+            original: {
+              name: inProgressTool.name,
+              arguments: inProgressTool.partialJson,
+            },
+          },
+        });
+        malformedIrs.push({
+          role: "tool-malformed",
+          error: parseResult.message,
+          toolName: inProgressTool.name,
+          arguments: inProgressTool.partialJson,
+          toolCallId: inProgressTool.id,
+        });
+        continue;
+      }
+
+      toolCalls.push(parseResult.tool);
+    }
+
+    if (toolCalls.length > 0) {
+      assistantMessage.toolCalls = toolCalls;
+    }
+
+    if (malformedIrs.length > 0) {
       return {
         success: true,
         curl,
-        output: [
-          assistantMessage,
-          {
-            role: "tool-malformed",
-            error: parseResult.message,
-            toolName: inProgressTool.name,
-            arguments: inProgressTool.partialJson,
-            toolCallId: inProgressTool.id,
-          },
-        ],
+        output: [assistantMessage, ...malformedIrs],
       };
     }
 
-    assistantMessage.toolCall = parseResult.tool;
     return { success: true, output: [assistantMessage], curl };
   } catch (e) {
     return {
@@ -555,9 +613,10 @@ type ParseToolResult =
 
 async function parseTool(
   toolCall: { toolCallId: string; toolName: string; args: any },
-  toolDefs: Record<string, any>,
+  toolDefs: Record<string, ToolDef<any, any, any>>,
   autofixJson: (badJson: string, signal: AbortSignal) => Promise<JsonFixResponse>,
   abortSignal: AbortSignal,
+  transport: Transport,
 ): Promise<ParseToolResult> {
   const name = toolCall.toolName;
   const toolDef = toolDefs[name];
@@ -600,18 +659,25 @@ Please try calling a valid tool.
   }
 
   try {
-    const parsed = toolSchema.slice({
+    const sliced = toolSchema.slice({
       name: toolCall.toolName,
       arguments: args,
     });
+    const parsed = await toolDef.parse(abortSignal, transport, sliced);
 
+    if (parsed.success) {
+      return {
+        status: "success",
+        tool: {
+          type: "tool-request",
+          call: parsed.data,
+          toolCallId: toolCall.toolCallId,
+        },
+      };
+    }
     return {
-      status: "success",
-      tool: {
-        type: "function",
-        function: parsed,
-        toolCallId: toolCall.toolCallId,
-      },
+      status: "error",
+      message: parsed.error,
     };
   } catch (e: unknown) {
     logger.error("verbose", e);

--- a/source/compilers/anthropic.ts
+++ b/source/compilers/anthropic.ts
@@ -8,7 +8,6 @@ import {
   ToolCallRequest,
   MalformedRequest,
   AnthropicAssistantData,
-  OutputIR,
 } from "../ir/llm-ir.ts";
 import { ToolDef } from "../tools/common.ts";
 import * as logger from "../logger.ts";
@@ -210,9 +209,9 @@ function modelMessageFromIr(
       content: [
         {
           type: "tool_result",
-          tool_use_id: ir.toolCallId,
+          tool_use_id: ir.malformedRequest.toolCallId,
           is_error: true,
-          content: `Error: ${ir.error}`,
+          content: `Error: ${ir.malformedRequest.error}`,
         },
       ],
     };
@@ -539,12 +538,12 @@ export const runAnthropicAgent: Compiler = async ({
     if (abortSignal.aborted) {
       // Success is only false when the request fails,
       // therefore success value is true here
-      return { success: true, output: [assistantMessage], curl };
+      return { success: true, output: assistantMessage, curl };
     }
 
     // No tools? Return
     if (inProgressTools.size === 0) {
-      return { success: true, output: [assistantMessage], curl };
+      return { success: true, output: assistantMessage, curl };
     }
 
     // Sort tool calls by their content block index to preserve ordering
@@ -553,7 +552,6 @@ export const runAnthropicAgent: Compiler = async ({
       .map(([_, v]) => v);
 
     const toolCalls: Array<ToolCallRequest | MalformedRequest> = [];
-    const malformedIrs: OutputIR[] = [];
 
     for (const inProgressTool of sortedTools) {
       const chatToolCall = {
@@ -572,6 +570,7 @@ export const runAnthropicAgent: Compiler = async ({
       if (parseResult.status === "error") {
         toolCalls.push({
           type: "malformed-request",
+          error: parseResult.message,
           toolCallId: inProgressTool.id,
           call: {
             original: {
@@ -580,32 +579,15 @@ export const runAnthropicAgent: Compiler = async ({
             },
           },
         });
-        malformedIrs.push({
-          role: "tool-malformed",
-          error: parseResult.message,
-          toolName: inProgressTool.name,
-          arguments: inProgressTool.partialJson,
-          toolCallId: inProgressTool.id,
-        });
         continue;
       }
 
       toolCalls.push(parseResult.tool);
     }
 
-    if (toolCalls.length > 0) {
-      assistantMessage.toolCalls = toolCalls;
-    }
+    if (toolCalls.length > 0) assistantMessage.toolCalls = toolCalls;
 
-    if (malformedIrs.length > 0) {
-      return {
-        success: true,
-        curl,
-        output: [assistantMessage, ...malformedIrs],
-      };
-    }
-
-    return { success: true, output: [assistantMessage], curl };
+    return { success: true, output: assistantMessage, curl };
   } catch (e) {
     return {
       success: false,

--- a/source/compilers/autocompact.ts
+++ b/source/compilers/autocompact.ts
@@ -113,10 +113,7 @@ export function processCompactedHistory(
   if (!compactSummaryAgentResult.success) {
     return;
   }
-  const assistantMessage = compactSummaryAgentResult.output.find(msg => msg.role === "assistant");
-  if (!assistantMessage || assistantMessage.role !== "assistant") {
-    return;
-  }
+  const assistantMessage = compactSummaryAgentResult.output;
 
   if (assistantMessage.content) {
     return assistantMessage.content;

--- a/source/compilers/autocompact.ts
+++ b/source/compilers/autocompact.ts
@@ -5,6 +5,7 @@ import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import { run } from "./run.ts";
 import { approximateIRTokens } from "../ir/count-ir-tokens.ts";
 import { CompactionRequestError } from "../errors.ts";
+import { Transport } from "../transports/transport-common.ts";
 
 const AUTOCOMPACT_THRESHOLD = 0.9;
 
@@ -58,6 +59,7 @@ export async function generateCompactionSummary({
   autofixJson,
   handlers,
   abortSignal,
+  transport,
 }: {
   apiKey: string;
   model: ModelConfig;
@@ -68,6 +70,7 @@ export async function generateCompactionSummary({
     onAutofixJson: (done: Promise<void>) => any;
   };
   abortSignal: AbortSignal;
+  transport: Transport;
 }): Promise<string | null> {
   const checkpointIndex = findMostRecentCompactionCheckpointIndex(messages);
   const slicedMessages = messages.slice(checkpointIndex);
@@ -85,6 +88,7 @@ export async function generateCompactionSummary({
     handlers,
     autofixJson,
     abortSignal,
+    transport,
     messages: summaryMessages,
   });
 

--- a/source/compilers/compiler-interface.ts
+++ b/source/compilers/compiler-interface.ts
@@ -4,6 +4,7 @@ import { QuotaData } from "../utils/quota.ts";
 import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import { LlmIR } from "../ir/llm-ir.ts";
 import { LoadedTools } from "../tools/index.ts";
+import { Transport } from "../transports/transport-common.ts";
 
 export type Compiler = (params: {
   systemPrompt?: () => Promise<string>;
@@ -13,6 +14,7 @@ export type Compiler = (params: {
   onTokens: (t: string, type: "reasoning" | "content" | "tool") => any;
   onQuotaUpdated?: (quota: QuotaData) => void;
   abortSignal: AbortSignal;
+  transport: Transport;
   autofixJson: (badJson: string, signal: AbortSignal) => Promise<JsonFixResponse>;
   tools?: Partial<LoadedTools>;
 }) => Promise<AgentResult>;

--- a/source/compilers/responses.ts
+++ b/source/compilers/responses.ts
@@ -2,7 +2,14 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { streamText, tool, ModelMessage, jsonSchema } from "ai";
 import { t, toJSONSchema } from "structural";
 import { Compiler } from "./compiler-interface.ts";
-import { LlmIR, ToolCallRequest, AssistantMessage } from "../ir/llm-ir.ts";
+import {
+  LlmIR,
+  ToolCallRequest,
+  MalformedRequest,
+  AssistantMessage,
+  OutputIR,
+} from "../ir/llm-ir.ts";
+import { ToolDef } from "../tools/common.ts";
 import { tryexpr } from "../tryexpr.ts";
 import { trackTokens } from "../token-tracker.ts";
 import { sumAssistantTokens } from "../ir/count-ir-tokens.ts";
@@ -13,6 +20,7 @@ import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
 import { canDisplayImage, MultimodalConfig } from "../providers.ts";
 import { APP_METADATA } from "../config.ts";
+import { Transport } from "../transports/transport-common.ts";
 
 async function toModelMessage(
   messages: LlmIR[],
@@ -63,7 +71,7 @@ function modelMessageFromIr(
           reasoningEncryptedContent: ir.openai.encryptedReasoningContent,
         };
       }
-      const toolCalls = ir.toolCall ? [ir.toolCall] : [];
+      const toolCalls = ir.toolCalls || [];
       return {
         role: "assistant",
         content: [
@@ -79,8 +87,8 @@ function modelMessageFromIr(
             return {
               type: "tool-call" as const,
               toolCallId: t.toolCallId,
-              toolName: t.function.name,
-              input: t.function.arguments || {},
+              toolName: t.call.original.name,
+              input: t.call.original.arguments || {},
             };
           }),
         ],
@@ -91,7 +99,7 @@ function modelMessageFromIr(
         },
       };
     }
-    const toolCalls = ir.toolCall ? [ir.toolCall] : [];
+    const toolCalls = ir.toolCalls || [];
     return {
       role: "assistant",
       content: [
@@ -100,8 +108,8 @@ function modelMessageFromIr(
           return {
             type: "tool-call" as const,
             toolCallId: t.toolCallId,
-            toolName: t.function.name,
-            input: t.function.arguments || {},
+            toolName: t.call.original.name,
+            input: t.call.original.arguments || {},
           };
         }),
       ],
@@ -155,7 +163,7 @@ function modelMessageFromIr(
       content: [
         {
           type: "tool-result" as const,
-          toolName: ir.toolCall.function.name,
+          toolName: ir.toolCall.call.original.name,
           toolCallId: ir.toolCall.toolCallId,
           output: {
             type: "text" as const,
@@ -179,7 +187,7 @@ function modelMessageFromIr(
       content: [
         {
           type: "tool-result" as const,
-          toolName: ir.toolCall.function.name,
+          toolName: ir.toolCall.call.original.name,
           toolCallId: ir.toolCall.toolCallId,
           output: {
             type: "text" as const,
@@ -196,7 +204,7 @@ function modelMessageFromIr(
       content: [
         {
           type: "tool-result",
-          toolName: ir.toolCall.function.name,
+          toolName: ir.toolCall.call.original.name,
           toolCallId: ir.toolCall.toolCallId,
           output: {
             type: "text" as const,
@@ -207,7 +215,24 @@ function modelMessageFromIr(
     };
   }
 
-  if (ir.role === "tool-error" || ir.role === "tool-malformed") {
+  if (ir.role === "tool-error") {
+    return {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: ir.toolCall.toolCallId,
+          toolName: ir.toolCall.call.original.name,
+          output: {
+            type: "text" as const,
+            value: `Error: ${ir.error}`,
+          },
+        },
+      ],
+    };
+  }
+
+  if (ir.role === "tool-malformed") {
     return {
       role: "tool",
       content: [
@@ -231,7 +256,7 @@ function modelMessageFromIr(
         {
           type: "tool-result",
           toolCallId: ir.toolCall.toolCallId,
-          toolName: ir.toolCall.function.name,
+          toolName: ir.toolCall.call.original.name,
           output: {
             type: "text",
             value: ir.error,
@@ -255,7 +280,7 @@ function modelMessageFromIr(
       {
         type: "tool-result",
         toolCallId: ir.toolCall.toolCallId,
-        toolName: ir.toolCall.function.name,
+        toolName: ir.toolCall.call.original.name,
         output: {
           type: "text",
           value: ir.error,
@@ -295,6 +320,7 @@ export const runResponsesAgent: Compiler = async ({
   irs,
   onTokens,
   abortSignal,
+  transport,
   systemPrompt,
   autofixJson,
   tools,
@@ -465,32 +491,59 @@ export const runResponsesAgent: Compiler = async ({
       return { success: true, output: [assistantHistoryItem], curl };
     }
 
-    const firstToolCall = toolCalls[0];
-    const chatToolCall = {
-      toolCallId: firstToolCall.toolCallId,
-      toolName: firstToolCall.toolName,
-      args: firstToolCall.input,
-    };
-    const parseResult = await parseTool(chatToolCall, toolDefs, autofixJson, abortSignal);
+    const parsedToolCalls: Array<ToolCallRequest | MalformedRequest> = [];
+    const malformedIrs: OutputIR[] = [];
 
-    if (parseResult.status === "error") {
+    for (const toolCall of toolCalls) {
+      const chatToolCall = {
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        args: toolCall.input,
+      };
+      const parseResult = await parseTool(
+        chatToolCall,
+        toolDefs,
+        autofixJson,
+        abortSignal,
+        transport,
+      );
+
+      if (parseResult.status === "error") {
+        parsedToolCalls.push({
+          type: "malformed-request",
+          call: {
+            original: {
+              name: toolCall.toolName,
+              arguments: toolCall.input,
+            },
+          },
+          toolCallId: toolCall.toolCallId,
+        });
+        malformedIrs.push({
+          role: "tool-malformed",
+          error: parseResult.message,
+          toolName: toolCall.toolName,
+          arguments: JSON.stringify(toolCall.input),
+          toolCallId: toolCall.toolCallId,
+        });
+        continue;
+      }
+
+      parsedToolCalls.push(parseResult.tool);
+    }
+
+    if (parsedToolCalls.length > 0) {
+      assistantHistoryItem.toolCalls = parsedToolCalls;
+    }
+
+    if (malformedIrs.length > 0) {
       return {
         success: true,
         curl,
-        output: [
-          assistantHistoryItem,
-          {
-            role: "tool-malformed",
-            error: parseResult.message,
-            toolName: firstToolCall.toolName,
-            arguments: JSON.stringify(firstToolCall.input),
-            toolCallId: firstToolCall.toolCallId,
-          },
-        ],
+        output: [assistantHistoryItem, ...malformedIrs],
       };
     }
 
-    assistantHistoryItem.toolCall = parseResult.tool;
     return { success: true, output: [assistantHistoryItem], curl };
   } catch (e) {
     return {
@@ -513,9 +566,10 @@ type ParseToolResult =
 
 async function parseTool(
   toolCall: { toolCallId: string; toolName: string; args: any },
-  toolDefs: Record<string, any>,
+  toolDefs: Record<string, ToolDef<any, any, any>>,
   autofixJson: (badJson: string, signal: AbortSignal) => Promise<JsonFixResponse>,
   abortSignal: AbortSignal,
+  transport: Transport,
 ): Promise<ParseToolResult> {
   const name = toolCall.toolName;
   const toolDef = toolDefs[name];
@@ -558,18 +612,25 @@ Please try calling a valid tool.
   }
 
   try {
-    const parsed = toolSchema.slice({
+    const sliced = toolSchema.slice({
       name: toolCall.toolName,
       arguments: args,
     });
+    const parsed = await toolDef.parse(abortSignal, transport, sliced);
 
+    if (parsed.success) {
+      return {
+        status: "success",
+        tool: {
+          type: "tool-request",
+          call: parsed.data,
+          toolCallId: toolCall.toolCallId,
+        },
+      };
+    }
     return {
-      status: "success",
-      tool: {
-        type: "function",
-        function: parsed,
-        toolCallId: toolCall.toolCallId,
-      },
+      status: "error",
+      message: parsed.error,
     };
   } catch (e: unknown) {
     logger.error("verbose", e);

--- a/source/compilers/responses.ts
+++ b/source/compilers/responses.ts
@@ -2,13 +2,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { streamText, tool, ModelMessage, jsonSchema } from "ai";
 import { t, toJSONSchema } from "structural";
 import { Compiler } from "./compiler-interface.ts";
-import {
-  LlmIR,
-  ToolCallRequest,
-  MalformedRequest,
-  AssistantMessage,
-  OutputIR,
-} from "../ir/llm-ir.ts";
+import { LlmIR, ToolCallRequest, MalformedRequest, AssistantMessage } from "../ir/llm-ir.ts";
 import { ToolDef } from "../tools/common.ts";
 import { tryexpr } from "../tryexpr.ts";
 import { trackTokens } from "../token-tracker.ts";
@@ -255,11 +249,11 @@ function modelMessageFromIr(
       content: [
         {
           type: "tool-result",
-          toolCallId: ir.toolCallId,
-          toolName: ir.toolName || "unknown",
+          toolCallId: ir.malformedRequest.toolCallId,
+          toolName: ir.malformedRequest.call.original.name || "unknown",
           output: {
             type: "text" as const,
-            value: `Error: ${ir.error}`,
+            value: `Error: ${ir.malformedRequest.error}`,
           },
         },
       ],
@@ -499,17 +493,16 @@ export const runResponsesAgent: Compiler = async ({
 
     // If aborted, don't try to parse tool calls
     if (abortSignal.aborted) {
-      return { success: true, output: [assistantHistoryItem], curl };
+      return { success: true, output: assistantHistoryItem, curl };
     }
 
     // Get tool calls
     const toolCalls = await result.toolCalls;
     if (toolCalls == null || toolCalls.length === 0) {
-      return { success: true, output: [assistantHistoryItem], curl };
+      return { success: true, output: assistantHistoryItem, curl };
     }
 
     const parsedToolCalls: Array<ToolCallRequest | MalformedRequest> = [];
-    const malformedIrs: OutputIR[] = [];
 
     for (const toolCall of toolCalls) {
       const chatToolCall = {
@@ -528,6 +521,7 @@ export const runResponsesAgent: Compiler = async ({
       if (parseResult.status === "error") {
         parsedToolCalls.push({
           type: "malformed-request",
+          error: parseResult.message,
           call: {
             original: {
               name: toolCall.toolName,
@@ -536,32 +530,15 @@ export const runResponsesAgent: Compiler = async ({
           },
           toolCallId: toolCall.toolCallId,
         });
-        malformedIrs.push({
-          role: "tool-malformed",
-          error: parseResult.message,
-          toolName: toolCall.toolName,
-          arguments: JSON.stringify(toolCall.input),
-          toolCallId: toolCall.toolCallId,
-        });
         continue;
       }
 
       parsedToolCalls.push(parseResult.tool);
     }
 
-    if (parsedToolCalls.length > 0) {
-      assistantHistoryItem.toolCalls = parsedToolCalls;
-    }
+    if (parsedToolCalls.length > 0) assistantHistoryItem.toolCalls = parsedToolCalls;
 
-    if (malformedIrs.length > 0) {
-      return {
-        success: true,
-        curl,
-        output: [assistantHistoryItem, ...malformedIrs],
-      };
-    }
-
-    return { success: true, output: [assistantHistoryItem], curl };
+    return { success: true, output: assistantHistoryItem, curl };
   } catch (e) {
     return {
       success: false,

--- a/source/compilers/responses.ts
+++ b/source/compilers/responses.ts
@@ -215,6 +215,23 @@ function modelMessageFromIr(
     };
   }
 
+  if (ir.role === "tool-skip") {
+    return {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolName: ir.toolCall.call.original.name,
+          toolCallId: ir.toolCall.toolCallId,
+          output: {
+            type: "text" as const,
+            value: irPrompts.toolSkip(ir.reason),
+          },
+        },
+      ],
+    };
+  }
+
   if (ir.role === "tool-error") {
     return {
       role: "tool",

--- a/source/compilers/run.ts
+++ b/source/compilers/run.ts
@@ -7,6 +7,7 @@ import { QuotaData } from "../utils/quota.ts";
 import { findMostRecentCompactionCheckpointIndex } from "./autocompact.ts";
 import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import { LoadedTools } from "../tools/index.ts";
+import { Transport } from "../transports/transport-common.ts";
 
 export async function run({
   model,
@@ -15,6 +16,7 @@ export async function run({
   handlers,
   autofixJson,
   abortSignal,
+  transport,
   systemPrompt,
   tools,
 }: {
@@ -28,6 +30,7 @@ export async function run({
     onQuotaUpdated?: (quota: QuotaData) => void;
   };
   abortSignal: AbortSignal;
+  transport: Transport;
   systemPrompt?: () => Promise<string>;
   tools?: Partial<LoadedTools>;
 }) {
@@ -55,5 +58,6 @@ export async function run({
       return fixPromise;
     },
     tools,
+    transport,
   });
 }

--- a/source/compilers/standard.ts
+++ b/source/compilers/standard.ts
@@ -6,6 +6,8 @@ import {
   AssistantMessage as AssistantIR,
   AgentResult,
   ToolCallRequest,
+  MalformedRequest,
+  OutputIR,
 } from "../ir/llm-ir.ts";
 import { QuotaData } from "../utils/quota.ts";
 import { parseQuotaJson } from "../utils/quota.ts";
@@ -20,6 +22,7 @@ import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
 import { canDisplayImage, MultimodalConfig } from "../providers.ts";
 import { getDefaultOpenaiClient } from "./openai.ts";
+import { Transport } from "../transports/transport-common.ts";
 
 type Content =
   | string
@@ -111,16 +114,14 @@ async function toLlmMessages(
 
   irs.reverse();
   const seenPaths = new Set<string>();
-  let prev: LlmIR | null = null;
   for (const ir of irs) {
     if (ir.role === "file-read") {
       let seen = seenPaths.has(ir.path);
       seenPaths.add(ir.path);
-      output.push(llmFromIr(ir, prev, seen, modalities));
+      output.push(llmFromIr(ir, seen, modalities));
     } else {
-      output.push(llmFromIr(ir, prev, false, modalities));
+      output.push(llmFromIr(ir, false, modalities));
     }
-    prev = ir;
   }
 
   output.reverse();
@@ -135,18 +136,13 @@ async function toLlmMessages(
   return output;
 }
 
-function llmFromIr(
-  ir: LlmIR,
-  prev: LlmIR | null,
-  seenPath: boolean,
-  modalities?: MultimodalConfig,
-): LlmMessage {
+function llmFromIr(ir: LlmIR, seenPath: boolean, modalities?: MultimodalConfig): LlmMessage {
   if (ir.role === "assistant") {
-    const { toolCall } = ir;
+    const { toolCalls } = ir;
     const reasoning: { reasoning_content?: string } = {};
     if (ir.reasoningContent) reasoning.reasoning_content = ir.reasoningContent;
 
-    if (toolCall == null || prev?.role === "tool-malformed") {
+    if (toolCalls == null || toolCalls.length === 0) {
       return {
         ...reasoning,
         role: "assistant",
@@ -157,18 +153,18 @@ function llmFromIr(
       ...reasoning,
       role: "assistant",
       content: ir.content,
-      tool_calls: [
-        {
-          type: "function",
+      tool_calls: toolCalls.map(tc => {
+        return {
+          type: "function" as const,
           function: {
-            name: toolCall.function.name,
-            arguments: toolCall.function.arguments
-              ? JSON.stringify(toolCall.function.arguments)
+            name: tc.call.original.name,
+            arguments: tc.call.original.arguments
+              ? JSON.stringify(tc.call.original.arguments)
               : "{}",
           },
-          id: toolCall.toolCallId,
-        },
-      ],
+          id: tc.toolCallId,
+        };
+      }),
     };
   }
   if (ir.role === "user") {
@@ -240,7 +236,8 @@ function llmFromIr(
 
   if (ir.role === "tool-malformed") {
     return {
-      role: "user",
+      role: "tool",
+      tool_call_id: ir.toolCallId,
       content: "Malformed tool call: " + tagged(TOOL_ERROR_TAG, {}, ir.error),
     };
   }
@@ -248,7 +245,7 @@ function llmFromIr(
   if (ir.role === "tool-error") {
     return {
       role: "tool",
-      tool_call_id: ir.toolCallId,
+      tool_call_id: ir.toolCall.toolCallId,
       content: "Error: " + tagged(TOOL_ERROR_TAG, {}, ir.error),
     };
   }
@@ -329,6 +326,7 @@ export const runAgent: Compiler = async ({
   onTokens,
   onQuotaUpdated,
   abortSignal,
+  transport,
   systemPrompt,
   autofixJson,
   tools,
@@ -368,7 +366,7 @@ export const runAgent: Compiler = async ({
     messages,
     ...toolsParam,
   });
-  return await handleKnownErrors(curl, async () => {
+  return await handleKnownErrors(curl, async (): Promise<AgentResult> => {
     const client = getDefaultOpenaiClient({ baseUrl: model.baseUrl, apiKey });
 
     let reasoning: {
@@ -429,13 +427,11 @@ export const runAgent: Compiler = async ({
       },
     });
 
-    let currTool: Partial<ResponseToolCall> | null = null;
-    let doneParsingTools = false;
+    let toolCallMap = new Map<number, Partial<ResponseToolCall>>();
 
     try {
       for await (const chunk of res) {
         if (abortSignal.aborted) break;
-        if (doneParsingTools) break;
         if (chunk.usage) {
           usage.input = chunk.usage.prompt_tokens;
           usage.output = chunk.usage.completion_tokens;
@@ -449,7 +445,7 @@ export const runAgent: Compiler = async ({
               reasoning_content: string;
             }
           | {
-              tool_calls: Array<ResponseToolCall>;
+              tool_calls: Array<ResponseToolCall & { index?: number }>;
             }
           | {
               reasoning: string;
@@ -474,26 +470,26 @@ export const runAgent: Compiler = async ({
           delta.tool_calls.length > 0
         ) {
           for (const deltaCall of delta.tool_calls) {
+            const index = deltaCall.index ?? 0;
             onTokens(
               (deltaCall.function.name || "") + (deltaCall.function.arguments || ""),
               "tool",
             );
-            if (currTool == null) {
-              currTool = {
+            if (deltaCall.id) {
+              toolCallMap.set(index, {
                 id: deltaCall.id,
                 function: {
                   name: deltaCall.function.name || "",
                   arguments: deltaCall.function.arguments || "",
                 },
-              };
+              });
             } else {
-              if (deltaCall.id && deltaCall.id !== currTool.id) {
-                doneParsingTools = true;
-                break;
+              const curr = toolCallMap.get(index);
+              if (curr) {
+                if (deltaCall.function.name) curr.function!.name = deltaCall.function.name;
+                if (deltaCall.function.arguments)
+                  curr.function!.arguments += deltaCall.function.arguments;
               }
-              if (deltaCall.function.name) currTool.function!.name = deltaCall.function.name;
-              if (deltaCall.function.arguments)
-                currTool.function!.arguments += deltaCall.function.arguments;
             }
           }
         }
@@ -532,50 +528,86 @@ export const runAgent: Compiler = async ({
     // If aborted, don't try to parse tool calls - just return the assistant response
     if (abortSignal.aborted) return { success: true, output: [assistantIr], curl };
 
-    // If no tool call, we're done
-    if (currTool == null) return { success: true, output: [assistantIr], curl };
+    // If no tool calls, we're done
+    if (toolCallMap.size === 0) return { success: true, output: [assistantIr], curl };
 
-    // Got this far? Parse out the tool call
-    const validatedTool = ResponseToolCallSchema.sliceResult(currTool);
-    if (validatedTool instanceof t.Err) {
-      const toolCallId = currTool["id"];
-      if (toolCallId == null) throw new Error("Impossible tool call: no id given");
+    // Sort tool calls by their streaming index to preserve ordering
+    const currTools = Array.from(toolCallMap.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([_, v]) => v);
+
+    const toolCalls: Array<MalformedRequest | ToolCallRequest> = [];
+    const malformedIrs: OutputIR[] = [];
+
+    for (const currTool of currTools) {
+      const validatedTool = ResponseToolCallSchema.sliceResult(currTool);
+      if (validatedTool instanceof t.Err) {
+        const toolCallId = currTool["id"];
+        if (toolCallId == null) throw new Error("Impossible tool call: no id given");
+        toolCalls.push({
+          type: "malformed-request",
+          call: {
+            original: {
+              name: currTool.function?.name || "unknown",
+              arguments: currTool.function?.arguments || "",
+            },
+          },
+          toolCallId,
+        });
+        malformedIrs.push({
+          role: "tool-malformed",
+          error: validatedTool.message,
+          toolCallId,
+          toolName: currTool.function?.name,
+          arguments: currTool.function?.arguments,
+        });
+        continue;
+      }
+
+      const parseResult = await parseTool(
+        validatedTool,
+        toolDefs,
+        autofixJson,
+        abortSignal,
+        transport,
+      );
+
+      if (parseResult.status === "error") {
+        toolCalls.push({
+          type: "malformed-request",
+          call: {
+            original: {
+              name: validatedTool.function.name,
+              arguments: validatedTool.function.arguments,
+            },
+          },
+          toolCallId: validatedTool.id,
+        });
+        malformedIrs.push({
+          role: "tool-malformed",
+          error: parseResult.message,
+          toolName: validatedTool.function.name,
+          arguments: validatedTool.function.arguments,
+          toolCallId: validatedTool.id,
+        });
+        continue;
+      }
+
+      toolCalls.push(parseResult.tool);
+    }
+
+    if (toolCalls.length > 0) {
+      assistantIr.toolCalls = toolCalls;
+    }
+
+    if (malformedIrs.length > 0) {
       return {
         success: true,
         curl,
-        output: [
-          assistantIr,
-          {
-            role: "tool-malformed",
-            error: validatedTool.message,
-            toolCallId,
-            toolName: currTool.function?.name,
-            arguments: currTool.function?.arguments,
-          },
-        ],
+        output: [assistantIr, ...malformedIrs],
       };
     }
 
-    const parseResult = await parseTool(validatedTool, toolDefs, autofixJson, abortSignal);
-
-    if (parseResult.status === "error") {
-      return {
-        success: true,
-        curl,
-        output: [
-          assistantIr,
-          {
-            role: "tool-malformed",
-            error: parseResult.message,
-            toolName: validatedTool.function.name,
-            arguments: validatedTool.function.arguments,
-            toolCallId: validatedTool.id,
-          },
-        ],
-      };
-    }
-
-    assistantIr.toolCall = parseResult.tool;
     return { success: true, output: [assistantIr], curl };
   });
 };
@@ -592,9 +624,10 @@ type ParseToolResult =
 
 async function parseTool(
   toolCall: ResponseToolCall,
-  toolDefs: Record<string, ToolDef<any>>,
+  toolDefs: Record<string, ToolDef<any, any, any>>,
   autofixJson: (badJson: string, signal: AbortSignal) => Promise<JsonFixResponse>,
   abortSignal: AbortSignal,
+  transport: Transport,
 ): Promise<ParseToolResult> {
   const name = toolCall.function.name;
   const toolDef = toolDefs[name];
@@ -651,18 +684,24 @@ Please try calling a valid tool.
   }
 
   try {
-    const parsed = toolSchema.slice({
+    const sliced = toolSchema.slice({
       name: toolCall.function.name,
       arguments: args,
     });
-
+    const parsed = await toolDef.parse(abortSignal, transport, sliced);
+    if (parsed.success) {
+      return {
+        status: "success",
+        tool: {
+          type: "tool-request",
+          call: parsed.data,
+          toolCallId: toolCall.id,
+        },
+      };
+    }
     return {
-      status: "success",
-      tool: {
-        type: "function",
-        function: parsed,
-        toolCallId: toolCall.id,
-      },
+      status: "error",
+      message: parsed.error,
     };
   } catch (e: unknown) {
     logger.error("verbose", e);

--- a/source/compilers/standard.ts
+++ b/source/compilers/standard.ts
@@ -7,7 +7,6 @@ import {
   AgentResult,
   ToolCallRequest,
   MalformedRequest,
-  OutputIR,
 } from "../ir/llm-ir.ts";
 import { QuotaData } from "../utils/quota.ts";
 import { parseQuotaJson } from "../utils/quota.ts";
@@ -245,8 +244,8 @@ function llmFromIr(ir: LlmIR, seenPath: boolean, modalities?: MultimodalConfig):
   if (ir.role === "tool-malformed") {
     return {
       role: "tool",
-      tool_call_id: ir.toolCallId,
-      content: "Malformed tool call: " + tagged(TOOL_ERROR_TAG, {}, ir.error),
+      tool_call_id: ir.malformedRequest.toolCallId,
+      content: "Malformed tool call: " + tagged(TOOL_ERROR_TAG, {}, ir.malformedRequest.error),
     };
   }
 
@@ -534,10 +533,10 @@ export const runAgent: Compiler = async ({
     };
 
     // If aborted, don't try to parse tool calls - just return the assistant response
-    if (abortSignal.aborted) return { success: true, output: [assistantIr], curl };
+    if (abortSignal.aborted) return { success: true, output: assistantIr, curl };
 
     // If no tool calls, we're done
-    if (toolCallMap.size === 0) return { success: true, output: [assistantIr], curl };
+    if (toolCallMap.size === 0) return { success: true, output: assistantIr, curl };
 
     // Sort tool calls by their streaming index to preserve ordering
     const currTools = Array.from(toolCallMap.entries())
@@ -545,7 +544,6 @@ export const runAgent: Compiler = async ({
       .map(([_, v]) => v);
 
     const toolCalls: Array<MalformedRequest | ToolCallRequest> = [];
-    const malformedIrs: OutputIR[] = [];
 
     for (const currTool of currTools) {
       const validatedTool = ResponseToolCallSchema.sliceResult(currTool);
@@ -554,6 +552,7 @@ export const runAgent: Compiler = async ({
         if (toolCallId == null) throw new Error("Impossible tool call: no id given");
         toolCalls.push({
           type: "malformed-request",
+          error: validatedTool.message,
           call: {
             original: {
               name: currTool.function?.name || "unknown",
@@ -561,13 +560,6 @@ export const runAgent: Compiler = async ({
             },
           },
           toolCallId,
-        });
-        malformedIrs.push({
-          role: "tool-malformed",
-          error: validatedTool.message,
-          toolCallId,
-          toolName: currTool.function?.name,
-          arguments: currTool.function?.arguments,
         });
         continue;
       }
@@ -583,6 +575,7 @@ export const runAgent: Compiler = async ({
       if (parseResult.status === "error") {
         toolCalls.push({
           type: "malformed-request",
+          error: parseResult.message,
           call: {
             original: {
               name: validatedTool.function.name,
@@ -591,32 +584,15 @@ export const runAgent: Compiler = async ({
           },
           toolCallId: validatedTool.id,
         });
-        malformedIrs.push({
-          role: "tool-malformed",
-          error: parseResult.message,
-          toolName: validatedTool.function.name,
-          arguments: validatedTool.function.arguments,
-          toolCallId: validatedTool.id,
-        });
         continue;
       }
 
       toolCalls.push(parseResult.tool);
     }
 
-    if (toolCalls.length > 0) {
-      assistantIr.toolCalls = toolCalls;
-    }
+    if (toolCalls.length > 0) assistantIr.toolCalls = toolCalls;
 
-    if (malformedIrs.length > 0) {
-      return {
-        success: true,
-        curl,
-        output: [assistantIr, ...malformedIrs],
-      };
-    }
-
-    return { success: true, output: [assistantIr], curl };
+    return { success: true, output: assistantIr, curl };
   });
 };
 

--- a/source/compilers/standard.ts
+++ b/source/compilers/standard.ts
@@ -234,6 +234,14 @@ function llmFromIr(ir: LlmIR, seenPath: boolean, modalities?: MultimodalConfig):
     };
   }
 
+  if (ir.role === "tool-skip") {
+    return {
+      role: "tool",
+      tool_call_id: ir.toolCall.toolCallId,
+      content: tagged(TOOL_ERROR_TAG, {}, irPrompts.toolSkip(ir.reason)),
+    };
+  }
+
   if (ir.role === "tool-malformed") {
     return {
       role: "tool",

--- a/source/components/diff-renderer.test.tsx
+++ b/source/components/diff-renderer.test.tsx
@@ -23,6 +23,7 @@ describe("DiffRenderer", () => {
         oldText={oldText}
         newText="line 1\nmodified line\nline 3\n"
         filepath="/test.txt"
+        fileContents={oldText}
       />,
     );
 
@@ -42,6 +43,7 @@ describe("DiffRenderer", () => {
         oldText=""
         newText="function example() {\n  return 'hello';\n}"
         filepath="/nonexistent.js"
+        fileContents={""}
       />,
     );
 
@@ -52,11 +54,14 @@ describe("DiffRenderer", () => {
     // This can happen if the file has been modified since the tool ran
     vi.mocked(readFileSync).mockReturnValue("line 1\nline 2\nline 3\n");
 
+    const oldText = "line 1\nline 2\n"; // Doesn't match the file content
+
     const { lastFrame } = render(
       <DiffRenderer
-        oldText="line 1\nline 2\n" // Doesn't match the file content
+        oldText={oldText}
         newText="line 1\nline 2\nline 3\n"
         filepath="/test.txt"
+        fileContents={oldText}
       />,
     );
 

--- a/source/components/diff-renderer.tsx
+++ b/source/components/diff-renderer.tsx
@@ -3,21 +3,21 @@ import { Box, Text } from "ink";
 import { diffLines } from "diff";
 import { DIFF_ADDED, DIFF_REMOVED, CODE_GUTTER_COLOR } from "../theme.ts";
 import { HighlightedCode } from "../markdown/highlight-code.tsx";
-import { readFileSync } from "fs";
 import { countLines, numWidth, fileExtLanguage, extractTrim } from "../str.ts";
 
 export function DiffRenderer({
   oldText,
   newText,
+  fileContents,
   filepath,
 }: {
   oldText: string;
   newText: string;
+  fileContents: string;
   filepath: string;
 }) {
   try {
     const language = fileExtLanguage(filepath);
-    const file = readFileSync(filepath, "utf8");
 
     const diff = diffLines(oldText, newText);
     const diffWithChanged: Array<
@@ -53,7 +53,7 @@ export function DiffRenderer({
       diffWithChanged.push(curr);
     }
 
-    const startLine = getStartLine(file, oldText);
+    const startLine = getStartLine(fileContents, oldText);
     const oldLineCounter = buildLineCounter(startLine);
     const newLineCounter = buildLineCounter(startLine);
     const maxOldLines = startLine + countLines(oldText);
@@ -139,7 +139,7 @@ export function DiffRenderer({
         </Box>
       </Box>
     );
-  } catch {
+  } catch (e) {
     return null;
   }
 }

--- a/source/components/diff-renderer.tsx
+++ b/source/components/diff-renderer.tsx
@@ -11,16 +11,15 @@ export function DiffRenderer({
   newText,
   filepath,
 }: {
-  oldText?: string;
+  oldText: string;
   newText: string;
   filepath: string;
 }) {
   try {
     const language = fileExtLanguage(filepath);
     const file = readFileSync(filepath, "utf8");
-    const effectiveOldText = oldText ?? file;
 
-    const diff = diffLines(effectiveOldText, newText);
+    const diff = diffLines(oldText, newText);
     const diffWithChanged: Array<
       | (typeof diff)[number]
       | {
@@ -54,10 +53,10 @@ export function DiffRenderer({
       diffWithChanged.push(curr);
     }
 
-    const startLine = getStartLine(file, effectiveOldText);
+    const startLine = getStartLine(file, oldText);
     const oldLineCounter = buildLineCounter(startLine);
     const newLineCounter = buildLineCounter(startLine);
-    const maxOldLines = startLine + countLines(effectiveOldText);
+    const maxOldLines = startLine + countLines(oldText);
     const maxNewLines = startLine + countLines(newText);
     const lineNrWidth = Math.max(numWidth(maxOldLines), numWidth(maxNewLines));
 
@@ -80,7 +79,7 @@ export function DiffRenderer({
                   newValue={part.value}
                   newAdded
                   language={language}
-                  oldText={effectiveOldText}
+                  oldText={oldText}
                   newText={newText}
                   oldLineCounter={oldLineCounter}
                   newLineCounter={newLineCounter}
@@ -96,7 +95,7 @@ export function DiffRenderer({
                   oldValue={part.value}
                   oldRemoved
                   language={language}
-                  oldText={effectiveOldText}
+                  oldText={oldText}
                   newText={newText}
                   oldLineCounter={oldLineCounter}
                   newLineCounter={newLineCounter}
@@ -114,7 +113,7 @@ export function DiffRenderer({
                   oldRemoved
                   newAdded
                   language={language}
-                  oldText={effectiveOldText}
+                  oldText={oldText}
                   newText={newText}
                   oldLineCounter={oldLineCounter}
                   newLineCounter={newLineCounter}
@@ -129,7 +128,7 @@ export function DiffRenderer({
                 oldValue={part.value}
                 newValue={part.value}
                 language={language}
-                oldText={effectiveOldText}
+                oldText={oldText}
                 newText={newText}
                 oldLineCounter={oldLineCounter}
                 newLineCounter={newLineCounter}

--- a/source/history.ts
+++ b/source/history.ts
@@ -19,15 +19,7 @@ export type ToolOutputItem = SequenceIdTagged<{
 
 export type ToolMalformedItem = SequenceIdTagged<{
   type: "tool-malformed";
-  error: string;
-  original: Partial<{
-    id: string;
-    function: Partial<{
-      name: string;
-      arguments: string;
-    }>;
-  }>;
-  toolCallId: string;
+  malformedRequest: MalformedRequest;
 }>;
 
 export type ToolFailedItem = SequenceIdTagged<{

--- a/source/history.ts
+++ b/source/history.ts
@@ -1,20 +1,20 @@
 import { ToolResult } from "./tools/common.ts";
-import { ToolCallRequest, AnthropicAssistantData } from "./ir/llm-ir.ts";
+import { ToolCallRequest, AnthropicAssistantData, MalformedRequest } from "./ir/llm-ir.ts";
 import { ImageInfo } from "./utils/image-utils.ts";
 
 export type SequenceIdTagged<T> = T & {
   id: bigint;
 };
 
-export type ToolCallItem = SequenceIdTagged<{
-  type: "tool";
-  tool: ToolCallRequest;
+export type ToolCallItems = SequenceIdTagged<{
+  type: "tool-calls";
+  tools: Array<ToolCallRequest | MalformedRequest>;
 }>;
 
 export type ToolOutputItem = SequenceIdTagged<{
   type: "tool-output";
   result: ToolResult;
-  toolCallId: string;
+  toolCall: ToolCallRequest;
 }>;
 
 export type ToolMalformedItem = SequenceIdTagged<{
@@ -33,25 +33,24 @@ export type ToolMalformedItem = SequenceIdTagged<{
 export type ToolFailedItem = SequenceIdTagged<{
   type: "tool-failed";
   error: string;
-  toolCallId: string;
-  toolName: string;
+  toolCall: ToolCallRequest;
 }>;
 
 export type ToolRejectItem = SequenceIdTagged<{
   type: "tool-reject";
-  toolCallId: string;
+  toolCall: ToolCallRequest;
 }>;
 
 export type FileOutdatedItem = SequenceIdTagged<{
   type: "file-outdated";
-  toolCallId: string;
+  toolCall: ToolCallRequest;
   error: string;
 }>;
 
 export type FileUnreadableItem = SequenceIdTagged<{
   type: "file-unreadable";
   path: string;
-  toolCallId: string;
+  toolCall: ToolCallRequest;
   error: string;
 }>;
 
@@ -95,7 +94,7 @@ export type CompactionCheckpointItem = SequenceIdTagged<{
 export type HistoryItem =
   | UserItem
   | AssistantItem
-  | ToolCallItem
+  | ToolCallItems
   | ToolOutputItem
   | ToolFailedItem
   | ToolMalformedItem

--- a/source/history.ts
+++ b/source/history.ts
@@ -41,6 +41,12 @@ export type ToolRejectItem = SequenceIdTagged<{
   toolCall: ToolCallRequest;
 }>;
 
+export type ToolSkipItem = SequenceIdTagged<{
+  type: "tool-skip";
+  toolCall: ToolCallRequest;
+  reason: string;
+}>;
+
 export type FileOutdatedItem = SequenceIdTagged<{
   type: "file-outdated";
   toolCall: ToolCallRequest;
@@ -99,6 +105,7 @@ export type HistoryItem =
   | ToolFailedItem
   | ToolMalformedItem
   | ToolRejectItem
+  | ToolSkipItem
   | FileOutdatedItem
   | FileUnreadableItem
   | RequestFailed

--- a/source/ir/convert-history-ir.ts
+++ b/source/ir/convert-history-ir.ts
@@ -6,6 +6,7 @@ import {
   ToolMalformedItem,
   ToolFailedItem,
   ToolRejectItem,
+  ToolSkipItem,
   FileOutdatedItem,
   FileUnreadableItem,
   AssistantItem,
@@ -23,6 +24,7 @@ type LoweredHistory =
   | ToolMalformedItem
   | ToolFailedItem
   | ToolRejectItem
+  | ToolSkipItem
   | FileOutdatedItem
   | FileUnreadableItem
   | AssistantItem
@@ -93,6 +95,17 @@ function singleOutputDecompile(output: TrajectoryOutputIR): HistoryItem[] {
         type: "compaction-checkpoint",
         id: sequenceId(),
         summary: output.summary,
+      },
+    ];
+  }
+
+  if (output.role === "tool-skip") {
+    return [
+      {
+        id: sequenceId(),
+        type: "tool-skip",
+        toolCall: output.toolCall,
+        reason: output.reason,
       },
     ];
   }
@@ -233,6 +246,17 @@ function collapseToIR(prev: LlmIR | null, item: LoweredHistory): [LlmIR | null, 
         role: "tool-error",
         error: item.error,
         toolCall: item.toolCall,
+      },
+    ];
+  }
+
+  if (item.type === "tool-skip") {
+    return [
+      null,
+      {
+        role: "tool-skip",
+        toolCall: item.toolCall,
+        reason: item.reason,
       },
     ];
   }

--- a/source/ir/convert-history-ir.ts
+++ b/source/ir/convert-history-ir.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import {
   HistoryItem,
-  ToolCallItem,
+  ToolCallItems,
   ToolOutputItem,
   ToolMalformedItem,
   ToolFailedItem,
@@ -14,11 +14,11 @@ import {
   sequenceId,
 } from "../history.ts";
 
-import { AssistantMessage, LlmIR, ToolCallRequest, TrajectoryOutputIR } from "./llm-ir.ts";
+import { AssistantMessage, LlmIR, TrajectoryOutputIR } from "./llm-ir.ts";
 
 // Filter out only relevant history items to the LLM IR
 type LoweredHistory =
-  | ToolCallItem
+  | ToolCallItems
   | ToolOutputItem
   | ToolMalformedItem
   | ToolFailedItem
@@ -49,8 +49,8 @@ function singleOutputDecompile(output: TrajectoryOutputIR): HistoryItem[] {
         original: {
           id: output.toolCallId,
           function: {
-            name: output.toolName,
-            arguments: output.arguments,
+            name: output.toolName || "unknown",
+            arguments: output.arguments || "{}",
           },
         },
       },
@@ -62,8 +62,7 @@ function singleOutputDecompile(output: TrajectoryOutputIR): HistoryItem[] {
         type: "tool-failed",
         id: sequenceId(),
         error: output.error,
-        toolCallId: output.toolCallId,
-        toolName: output.toolName,
+        toolCall: output.toolCall,
       },
     ];
   }
@@ -72,7 +71,7 @@ function singleOutputDecompile(output: TrajectoryOutputIR): HistoryItem[] {
       {
         type: "file-outdated",
         id: sequenceId(),
-        toolCallId: output.toolCall.toolCallId,
+        toolCall: output.toolCall,
         error: output.error,
       },
     ];
@@ -83,7 +82,7 @@ function singleOutputDecompile(output: TrajectoryOutputIR): HistoryItem[] {
         type: "file-unreadable",
         path: output.path,
         id: sequenceId(),
-        toolCallId: output.toolCall.toolCallId,
+        toolCall: output.toolCall,
         error: output.error,
       },
     ];
@@ -113,15 +112,11 @@ function singleOutputDecompile(output: TrajectoryOutputIR): HistoryItem[] {
     outputTokens: output.outputTokens,
   });
 
-  if (output.toolCall) {
+  if (output.toolCalls && output.toolCalls.length > 0) {
     history.push({
-      type: "tool",
+      type: "tool-calls",
       id: sequenceId(),
-      tool: {
-        type: output.toolCall.type,
-        function: output.toolCall.function,
-        toolCallId: output.toolCall.toolCallId,
-      },
+      tools: output.toolCalls.concat([]),
     });
   }
 
@@ -171,14 +166,14 @@ function lowerItem(item: HistoryItem): LoweredHistory | null {
 // message must be a new object: do not simply return the history item, or it could be modified by
 // future calls.
 function collapseToIR(prev: LlmIR | null, item: LoweredHistory): [LlmIR | null, LlmIR | null] {
-  if (item.type === "tool") {
-    return assertPrevAssistant("tool", item, prev, prev => {
+  if (item.type === "tool-calls") {
+    return assertPrevAssistant("tool-calls", item, prev, prev => {
       // Collapse the tool call into the previous assistant message
       return [
         {
           role: "assistant",
           content: prev.content || "",
-          toolCall: item.tool,
+          toolCalls: [...(prev.toolCalls || []), ...item.tools],
           openai: prev.openai,
           anthropic: prev.anthropic,
           reasoningContent: prev.reasoningContent,
@@ -202,14 +197,7 @@ function collapseToIR(prev: LlmIR | null, item: LoweredHistory): [LlmIR | null, 
           {
             role: "assistant",
             content: prev.content || "",
-            toolCall: {
-              type: "function",
-              function: {
-                name: toolName as any,
-                arguments: item.original.function?.arguments || "{}",
-              },
-              toolCallId: item.toolCallId,
-            },
+            toolCalls: [...(prev.toolCalls || [])],
             openai: prev.openai,
             anthropic: prev.anthropic,
             reasoningContent: prev.reasoningContent,
@@ -229,103 +217,92 @@ function collapseToIR(prev: LlmIR | null, item: LoweredHistory): [LlmIR | null, 
   }
 
   if (item.type === "tool-reject") {
-    return assertPrevAssistantToolCall("tool-reject", item, prev, prev => {
-      return [
-        prev,
-        {
-          role: "tool-reject",
-          toolCall: prev.toolCall,
-        },
-      ];
-    });
+    return [
+      null,
+      {
+        role: "tool-reject",
+        toolCall: item.toolCall,
+      },
+    ];
   }
 
   if (item.type === "tool-failed") {
-    return assertPrevAssistantToolCall("tool-failed", item, prev, prev => {
-      return [
-        prev,
-        {
-          role: "tool-error",
-          error: item.error,
-          toolCallId: item.toolCallId,
-          toolName: item.toolName,
-        },
-      ];
-    });
+    return [
+      null,
+      {
+        role: "tool-error",
+        error: item.error,
+        toolCall: item.toolCall,
+      },
+    ];
   }
 
   if (item.type === "tool-output") {
-    return assertPrevAssistantToolCall("tool-output", item, prev, prev => {
-      switch (prev.toolCall.function.name) {
-        case "append":
-        case "prepend":
-        case "rewrite":
-        case "edit":
-        case "create":
-          return [
-            prev,
-            {
-              role: "file-mutate",
-              content: item.result.content,
-              toolCall: prev.toolCall,
-              path: path.resolve(prev.toolCall.function.arguments.filePath),
-            },
-          ];
-        case "read":
-          return [
-            prev,
-            {
-              role: "file-read",
-              content: item.result.content,
-              toolCall: prev.toolCall,
-              path: path.resolve(prev.toolCall.function.arguments.filePath),
-              image: item.result.image,
-            },
-          ];
-        case "skill":
-        case "fetch":
-        case "list":
-        case "shell":
-        case "mcp":
-        case "web-search":
-        case "glob":
-          return [
-            prev,
-            {
-              role: "tool-output",
-              content: item.result.content,
-              toolCall: prev.toolCall,
-            },
-          ];
-      }
-    });
+    switch (item.toolCall.call.parsed.name) {
+      case "append":
+      case "prepend":
+      case "edit":
+      case "rewrite":
+      case "create":
+        return [
+          null,
+          {
+            role: "file-mutate",
+            content: item.result.content,
+            toolCall: item.toolCall,
+            path: path.resolve(item.toolCall.call.parsed.arguments.filePath),
+          },
+        ];
+      case "read":
+        return [
+          null,
+          {
+            role: "file-read",
+            content: item.result.content,
+            toolCall: item.toolCall,
+            path: path.resolve(item.toolCall.call.parsed.arguments.filePath),
+            image: item.result.image,
+          },
+        ];
+      case "skill":
+      case "fetch":
+      case "list":
+      case "shell":
+      case "mcp":
+      case "web-search":
+      case "glob":
+        return [
+          null,
+          {
+            role: "tool-output",
+            content: item.result.content,
+            toolCall: item.toolCall,
+          },
+        ];
+    }
   }
 
   if (item.type === "file-outdated") {
-    return assertPrevAssistantToolCall("file-outdated", item, prev, prev => {
-      return [
-        prev,
-        {
-          role: "file-outdated",
-          toolCall: prev.toolCall,
-          error: item.error,
-        },
-      ];
-    });
+    return [
+      null,
+      {
+        role: "file-outdated",
+        toolCall: item.toolCall,
+        error: item.error,
+      },
+    ];
   }
 
   if (item.type === "file-unreadable") {
-    return assertPrevAssistantToolCall("file-unreadable", item, prev, prev => {
-      return [
-        prev,
-        {
-          role: "file-unreadable",
-          toolCall: prev.toolCall,
-          path: item.path,
-          error: item.error,
-        },
-      ];
-    });
+    return [
+      null,
+      {
+        role: "file-unreadable",
+        toolCall: item.toolCall,
+        path: item.path,
+        error: item.error,
+      },
+    ];
   }
 
   if (item.type === "compaction-checkpoint") {
@@ -377,21 +354,4 @@ function assertPrevAssistant<T extends HistoryItem["type"]>(
   throw new Error(
     `Impossible tool ordering: no prev assistant response for ${type}. Prev role: ${prev.role}`,
   );
-}
-
-function assertPrevAssistantToolCall<T extends HistoryItem["type"]>(
-  type: T,
-  item: HistoryItem & { type: T },
-  prev: LlmIR | null,
-  callback: (
-    prev: AssistantMessage & { toolCall: ToolCallRequest },
-  ) => [LlmIR | null, LlmIR | null],
-): [LlmIR | null, LlmIR | null] {
-  return assertPrevAssistant(type, item, prev, prev => {
-    const { toolCall } = prev;
-    if (toolCall) return callback({ ...prev, toolCall });
-    throw new Error(
-      `Impossible tool ordering: no prev assistant tool call for ${type}. Prev role: ${prev.role}`,
-    );
-  });
 }

--- a/source/ir/convert-history-ir.ts
+++ b/source/ir/convert-history-ir.ts
@@ -46,15 +46,7 @@ function singleOutputDecompile(output: TrajectoryOutputIR): HistoryItem[] {
       {
         type: "tool-malformed",
         id: sequenceId(),
-        error: output.error,
-        toolCallId: output.toolCallId,
-        original: {
-          id: output.toolCallId,
-          function: {
-            name: output.toolName || "unknown",
-            arguments: output.arguments || "{}",
-          },
-        },
+        malformedRequest: output.malformedRequest,
       },
     ];
   }
@@ -198,35 +190,13 @@ function collapseToIR(prev: LlmIR | null, item: LoweredHistory): [LlmIR | null, 
     });
   }
   if (item.type === "tool-malformed") {
-    return assertPrevAssistant(
-      "tool-malformed",
-      item,
-      prev,
-      (prev): [LlmIR | null, LlmIR | null] => {
-        // Collapse the malformed tool call into the previous assistant message, and structure the
-        // response
-        const toolName = item.original.function?.name || "unknown";
-        return [
-          {
-            role: "assistant",
-            content: prev.content || "",
-            toolCalls: [...(prev.toolCalls || [])],
-            openai: prev.openai,
-            anthropic: prev.anthropic,
-            reasoningContent: prev.reasoningContent,
-            tokenUsage: prev.tokenUsage,
-            outputTokens: prev.outputTokens,
-          } satisfies LlmIR,
-          {
-            role: "tool-malformed",
-            toolCallId: item.toolCallId,
-            toolName,
-            arguments: item.original.function?.arguments || "",
-            error: item.error,
-          },
-        ];
+    return [
+      null,
+      {
+        role: "tool-malformed",
+        malformedRequest: item.malformedRequest,
       },
-    );
+    ];
   }
 
   if (item.type === "tool-reject") {

--- a/source/ir/count-ir-tokens.ts
+++ b/source/ir/count-ir-tokens.ts
@@ -17,7 +17,9 @@ function getMessageText(msg: LlmIR): string {
     case "tool-error":
       return msg.error;
     case "tool-malformed":
-      return (msg.arguments ?? "") + (msg.error ?? "");
+      return (
+        (msg.malformedRequest.call.original.arguments ?? "") + (msg.malformedRequest.error ?? "")
+      );
     case "file-outdated":
     case "file-unreadable":
       return msg.error;

--- a/source/ir/count-ir-tokens.ts
+++ b/source/ir/count-ir-tokens.ts
@@ -25,6 +25,8 @@ function getMessageText(msg: LlmIR): string {
       return msg.summary;
     case "tool-reject":
       return "";
+    case "tool-skip":
+      return msg.reason;
   }
 }
 

--- a/source/ir/llm-ir.ts
+++ b/source/ir/llm-ir.ts
@@ -2,8 +2,19 @@ import { ToolCall } from "../tools/index.ts";
 import { ImageInfo } from "../utils/image-utils.ts";
 
 export type ToolCallRequest = {
-  type: "function";
-  function: ToolCall;
+  type: "tool-request";
+  call: ToolCall;
+  toolCallId: string;
+};
+
+export type MalformedRequest = {
+  type: "malformed-request";
+  call: {
+    original: {
+      name: string;
+      arguments: any;
+    };
+  };
   toolCallId: string;
 };
 
@@ -30,7 +41,7 @@ export type AssistantMessage = {
     reasoningId?: string;
   };
   anthropic?: AnthropicAssistantData;
-  toolCall?: ToolCallRequest;
+  toolCalls?: Array<ToolCallRequest | MalformedRequest>;
   tokenUsage: number;
   outputTokens: number;
 };
@@ -69,8 +80,7 @@ export type ToolRejectMessage = {
 
 export type ToolErrorMessage = {
   role: "tool-error";
-  toolCallId: string;
-  toolName: string;
+  toolCall: ToolCallRequest;
   error: string;
 };
 

--- a/source/ir/llm-ir.ts
+++ b/source/ir/llm-ir.ts
@@ -84,6 +84,12 @@ export type ToolErrorMessage = {
   error: string;
 };
 
+export type ToolSkipMessage = {
+  role: "tool-skip";
+  toolCall: ToolCallRequest;
+  reason: string;
+};
+
 export type ToolMalformedMessage = {
   role: "tool-malformed";
   toolCallId: string;
@@ -119,6 +125,7 @@ export type InputIR =
   | FileMutateMethod
   | ToolRejectMessage
   | ToolErrorMessage
+  | ToolSkipMessage
   | FileOutdatedMessage
   | FileUnreadableMessage
   | CompactionCheckpoint;
@@ -128,6 +135,7 @@ export type LlmIR = OutputIR | InputIR;
 export type TrajectoryOutputIR =
   | OutputIR
   | ToolErrorMessage
+  | ToolSkipMessage
   | FileOutdatedMessage
   | FileUnreadableMessage
   | CompactionCheckpoint;

--- a/source/ir/llm-ir.ts
+++ b/source/ir/llm-ir.ts
@@ -9,6 +9,7 @@ export type ToolCallRequest = {
 
 export type MalformedRequest = {
   type: "malformed-request";
+  error: string;
   call: {
     original: {
       name: string;
@@ -92,10 +93,7 @@ export type ToolSkipMessage = {
 
 export type ToolMalformedMessage = {
   role: "tool-malformed";
-  toolCallId: string;
-  toolName?: string;
-  arguments?: string;
-  error: string;
+  malformedRequest: MalformedRequest;
 };
 
 export type FileOutdatedMessage = {
@@ -116,14 +114,10 @@ export type CompactionCheckpoint = {
   summary: string;
 };
 
-// TODO: remove the ToolMalformedMessage from OutputIR, since it's duplicative: any assistant item
-// with a malformed request tool call is malformed, and the trajectoryArc can handle inserting the
-// malformed message when it encounters this
-export type OutputIR = AssistantMessage | ToolMalformedMessage;
-
 export type InputIR =
   | UserMessage
   | ToolOutputMessage
+  | ToolMalformedMessage
   | FileReadMessage
   | FileMutateMethod
   | ToolRejectMessage
@@ -133,10 +127,11 @@ export type InputIR =
   | FileUnreadableMessage
   | CompactionCheckpoint;
 
-export type LlmIR = OutputIR | InputIR;
+export type LlmIR = AssistantMessage | InputIR;
 
 export type TrajectoryOutputIR =
-  | OutputIR
+  | AssistantMessage
+  | ToolMalformedMessage
   | ToolErrorMessage
   | ToolSkipMessage
   | FileOutdatedMessage
@@ -146,7 +141,7 @@ export type TrajectoryOutputIR =
 export type AgentResult =
   | {
       success: true;
-      output: OutputIR[];
+      output: AssistantMessage;
       curl: string;
     }
   | {

--- a/source/ir/llm-ir.ts
+++ b/source/ir/llm-ir.ts
@@ -116,6 +116,9 @@ export type CompactionCheckpoint = {
   summary: string;
 };
 
+// TODO: remove the ToolMalformedMessage from OutputIR, since it's duplicative: any assistant item
+// with a malformed request tool call is malformed, and the trajectoryArc can handle inserting the
+// malformed message when it encounters this
 export type OutputIR = AssistantMessage | ToolMalformedMessage;
 
 export type InputIR =

--- a/source/prompts/ir-prompts.ts
+++ b/source/prompts/ir-prompts.ts
@@ -7,6 +7,13 @@ Tool call was rejected by user. Your tool call did not run. No changes were appl
 `.trim();
 }
 
+export function toolSkip(reason: string) {
+  return `
+Tool was skipped and didn't run. The reason for skipping the tool was:
+${reason}
+`.trim();
+}
+
 export function fileMutation(filePath: string) {
   return `${filePath} was updated successfully.`;
 }

--- a/source/prompts/system-prompt.ts
+++ b/source/prompts/system-prompt.ts
@@ -86,10 +86,9 @@ ${config.yourName} with the task.
 You may need to use tools again after some back-and-forth with ${config.yourName}, as they help you
 refine your solution.
 
-You can only run tools or edits one-by-one. After viewing tool output or editing files, you may need
-to run more tools or edits in a step-by-step process. If you want to run multiple tools in a row,
-don't worry: just state your plan out loud, and then follow it over the course of multiple messages.
-Don't overthink.
+After viewing tool output or editing files, you may need to run more tools or edits in a
+step-by-step process. If you want to run multiple tools in a row, don't worry: just state your plan
+out loud, and then follow it. Don't overthink.
 
 # Coding guidelines
 

--- a/source/result.ts
+++ b/source/result.ts
@@ -1,0 +1,9 @@
+export type Result<T, E> =
+  | {
+      success: true;
+      data: T;
+    }
+  | {
+      success: false;
+      error: E;
+    };

--- a/source/state.ts
+++ b/source/state.ts
@@ -4,6 +4,7 @@ import {
   UserItem,
   AssistantItem,
   CompactionCheckpointItem,
+  ToolOutputItem,
   sequenceId,
 } from "./history.ts";
 import { ImageInfo } from "./utils/image-utils.ts";
@@ -41,7 +42,8 @@ export type UiState = {
       }
     | {
         mode: "tool-request";
-        toolReq: ToolCallRequest;
+        toolReqs: ToolCallRequest[];
+        runningToolCallId: string | null;
       }
     | {
         mode: "error-recovery";
@@ -79,11 +81,8 @@ export type UiState = {
       }
     | {
         mode: "menu";
-      }
-    | {
-        mode: "tool-waiting";
-        abortController: AbortController;
       };
+
   modelOverride: string | null;
   quotaData: QuotaData | null;
   byteCount: number;
@@ -94,7 +93,7 @@ export type UiState = {
   whitelist: Set<string>;
   input: (args: RunArgs & { query: string; images?: ImageInfo[] }) => Promise<void>;
   runTool: (args: RunArgs & { toolReq: ToolCallRequest }) => Promise<void>;
-  rejectTool: (toolCallId: string) => void;
+  rejectTool: (toolCall: ToolCallRequest) => void;
   abortResponse: () => void;
   toggleMenu: () => void;
   openMenu: () => void;
@@ -113,7 +112,7 @@ export type UiState = {
   isWhitelisted: (whitelistKey: string) => Promise<boolean>;
   clearHistory: () => void;
   _maybeHandleAbort: (signal: AbortSignal) => boolean;
-  _runAgent: (args: RunArgs) => Promise<void>;
+  runAgent: (args: RunArgs) => Promise<void>;
 };
 
 export const useAppStore = create<UiState>((set, get) => ({
@@ -141,12 +140,12 @@ export const useAppStore = create<UiState>((set, get) => ({
 
     let history = [...get().history, userMessage];
     set({ history, lastUserPromptId: userMessage.id });
-    await get()._runAgent({ config, transport });
+    await get().runAgent({ config, transport });
   },
 
   retryFrom: async (mode, args) => {
     if (get().modeData.mode === mode) {
-      await get()._runAgent(args);
+      await get().runAgent(args);
     }
   },
 
@@ -155,7 +154,7 @@ export const useAppStore = create<UiState>((set, get) => ({
       return;
     }
 
-    const { history, lastUserPromptId, byteCount } = get();
+    const { history, lastUserPromptId } = get();
 
     if (lastUserPromptId === null) {
       set({
@@ -186,14 +185,14 @@ export const useAppStore = create<UiState>((set, get) => ({
     }));
   },
 
-  rejectTool: toolCallId => {
+  rejectTool: toolCall => {
     set({
       history: [
         ...get().history,
         {
           type: "tool-reject",
           id: sequenceId(),
-          toolCallId,
+          toolCall,
         },
       ],
       modeData: {
@@ -320,36 +319,33 @@ export const useAppStore = create<UiState>((set, get) => ({
   },
 
   runTool: async ({ config, toolReq, transport }) => {
-    const modelOverride = get().modelOverride;
     const abortController = new AbortController();
-    set({
-      modeData: {
-        mode: "tool-waiting",
-        abortController,
-      },
-    });
+    let { modeData } = get();
+    if (modeData.mode === "tool-request") {
+      set({ modeData: { ...modeData, runningToolCallId: toolReq.toolCallId } });
+    }
 
+    const modelOverride = get().modelOverride;
     const tools = await loadTools(transport, abortController.signal, config);
+
     try {
       const result = await runTool(
         abortController.signal,
         transport,
         tools,
-        toolReq.function,
+        toolReq.call,
         config,
         modelOverride,
       );
 
-      const toolHistoryItem: HistoryItem = {
+      const toolHistoryItem: ToolOutputItem = {
         type: "tool-output",
         id: sequenceId(),
         result,
-        toolCallId: toolReq.toolCallId,
+        toolCall: toolReq,
       };
 
-      const history: HistoryItem[] = [...get().history, toolHistoryItem];
-
-      set({ history });
+      set({ history: [...get().history, toolHistoryItem] });
     } catch (e) {
       const history = [
         ...get().history,
@@ -361,10 +357,14 @@ export const useAppStore = create<UiState>((set, get) => ({
     if (get()._maybeHandleAbort(abortController.signal)) {
       return;
     }
-    await get()._runAgent({ config, transport });
+
+    ({ modeData } = get());
+    if (modeData.mode === "tool-request") {
+      set({ modeData: { ...modeData, runningToolCallId: null } });
+    }
   },
 
-  _runAgent: async ({ config, transport }) => {
+  runAgent: async ({ config, transport }) => {
     const historyCopy = [...get().history];
     const abortController = new AbortController();
     let compactionByteCount = 0;
@@ -506,7 +506,8 @@ export const useAppStore = create<UiState>((set, get) => ({
       set({
         modeData: {
           mode: "tool-request",
-          toolReq: finishReason.toolCall,
+          toolReqs: finishReason.toolCalls,
+          runningToolCallId: null,
         },
       });
     } catch (e) {
@@ -557,19 +558,17 @@ async function tryTransformToolError(
       type: "tool-failed",
       id: sequenceId(),
       error: e.message,
-      toolCallId: toolReq.toolCallId,
-      toolName: toolReq.function.name,
+      toolCall: toolReq,
     };
   }
   if (e instanceof FileOutdatedError) {
     const absolutePath = path.resolve(e.filePath);
-    // Actually perform the read to ensure it's readable
     try {
       await fileTracker.readUntracked(transport, signal, absolutePath);
       return {
         type: "file-outdated",
         id: sequenceId(),
-        toolCallId: toolReq.toolCallId,
+        toolCall: toolReq,
         error:
           "File could not be updated because it was modified after being last read. Please read the file again before modifying it.",
       };
@@ -578,7 +577,7 @@ async function tryTransformToolError(
         type: "file-unreadable",
         path: e.filePath,
         id: sequenceId(),
-        toolCallId: toolReq.toolCallId,
+        toolCall: toolReq,
         error: `File ${e.filePath} could not be read. Has it been deleted?`,
       };
     }

--- a/source/state.ts
+++ b/source/state.ts
@@ -364,6 +364,13 @@ export const useAppStore = create<UiState>((set, get) => ({
     if (modeData.mode !== "tool-request") {
       throw new Error(`Impossible tool mode: ${modeData.mode}`);
     }
+    if (modeData.runningToolCallId != null) {
+      if (process.env["CANARY_OCTO"] === "1") {
+        throw new Error(
+          "Canary build error: attempted to run a tool when a tool was already running",
+        );
+      }
+    }
 
     const abortController = modeData.abortController;
     set({ modeData: { ...modeData, runningToolCallId: toolReq.toolCallId } });

--- a/source/state.ts
+++ b/source/state.ts
@@ -5,6 +5,7 @@ import {
   AssistantItem,
   CompactionCheckpointItem,
   ToolOutputItem,
+  ToolCallItems,
   sequenceId,
 } from "./history.ts";
 import { ImageInfo } from "./utils/image-utils.ts";
@@ -44,6 +45,7 @@ export type UiState = {
         mode: "tool-request";
         toolReqs: ToolCallRequest[];
         runningToolCallId: string | null;
+        abortController: AbortController;
       }
     | {
         mode: "error-recovery";
@@ -186,6 +188,44 @@ export const useAppStore = create<UiState>((set, get) => ({
   },
 
   rejectTool: toolCall => {
+    const history = get().history;
+
+    // If we reject a tool call, we need to mark all subsequent tool calls as skipped, so the LLM
+    // knows we rejected partway through and didn't run the rest of the array of tools.
+    //
+    // Find the most recent set of tool calls, and attempt to find any tool calls subsequent to this
+    // one that may be skipped, and mark them all as skipped.
+    let lastToolCallIndex = history.length - 1;
+    for (lastToolCallIndex; lastToolCallIndex >= 0; lastToolCallIndex--) {
+      const item = history[lastToolCallIndex];
+      if (item.type === "tool-calls") break;
+    }
+    const skippedCalls: HistoryItem[] = [];
+
+    if (lastToolCallIndex >= 0) {
+      const originatingToolCalls = history[lastToolCallIndex] as ToolCallItems;
+      for (
+        let toolCallIndex = 0;
+        toolCallIndex < originatingToolCalls.tools.length;
+        toolCallIndex++
+      ) {
+        const call = originatingToolCalls.tools[toolCallIndex];
+        if (call.toolCallId === toolCall.toolCallId && call.type === "tool-request") {
+          const skippedCount = originatingToolCalls.tools.length - toolCallIndex - 1;
+          if (skippedCount > 0) {
+            for (let i = 0; i < skippedCount; i++) {
+              skippedCalls.push({
+                id: sequenceId(),
+                type: "tool-skip",
+                toolCall: call,
+                reason: "A previous tool call was rejected, so this tool was skipped",
+              });
+            }
+          }
+          break;
+        }
+      }
+    }
     set({
       history: [
         ...get().history,
@@ -194,6 +234,7 @@ export const useAppStore = create<UiState>((set, get) => ({
           id: sequenceId(),
           toolCall,
         },
+        ...skippedCalls,
       ],
       modeData: {
         mode: "input",
@@ -319,11 +360,13 @@ export const useAppStore = create<UiState>((set, get) => ({
   },
 
   runTool: async ({ config, toolReq, transport }) => {
-    const abortController = new AbortController();
     let { modeData } = get();
-    if (modeData.mode === "tool-request") {
-      set({ modeData: { ...modeData, runningToolCallId: toolReq.toolCallId } });
+    if (modeData.mode !== "tool-request") {
+      throw new Error(`Impossible tool mode: ${modeData.mode}`);
     }
+
+    const abortController = modeData.abortController;
+    set({ modeData: { ...modeData, runningToolCallId: toolReq.toolCallId } });
 
     const modelOverride = get().modelOverride;
     const tools = await loadTools(transport, abortController.signal, config);
@@ -508,6 +551,7 @@ export const useAppStore = create<UiState>((set, get) => ({
           mode: "tool-request",
           toolReqs: finishReason.toolCalls,
           runningToolCallId: null,
+          abortController: new AbortController(),
         },
       });
     } catch (e) {

--- a/source/tools/common.ts
+++ b/source/tools/common.ts
@@ -81,7 +81,7 @@ export type ToolDef<Name extends string, Arguments, Parsed> = {
     transport: Transport,
     t: {
       original: Schema<Name, Arguments>;
-      parsed: Parsed;
+      parsed: Schema<Name, Parsed>;
     },
     cfg: Config,
     modelOverride: string | null,

--- a/source/tools/common.ts
+++ b/source/tools/common.ts
@@ -42,6 +42,43 @@ export async function attemptUntrackedRead(
   });
 }
 
+// Used by some edit tools to add the original file contents to the parsed data for diff tracking
+export async function parseOriginalFile<
+  Name extends string,
+  Arguments extends { filePath: string },
+>(
+  signal: AbortSignal,
+  transport: Transport,
+  original: Schema<Name, Arguments>,
+): Promise<
+  Result<ParseResult<Name, Arguments, Arguments & { originalFileContents: string }>, string>
+> {
+  try {
+    const contents = await attemptUntrackedRead(transport, signal, original.arguments.filePath);
+    return {
+      success: true,
+      data: {
+        original,
+        parsed: {
+          name: original.name,
+          arguments: {
+            ...original.arguments,
+            originalFileContents: contents,
+          },
+        },
+      },
+    };
+  } catch (e) {
+    if (e instanceof ToolError) {
+      return {
+        success: false,
+        error: e.message,
+      };
+    }
+    throw e;
+  }
+}
+
 export type ToolResult = {
   content: string;
 

--- a/source/tools/common.ts
+++ b/source/tools/common.ts
@@ -2,6 +2,7 @@ import { t } from "structural";
 import { Config } from "../config.ts";
 import { Transport } from "../transports/transport-common.ts";
 import { ImageInfo } from "../utils/image-utils.ts";
+import { Result } from "../result.ts";
 
 export class ToolError extends Error {
   constructor(message: string) {
@@ -50,27 +51,81 @@ export type ToolResult = {
   image?: ImageInfo;
 };
 
-export type ToolDef<T> = {
-  ArgumentsSchema: t.Type<any>;
-  Schema: t.Type<T>;
-  validate: (abortSignal: AbortSignal, transport: Transport, t: T, cfg: Config) => Promise<null>;
+type Schema<Name extends string, Arguments> = {
+  name: Name;
+  arguments: Arguments;
+};
+
+export type ParseResult<Name extends string, Arguments, Parsed> = {
+  original: Schema<Name, Arguments>;
+  parsed: Schema<Name, Parsed>;
+};
+
+export type ToolDef<Name extends string, Arguments, Parsed> = {
+  ArgumentsSchema: t.Type<Arguments>;
+  ParsedSchema: t.Type<Parsed>;
+  Schema: t.Type<Schema<Name, Arguments>>;
+  parse: (
+    abortSignal: AbortSignal,
+    transport: Transport,
+    original: Schema<Name, Arguments>,
+  ) => Promise<Result<ParseResult<Name, Arguments, Parsed>, string>>;
+  validate: (
+    abortSignal: AbortSignal,
+    transport: Transport,
+    t: Schema<Name, Arguments>,
+    cfg: Config,
+  ) => Promise<null>;
   run: (
     abortSignal: AbortSignal,
     transport: Transport,
-    t: T,
+    t: {
+      original: Schema<Name, Arguments>;
+      parsed: Parsed;
+    },
     cfg: Config,
     modelOverride: string | null,
   ) => Promise<ToolResult>;
 };
 
-export type ToolFactory<T> = (
+export type ToolFactory<S extends Schema<any, any>, Parsed> = (
   signal: AbortSignal,
   transport: Transport,
   config: Config,
-) => Promise<ToolDef<T> | null>;
+) => Promise<ToolDef<S["name"], S["arguments"], Parsed> | null>;
 
-export function defineTool<T>(factory: ToolFactory<T>): ToolFactory<T> {
+export function defineTool<T extends Schema<any, any>, Parsed>(
+  _1: t.Type<T>,
+  _2: t.Type<Parsed>,
+  factory: ToolFactory<T, Parsed>,
+): ToolFactory<T, Parsed> {
   return factory;
 }
 
-export type ToolSchemaFrom<T extends ToolFactory<any>> = T extends ToolFactory<infer T> ? T : never;
+// An uglier way to define tools, since you need to specify the actual types somewhere
+// Useful for dynamically-shaped tools, where the schemas change based on runtime code
+export function dynamicDefineTool<Name extends string, T extends Schema<Name, any>, Parsed>(
+  _: Name,
+  factory: ToolFactory<T, Parsed>,
+): ToolFactory<T, Parsed> {
+  return factory;
+}
+
+export type ParsedToolSchemaFrom<T extends ToolFactory<any, any>> =
+  T extends ToolFactory<infer S, infer P> ? Schema<S["name"], P> : never;
+
+export function autoparse<Name extends string, Args>(
+  ArgSchema: t.Type<Args>,
+): {
+  parse: (
+    abortSignal: AbortSignal,
+    transport: Transport,
+    args: Schema<Name, Args>,
+  ) => Promise<Result<ParseResult<Name, Args, Args>, string>>;
+  ParsedSchema: t.Type<Args>;
+} {
+  return {
+    parse: async (_1, _2, input) => ({ success: true, data: { original: input, parsed: input } }),
+    ParsedSchema: ArgSchema,
+  };
+}

--- a/source/tools/index.ts
+++ b/source/tools/index.ts
@@ -8,7 +8,15 @@ export { ToolError } from "./common.ts";
 export type LoadedTools = {
   [K in keyof typeof toolMap]: Exclude<Awaited<ReturnType<(typeof toolMap)[K]>>, null>;
 };
-export type ToolCall = t.GetType<LoadedTools[keyof LoadedTools]["Schema"]>;
+export type ToolCall = {
+  [K in keyof LoadedTools]: {
+    parsed: {
+      name: t.GetType<LoadedTools[K]["Schema"]>["name"];
+      arguments: t.GetType<LoadedTools[K]["ParsedSchema"]>;
+    };
+    original: t.GetType<LoadedTools[K]["Schema"]>;
+  };
+}[keyof LoadedTools];
 
 export async function loadTools(
   transport: Transport,
@@ -60,11 +68,14 @@ export async function validateTool(
   config: Config,
 ): Promise<null> {
   const toolDef = lookup(loaded, tool);
-  return await toolDef.validate(abortSignal, transport, tool, config);
+  return await toolDef.validate(abortSignal, transport, tool.original, config);
 }
 
-function lookup<T extends ToolCall>(loaded: Partial<LoadedTools>, t: T): ToolDef<T> {
-  const def = loaded[t.name];
-  if (def == null) throw new ToolError(`No tool named ${t.name}`);
-  return def as ToolDef<T>;
+function lookup<T extends ToolCall>(
+  loaded: Partial<LoadedTools>,
+  t: T,
+): ToolDef<any, T["original"]["arguments"], any> {
+  const def = loaded[t.original.name];
+  if (def == null) throw new ToolError(`No tool named ${t.original.name}`);
+  return def as ToolDef<any, T["original"]["arguments"], any>;
 }

--- a/source/tools/tool-defs/append.ts
+++ b/source/tools/tool-defs/append.ts
@@ -1,6 +1,6 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import { attemptUntrackedRead, defineTool } from "../common.ts";
+import { attemptUntrackedRead, defineTool, autoparse } from "../common.ts";
 import { Transport } from "../../transports/transport-common.ts";
 
 const ArgumentsSchema = t
@@ -15,19 +15,19 @@ const Schema = t.subtype({
   arguments: ArgumentsSchema,
 });
 
-export default defineTool<t.GetType<typeof Schema>>(async () => ({
+export default defineTool(Schema, ArgumentsSchema, async () => ({
   Schema,
   ArgumentsSchema,
   validate,
+  ...autoparse(ArgumentsSchema),
   async run(signal, transport, call) {
-    const { filePath } = call.arguments;
-    const edit = call.arguments;
+    const { filePath } = call.parsed;
     await fileTracker.assertCanEdit(transport, signal, filePath);
 
     const file = await attemptUntrackedRead(transport, signal, filePath);
     const replaced = runEdit({
       file,
-      edit,
+      edit: call.parsed,
     });
     await fileTracker.write(transport, signal, filePath, replaced);
     return {

--- a/source/tools/tool-defs/append.ts
+++ b/source/tools/tool-defs/append.ts
@@ -21,13 +21,13 @@ export default defineTool(Schema, ArgumentsSchema, async () => ({
   validate,
   ...autoparse(ArgumentsSchema),
   async run(signal, transport, call) {
-    const { filePath } = call.parsed;
+    const { filePath } = call.parsed.arguments;
     await fileTracker.assertCanEdit(transport, signal, filePath);
 
     const file = await attemptUntrackedRead(transport, signal, filePath);
     const replaced = runEdit({
       file,
-      edit: call.parsed,
+      edit: call.parsed.arguments,
     });
     await fileTracker.write(transport, signal, filePath, replaced);
     return {

--- a/source/tools/tool-defs/bash.ts
+++ b/source/tools/tool-defs/bash.ts
@@ -1,5 +1,5 @@
 import { t } from "structural";
-import { ToolError, defineTool, USER_ABORTED_ERROR_MESSAGE } from "../common.ts";
+import { ToolError, defineTool, USER_ABORTED_ERROR_MESSAGE, autoparse } from "../common.ts";
 import { AbortError, CommandFailedError } from "../../transports/transport-common.ts";
 
 const ArgumentsSchema = t.subtype({
@@ -26,12 +26,13 @@ const Schema = t.subtype({
   Often interactive commands provide flags to run them non-interactively. Prefer those flags.
 `);
 
-export default defineTool<t.GetType<typeof Schema>>(async () => ({
+export default defineTool(Schema, ArgumentsSchema, async () => ({
   Schema,
   ArgumentsSchema,
   validate: async () => null,
+  ...autoparse(ArgumentsSchema),
   async run(abortSignal, transport, call) {
-    const { cmd, timeout } = call.arguments;
+    const { cmd, timeout } = call.parsed;
     try {
       return { content: await transport.shell(abortSignal, cmd, timeout) };
     } catch (e) {

--- a/source/tools/tool-defs/bash.ts
+++ b/source/tools/tool-defs/bash.ts
@@ -32,7 +32,7 @@ export default defineTool(Schema, ArgumentsSchema, async () => ({
   validate: async () => null,
   ...autoparse(ArgumentsSchema),
   async run(abortSignal, transport, call) {
-    const { cmd, timeout } = call.parsed;
+    const { cmd, timeout } = call.parsed.arguments;
     try {
       return { content: await transport.shell(abortSignal, cmd, timeout) };
     } catch (e) {

--- a/source/tools/tool-defs/create.ts
+++ b/source/tools/tool-defs/create.ts
@@ -1,6 +1,6 @@
 import { t } from "structural";
 import { fileTracker, FileExistsError } from "../file-tracker.ts";
-import { ToolError, attempt, defineTool } from "../common.ts";
+import { ToolError, attempt, defineTool, autoparse } from "../common.ts";
 import { Transport } from "../../transports/transport-common.ts";
 
 export const ArgumentsSchema = t.subtype({
@@ -29,13 +29,14 @@ async function validate(
   return null;
 }
 
-export default defineTool<t.GetType<typeof Schema>>(async () => ({
+export default defineTool(Schema, ArgumentsSchema, async () => ({
   Schema,
   ArgumentsSchema,
   validate,
+  ...autoparse(ArgumentsSchema),
   async run(signal, transport, call) {
-    await validate(signal, transport, call);
-    const { filePath, content } = call.arguments;
+    await validate(signal, transport, call.original);
+    const { filePath, content } = call.parsed;
     return attempt(`Failed to create file ${filePath}`, async () => {
       await fileTracker.write(transport, signal, filePath, content);
       return {

--- a/source/tools/tool-defs/create.ts
+++ b/source/tools/tool-defs/create.ts
@@ -36,7 +36,7 @@ export default defineTool(Schema, ArgumentsSchema, async () => ({
   ...autoparse(ArgumentsSchema),
   async run(signal, transport, call) {
     await validate(signal, transport, call.original);
-    const { filePath, content } = call.parsed;
+    const { filePath, content } = call.parsed.arguments;
     return attempt(`Failed to create file ${filePath}`, async () => {
       await fileTracker.write(transport, signal, filePath, content);
       return {

--- a/source/tools/tool-defs/edit.ts
+++ b/source/tools/tool-defs/edit.ts
@@ -1,6 +1,6 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import { ToolError, attemptUntrackedRead, defineTool, autoparse } from "../common.ts";
+import { ToolError, attemptUntrackedRead, defineTool, parseOriginalFile } from "../common.ts";
 import { Transport } from "../../transports/transport-common.ts";
 
 // Construct the intersection manually, since OpenAI and Anthropic can't handle top-level allOf(...)
@@ -38,22 +38,7 @@ export default defineTool(Schema, ParsedSchema, async () => ({
   ArgumentsSchema,
   ParsedSchema,
   validate,
-  parse: async (signal, transport, original) => {
-    const contents = await attemptUntrackedRead(transport, signal, original.arguments.filePath);
-    return {
-      success: true,
-      data: {
-        original,
-        parsed: {
-          name: original.name,
-          arguments: {
-            ...original.arguments,
-            originalFileContents: contents,
-          },
-        },
-      },
-    };
-  },
+  parse: parseOriginalFile,
   async run(signal, transport, call) {
     const { filePath } = call.parsed.arguments;
     const diff = call.parsed.arguments;

--- a/source/tools/tool-defs/edit.ts
+++ b/source/tools/tool-defs/edit.ts
@@ -33,8 +33,8 @@ export default defineTool(Schema, ArgumentsSchema, async () => ({
   validate,
   ...autoparse(ArgumentsSchema),
   async run(signal, transport, call) {
-    const { filePath } = call.parsed;
-    const diff = call.parsed;
+    const { filePath } = call.parsed.arguments;
+    const diff = call.parsed.arguments;
     await fileTracker.assertCanEdit(transport, signal, filePath);
 
     const file = await attemptUntrackedRead(transport, signal, filePath);

--- a/source/tools/tool-defs/edit.ts
+++ b/source/tools/tool-defs/edit.ts
@@ -1,6 +1,6 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import { ToolError, attemptUntrackedRead, defineTool } from "../common.ts";
+import { ToolError, attemptUntrackedRead, defineTool, autoparse } from "../common.ts";
 import { Transport } from "../../transports/transport-common.ts";
 
 // Construct the intersection manually, since OpenAI and Anthropic can't handle top-level allOf(...)
@@ -27,13 +27,14 @@ export const Schema = t.subtype({
   arguments: ArgumentsSchema,
 });
 
-export default defineTool<t.GetType<typeof Schema>>(async () => ({
+export default defineTool(Schema, ArgumentsSchema, async () => ({
   Schema,
   ArgumentsSchema,
   validate,
+  ...autoparse(ArgumentsSchema),
   async run(signal, transport, call) {
-    const { filePath } = call.arguments;
-    const diff = call.arguments;
+    const { filePath } = call.parsed;
+    const diff = call.parsed;
     await fileTracker.assertCanEdit(transport, signal, filePath);
 
     const file = await attemptUntrackedRead(transport, signal, filePath);

--- a/source/tools/tool-defs/edit.ts
+++ b/source/tools/tool-defs/edit.ts
@@ -27,11 +27,33 @@ export const Schema = t.subtype({
   arguments: ArgumentsSchema,
 });
 
-export default defineTool(Schema, ArgumentsSchema, async () => ({
+export const ParsedSchema = ArgumentsSchema.and(
+  t.subtype({
+    originalFileContents: t.str,
+  }),
+);
+
+export default defineTool(Schema, ParsedSchema, async () => ({
   Schema,
   ArgumentsSchema,
+  ParsedSchema,
   validate,
-  ...autoparse(ArgumentsSchema),
+  parse: async (signal, transport, original) => {
+    const contents = await attemptUntrackedRead(transport, signal, original.arguments.filePath);
+    return {
+      success: true,
+      data: {
+        original,
+        parsed: {
+          name: original.name,
+          arguments: {
+            ...original.arguments,
+            originalFileContents: contents,
+          },
+        },
+      },
+    };
+  },
   async run(signal, transport, call) {
     const { filePath } = call.parsed.arguments;
     const diff = call.parsed.arguments;

--- a/source/tools/tool-defs/fetch.ts
+++ b/source/tools/tool-defs/fetch.ts
@@ -1,5 +1,5 @@
 import { t } from "structural";
-import { ToolError, defineTool, USER_ABORTED_ERROR_MESSAGE } from "../common.ts";
+import { ToolError, defineTool, USER_ABORTED_ERROR_MESSAGE, autoparse } from "../common.ts";
 import { getModelFromConfig } from "../../config.ts";
 import { compile } from "html-to-text";
 import { AbortError } from "../../transports/transport-common.ts";
@@ -25,12 +25,13 @@ const Schema = t
   })
   .comment("Fetches web resources via HTTP/HTTPS. Prefer this to bash-isms like curl/wget");
 
-export default defineTool<t.GetType<typeof Schema>>(async () => ({
+export default defineTool(Schema, ArgumentsSchema, async () => ({
   Schema,
   ArgumentsSchema,
   validate: async () => null,
+  ...autoparse(ArgumentsSchema),
   async run(signal, _, call, config, modelOverride) {
-    const { url, includeMarkup } = call.arguments;
+    const { url, includeMarkup } = call.parsed;
     try {
       const response = await fetch(url, { signal });
       const full = await response.text();

--- a/source/tools/tool-defs/fetch.ts
+++ b/source/tools/tool-defs/fetch.ts
@@ -31,7 +31,7 @@ export default defineTool(Schema, ArgumentsSchema, async () => ({
   validate: async () => null,
   ...autoparse(ArgumentsSchema),
   async run(signal, _, call, config, modelOverride) {
-    const { url, includeMarkup } = call.parsed;
+    const { url, includeMarkup } = call.parsed.arguments;
     try {
       const response = await fetch(url, { signal });
       const full = await response.text();

--- a/source/tools/tool-defs/glob.ts
+++ b/source/tools/tool-defs/glob.ts
@@ -1,5 +1,5 @@
 import { t } from "structural";
-import { ToolError, defineTool, USER_ABORTED_ERROR_MESSAGE } from "../common.ts";
+import { ToolError, defineTool, USER_ABORTED_ERROR_MESSAGE, autoparse } from "../common.ts";
 import { getModelFromConfig } from "../../config.ts";
 import { AbortError } from "../../transports/transport-common.ts";
 import { findFiles } from "../../transports/transport-common.ts";
@@ -34,12 +34,13 @@ depend on this fact: there may be directories that it doesn't know it should ign
 terms scoped and specific.
 `);
 
-export default defineTool<t.GetType<typeof Schema>>(async () => ({
+export default defineTool(Schema, ArgumentsSchema, async () => ({
   Schema,
   ArgumentsSchema,
   validate: async () => null,
+  ...autoparse(ArgumentsSchema),
   async run(signal, transport, call, config, modelOverride) {
-    const { cwd, search } = call.arguments;
+    const { cwd, search } = call.parsed;
     try {
       const files = await findFiles(signal, transport, {
         cwd,

--- a/source/tools/tool-defs/glob.ts
+++ b/source/tools/tool-defs/glob.ts
@@ -40,7 +40,7 @@ export default defineTool(Schema, ArgumentsSchema, async () => ({
   validate: async () => null,
   ...autoparse(ArgumentsSchema),
   async run(signal, transport, call, config, modelOverride) {
-    const { cwd, search } = call.parsed;
+    const { cwd, search } = call.parsed.arguments;
     try {
       const files = await findFiles(signal, transport, {
         cwd,

--- a/source/tools/tool-defs/list.ts
+++ b/source/tools/tool-defs/list.ts
@@ -1,5 +1,5 @@
 import { t } from "structural";
-import { ToolError, attempt, defineTool } from "../common.ts";
+import { ToolError, attempt, defineTool, autoparse } from "../common.ts";
 import { Transport } from "../../transports/transport-common.ts";
 
 const ArgumentsSchema = t.subtype({
@@ -8,7 +8,7 @@ const ArgumentsSchema = t.subtype({
 const Schema = t
   .subtype({
     name: t.value("list"),
-    arguments: t.optional(ArgumentsSchema),
+    arguments: ArgumentsSchema,
   })
   .comment(
     "Lists directories. Prefer this to Unix tools like `ls`. If no dirPath is provided, lists the cwd",
@@ -25,13 +25,14 @@ async function validate(
   return null;
 }
 
-export default defineTool<t.GetType<typeof Schema>>(async () => ({
+export default defineTool(Schema, ArgumentsSchema, async () => ({
   Schema,
   ArgumentsSchema,
   validate,
+  ...autoparse(ArgumentsSchema),
   async run(abortSignal, transport, call) {
-    const dirpath = call.arguments?.dirPath || transport.cwd;
-    await validate(abortSignal, transport, call);
+    const dirpath = call.parsed.dirPath || transport.cwd;
+    await validate(abortSignal, transport, call.original);
     return attempt(`No such directory: ${dirpath}`, async () => {
       const entries = await transport.readdir(abortSignal, dirpath);
       return { content: entries.map(entry => JSON.stringify(entry)).join("\n") };

--- a/source/tools/tool-defs/list.ts
+++ b/source/tools/tool-defs/list.ts
@@ -31,7 +31,7 @@ export default defineTool(Schema, ArgumentsSchema, async () => ({
   validate,
   ...autoparse(ArgumentsSchema),
   async run(abortSignal, transport, call) {
-    const dirpath = call.parsed.dirPath || transport.cwd;
+    const dirpath = call.parsed.arguments.dirPath || transport.cwd;
     await validate(abortSignal, transport, call.original);
     return attempt(`No such directory: ${dirpath}`, async () => {
       const entries = await transport.readdir(abortSignal, dirpath);

--- a/source/tools/tool-defs/mcp.ts
+++ b/source/tools/tool-defs/mcp.ts
@@ -1,7 +1,7 @@
 import { t } from "structural";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { ToolError, defineTool, USER_ABORTED_ERROR_MESSAGE } from "../common.ts";
+import { ToolError, defineTool, USER_ABORTED_ERROR_MESSAGE, autoparse } from "../common.ts";
 import { Config } from "../../config.ts";
 import { getModelFromConfig } from "../../config.ts";
 
@@ -128,7 +128,7 @@ export async function shutdownMcpClients(): Promise<void> {
   }
 }
 
-export default defineTool<t.GetType<typeof Schema>>(async (_1, _2, config) => {
+export default defineTool(Schema, ArgumentsSchema, async (_1, _2, config) => {
   const hasMcp = config.mcpServers != null && Object.keys(config.mcpServers).length > 0;
   if (!hasMcp) return null;
 
@@ -136,8 +136,9 @@ export default defineTool<t.GetType<typeof Schema>>(async (_1, _2, config) => {
     Schema,
     ArgumentsSchema,
     validate: async () => null,
+    ...autoparse(ArgumentsSchema),
     async run(abortSignal, _, call, config, modelOverride) {
-      const { server: serverName, tool: toolName, arguments: toolArgs = {} } = call.arguments;
+      const { server: serverName, tool: toolName, arguments: toolArgs = {} } = call.parsed;
 
       // Helper to race any promise against the abort signal
       const withAbort = async <T>(p: Promise<T>): Promise<T> => {

--- a/source/tools/tool-defs/mcp.ts
+++ b/source/tools/tool-defs/mcp.ts
@@ -138,7 +138,11 @@ export default defineTool(Schema, ArgumentsSchema, async (_1, _2, config) => {
     validate: async () => null,
     ...autoparse(ArgumentsSchema),
     async run(abortSignal, _, call, config, modelOverride) {
-      const { server: serverName, tool: toolName, arguments: toolArgs = {} } = call.parsed;
+      const {
+        server: serverName,
+        tool: toolName,
+        arguments: toolArgs = {},
+      } = call.parsed.arguments;
 
       // Helper to race any promise against the abort signal
       const withAbort = async <T>(p: Promise<T>): Promise<T> => {

--- a/source/tools/tool-defs/prepend.ts
+++ b/source/tools/tool-defs/prepend.ts
@@ -21,8 +21,8 @@ export default defineTool(Schema, ArgumentsSchema, async () => ({
   validate,
   ...autoparse(ArgumentsSchema),
   async run(signal, transport, call) {
-    const { filePath } = call.parsed;
-    const edit = call.parsed;
+    const { filePath } = call.parsed.arguments;
+    const edit = call.parsed.arguments;
     await fileTracker.assertCanEdit(transport, signal, filePath);
 
     const file = await attemptUntrackedRead(transport, signal, filePath);

--- a/source/tools/tool-defs/prepend.ts
+++ b/source/tools/tool-defs/prepend.ts
@@ -1,6 +1,6 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import { attemptUntrackedRead, defineTool } from "../common.ts";
+import { attemptUntrackedRead, defineTool, autoparse } from "../common.ts";
 import { Transport } from "../../transports/transport-common.ts";
 
 const ArgumentsSchema = t
@@ -15,13 +15,14 @@ const Schema = t.subtype({
   arguments: ArgumentsSchema,
 });
 
-export default defineTool<t.GetType<typeof Schema>>(async () => ({
+export default defineTool(Schema, ArgumentsSchema, async () => ({
   Schema,
   ArgumentsSchema,
   validate,
+  ...autoparse(ArgumentsSchema),
   async run(signal, transport, call) {
-    const { filePath } = call.arguments;
-    const edit = call.arguments;
+    const { filePath } = call.parsed;
+    const edit = call.parsed;
     await fileTracker.assertCanEdit(transport, signal, filePath);
 
     const file = await attemptUntrackedRead(transport, signal, filePath);

--- a/source/tools/tool-defs/read.ts
+++ b/source/tools/tool-defs/read.ts
@@ -1,6 +1,6 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import { attempt, attemptUntrackedStat, defineTool } from "../common.ts";
+import { attempt, attemptUntrackedStat, defineTool, autoparse } from "../common.ts";
 import { isImagePath, loadImageFromPath } from "../../utils/image-utils.ts";
 
 const ArgumentsSchema = t.subtype({
@@ -15,15 +15,16 @@ const Schema = t
     "Reads file contents as UTF-8, or loads supported image files (PNG, JPEG, etc.) for visual inspection. Prefer this to Unix tools like `cat`",
   );
 
-export default defineTool<t.GetType<typeof Schema>>(async () => ({
+export default defineTool(Schema, ArgumentsSchema, async () => ({
   Schema,
   ArgumentsSchema,
   async validate(abortSignal, transport, toolCall) {
     await attemptUntrackedStat(transport, abortSignal, toolCall.arguments.filePath);
     return null;
   },
+  ...autoparse(ArgumentsSchema),
   async run(abortSignal, transport, call) {
-    const { filePath } = call.arguments;
+    const { filePath } = call.parsed;
 
     if (isImagePath(filePath)) {
       return attempt(`Could not read image ${filePath}`, async () => {

--- a/source/tools/tool-defs/read.ts
+++ b/source/tools/tool-defs/read.ts
@@ -24,7 +24,7 @@ export default defineTool(Schema, ArgumentsSchema, async () => ({
   },
   ...autoparse(ArgumentsSchema),
   async run(abortSignal, transport, call) {
-    const { filePath } = call.parsed;
+    const { filePath } = call.parsed.arguments;
 
     if (isImagePath(filePath)) {
       return attempt(`Could not read image ${filePath}`, async () => {

--- a/source/tools/tool-defs/rewrite.ts
+++ b/source/tools/tool-defs/rewrite.ts
@@ -1,6 +1,6 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import { attemptUntrackedRead, defineTool } from "../common.ts";
+import { attemptUntrackedRead, defineTool, autoparse } from "../common.ts";
 
 const ArgumentsSchema = t.subtype({
   filePath: t.str.comment("The path to the file"),
@@ -18,17 +18,40 @@ const Schema = t.subtype({
   arguments: ArgumentsSchema,
 });
 
-export default defineTool<t.GetType<typeof Schema>>(async () => ({
+const ParsedSchema = ArgumentsSchema.and(
+  t.subtype({
+    originalFileContents: t.str,
+  }),
+);
+
+export default defineTool(Schema, ParsedSchema, async () => ({
   Schema,
   ArgumentsSchema,
+  ParsedSchema,
   async validate(signal, transport, toolCall) {
     await fileTracker.assertCanEdit(transport, signal, toolCall.arguments.filePath);
     await attemptUntrackedRead(transport, signal, toolCall.arguments.filePath);
     return null;
   },
+  parse: async (signal, transport, original) => {
+    const contents = await attemptUntrackedRead(transport, signal, original.arguments.filePath);
+    return {
+      success: true,
+      data: {
+        original,
+        parsed: {
+          name: original.name,
+          arguments: {
+            ...original.arguments,
+            originalFileContents: contents,
+          },
+        },
+      },
+    };
+  },
   async run(signal, transport, call) {
-    const { filePath } = call.arguments;
-    const edit = call.arguments;
+    const { filePath } = call.parsed;
+    const edit = call.parsed;
     await fileTracker.assertCanEdit(transport, signal, filePath);
     const replaced = runEdit({ edit });
     await fileTracker.write(transport, signal, filePath, replaced);

--- a/source/tools/tool-defs/rewrite.ts
+++ b/source/tools/tool-defs/rewrite.ts
@@ -1,6 +1,6 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import { attemptUntrackedRead, defineTool } from "../common.ts";
+import { attemptUntrackedRead, defineTool, parseOriginalFile } from "../common.ts";
 
 const ArgumentsSchema = t.subtype({
   filePath: t.str.comment("The path to the file"),
@@ -33,22 +33,7 @@ export default defineTool(Schema, ParsedSchema, async () => ({
     await attemptUntrackedRead(transport, signal, toolCall.arguments.filePath);
     return null;
   },
-  parse: async (signal, transport, original) => {
-    const contents = await attemptUntrackedRead(transport, signal, original.arguments.filePath);
-    return {
-      success: true,
-      data: {
-        original,
-        parsed: {
-          name: original.name,
-          arguments: {
-            ...original.arguments,
-            originalFileContents: contents,
-          },
-        },
-      },
-    };
-  },
+  parse: parseOriginalFile,
   async run(signal, transport, call) {
     const { filePath } = call.parsed.arguments;
     const edit = call.parsed.arguments;

--- a/source/tools/tool-defs/rewrite.ts
+++ b/source/tools/tool-defs/rewrite.ts
@@ -1,6 +1,6 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import { attemptUntrackedRead, defineTool, autoparse } from "../common.ts";
+import { attemptUntrackedRead, defineTool } from "../common.ts";
 
 const ArgumentsSchema = t.subtype({
   filePath: t.str.comment("The path to the file"),

--- a/source/tools/tool-defs/rewrite.ts
+++ b/source/tools/tool-defs/rewrite.ts
@@ -50,8 +50,8 @@ export default defineTool(Schema, ParsedSchema, async () => ({
     };
   },
   async run(signal, transport, call) {
-    const { filePath } = call.parsed;
-    const edit = call.parsed;
+    const { filePath } = call.parsed.arguments;
+    const edit = call.parsed.arguments;
     await fileTracker.assertCanEdit(transport, signal, filePath);
     const replaced = runEdit({ edit });
     await fileTracker.write(transport, signal, filePath, replaced);

--- a/source/tools/tool-defs/skill.ts
+++ b/source/tools/tool-defs/skill.ts
@@ -1,9 +1,9 @@
 import { t } from "structural";
 import { unionAll } from "../../types.ts";
-import { defineTool, ToolDef } from "../common.ts";
+import { dynamicDefineTool, ToolDef, autoparse } from "../common.ts";
 import { discoverSkills } from "../../skills/skills.ts";
 
-export default defineTool(async function (signal, transport, config) {
+export default dynamicDefineTool("skill", async function (signal, transport, config) {
   const skills = await discoverSkills(transport, signal, config);
   if (skills.length === 0) return null;
 
@@ -31,8 +31,9 @@ export default defineTool(async function (signal, transport, config) {
     async validate() {
       return null;
     },
+    ...autoparse(ArgumentsSchema),
     async run(_1, _2, call) {
-      const { skillName } = call.arguments;
+      const { skillName } = call.parsed;
       const skill = skills.find(s => s.name === skillName)!;
 
       return {
@@ -56,5 +57,9 @@ ${skill.instructions}
 `.trim(),
       };
     },
-  } satisfies ToolDef<t.GetType<typeof Schema>>;
+  } satisfies ToolDef<
+    "skill",
+    t.GetType<typeof ArgumentsSchema>,
+    t.GetType<typeof ArgumentsSchema>
+  >;
 });

--- a/source/tools/tool-defs/skill.ts
+++ b/source/tools/tool-defs/skill.ts
@@ -33,7 +33,7 @@ export default dynamicDefineTool("skill", async function (signal, transport, con
     },
     ...autoparse(ArgumentsSchema),
     async run(_1, _2, call) {
-      const { skillName } = call.parsed;
+      const { skillName } = call.parsed.arguments;
       const skill = skills.find(s => s.name === skillName)!;
 
       return {

--- a/source/tools/tool-defs/web-search.ts
+++ b/source/tools/tool-defs/web-search.ts
@@ -1,5 +1,5 @@
 import { t } from "structural";
-import { attempt, defineTool } from "../common.ts";
+import { attempt, defineTool, autoparse } from "../common.ts";
 import { readSearchConfig } from "../../config.ts";
 
 const ArgumentsSchema = t.subtype({
@@ -29,7 +29,7 @@ const SearchResultsSchema = t.subtype({
   ),
 });
 
-export default defineTool<t.GetType<typeof Schema>>(async (_1, _2, config) => {
+export default defineTool(Schema, ArgumentsSchema, async (_1, _2, config) => {
   const searchConf = await readSearchConfig(config);
   if (searchConf == null) return null;
 
@@ -37,8 +37,9 @@ export default defineTool<t.GetType<typeof Schema>>(async (_1, _2, config) => {
     Schema,
     ArgumentsSchema,
     validate,
+    ...autoparse(ArgumentsSchema),
     async run(abortSignal, _, call) {
-      const query = call.arguments.query;
+      const query = call.parsed.query;
       return attempt(`Web search failed: ${query}`, async () => {
         const response = await fetch(searchConf.url, {
           headers: {

--- a/source/tools/tool-defs/web-search.ts
+++ b/source/tools/tool-defs/web-search.ts
@@ -39,7 +39,7 @@ export default defineTool(Schema, ArgumentsSchema, async (_1, _2, config) => {
     validate,
     ...autoparse(ArgumentsSchema),
     async run(abortSignal, _, call) {
-      const query = call.parsed.query;
+      const query = call.parsed.arguments.query;
       return attempt(`Web search failed: ${query}`, async () => {
         const response = await fetch(searchConf.url, {
           headers: {


### PR DESCRIPTION
#175 was a little large as a vibecoded PR to review and parallel tool calling in general is a pretty tricky feature, since so much silently assumes single-tool-call-only in the Octo codebase. But, parallel tool calling is indeed a very useful feature: it's more efficient in terms of tokens, and also can just help LLMs be more accurate in general since if there's a complex edit in several different parts of the same large file, the LLM can send all the edits down in a single response rather than needing to track state across multiple turns.

This PR does the hard work of adding support for parallel tool calls. It's pretty invasive and large, unfortunately, as I uncovered many places in our codebase that assumed single-tool-calls.

There are a few things worth calling out in this PR:

1. `toolCall: ToolCallRequest` -> `toolCalls: ToolCallRequest[]` in the obvious places. There were also a couple history items / IRs where we were storing denormalized tool call data rather than full `ToolCallRequest` objects, and for simplification's sake in the compilers and history transforms I swapped those out to just store the original `ToolCallRequest`: previously they'd do single-item lookback to find the originating tool call, but that single-item-lookback isn't possible when there may be multiple tool calls, so rather than denorm+lookback-N-times I just store the entire originating tool call in the respective item/IR and don't need to do any lookback in those cases anymore.
2. We add a new `tool-skip` IR and HistoryItem. When a tool call in a batch fails validation, generally we should just retry right away... But, the LLM needs to know two things: a) which tool call failed, and b) that all other tool calls were skipped and didn't run. In theory we could edit the IR to remove the non-failed tool calls, but a) that could impact cache hits, and also b) that could poison the LLM with a history of making nonsense changes, i.e. if we only show it a single tool call when it intended to call a large batch, it will be confused since its in-domain action was to attempt a larger edit / set of edits / etc. Adding a `tool-skip` IR lets us track which tools were skipped, and provide correct markers in the compilers to show to the LLM that those tools didn't run using the various LLM API hooks for this sort of thing.
3. We also silently insert `tool-skip` IRs for any tool call that came *after* a rejected tool call. Generally rejection UX should only require a single rejection from the user, and so as soon as they reject one tool call, all subsequent ones are also rejected. Previous ones don't have to be rejected, since presumably they already ran i.e. previous edits.
4. Surprisingly, this required fairly invasive tool call and UI changes especially around diff handling! Previously, since tool calls happened only once, and were immediately turned into StaticItems, we could do things like read the underlying file and use it as the source of truth for rendering diffs *at UI layout time*. This doesn't work with parallel tool calls, since the file may be changing in between tool calls in the same batch, and by the time the tool runs and is turned into a `tool-output` for the static item renderer, the underlying file may have already been modified and the search string may no longer exist: both codepaths are racing each other, and the diff edit renderer sometimes would fail to render as a result, since it tries to find the search string in the underlying file as part of rendering updated line numbers. In order to handle this race condition, we need to store the file contents *at the time of the tool call parsing,* before any edits were made. The simplest/most elegant way I could think of doing this  is to actually store it on the parsed output from the tool call (i.e. just like we previously could read `edit.filePath`, we might want to be able to read `edit.originalFileContents`). This meant adding a `parse()` function to tool definitions, so that we could transform the LLM responses into richer data stored internally, including for example file contents at the time of parsing. Most tools just use a new `autoparse` function that is a no-op identity function, but the `edit` and `rewrite` tools have now have parsing logic to read and store the original file contents so that they can later be used for diff rendering. The mildly nice side effect of this change is that we don't use `readFileSync` during React layout anymore.

Playing around with it, it seems to work reasonably well! LLMs can make multiple edits in a single batch; people are presented with the edits one-by-one as if multiple requests were being made (aka the UX is the same); and rejection UX is identical and yet LLMs in my testing were able to understand precisely which tool calls ran, which were rejected, and which were skipped.