### PR TITLE
Fix shell timeout with bash commands

### DIFF
--- a/source/transports/local.ts
+++ b/source/transports/local.ts
@@ -80,16 +80,15 @@ export class LocalTransport implements Transport {
       const child = spawn(cmd, {
         cwd: process.cwd(),
         shell: "bash",
-        timeout,
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
       });
 
       let output = "";
       let aborted = false;
+      let timedOut = false;
 
-      const onAbort = () => {
-        aborted = true;
+      function killGroup() {
         // Kill the entire process group to handle child processes
         try {
           // First, try to kill the process group with SIGTERM
@@ -108,14 +107,25 @@ export class LocalTransport implements Transport {
             } catch {}
           }
         }, 500).unref?.();
-      };
+      }
+
+      function onAbort() {
+        aborted = true;
+        killGroup();
+      }
+
+      function cleanup() {
+        signal.removeEventListener("abort", onAbort);
+        clearTimeout(timeoutHandler);
+      }
+
+      const timeoutHandler = setTimeout(() => {
+        timedOut = true;
+        killGroup();
+      }, timeout);
 
       if (signal.aborted) onAbort();
       signal.addEventListener("abort", onAbort);
-
-      const cleanup = () => {
-        signal.removeEventListener("abort", onAbort);
-      };
 
       child.stdout.on("data", data => {
         output += data.toString();
@@ -131,13 +141,22 @@ export class LocalTransport implements Transport {
           reject(new AbortError());
           return;
         }
+        if (timedOut) {
+          reject(
+            new CommandFailedError(
+              `Command timed out.
+output: ${output}`,
+            ),
+          );
+          return;
+        }
         if (code === 0) {
           resolve(output);
         } else {
           if (code == null) {
             reject(
               new CommandFailedError(
-                `Command timed out.
+                `Command killed by signal.
 output: ${output}`,
               ),
             );

--- a/source/transports/local.ts
+++ b/source/transports/local.ts
@@ -87,8 +87,11 @@ export class LocalTransport implements Transport {
       let output = "";
       let aborted = false;
       let timedOut = false;
+      let killed = false;
 
       function killGroup() {
+        if (killed) return;
+        killed = true;
         // Kill the entire process group to handle child processes
         try {
           // First, try to kill the process group with SIGTERM


### PR DESCRIPTION
Previously when running a command such as `npm run dev &`, the command hangs forever and doesn't time out (even though Octo does set a timeout).

The fix is to manually run a `setTimeout` and kill the process group once `timeout` is hit.
The built-in `timeout` option in `spawn` won't work since it would just kill the child process `bash` instead of the whole group (including `npm` in this case). 