### PR TITLE
Fix package.json resolution in unit tests

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -616,10 +616,15 @@ export type Metadata = {
 };
 
 async function readMetadata(): Promise<Metadata> {
-  const packageFile = await fs.readFile(path.join(__dir, "../../package.json"), "utf8");
-  const packageJson = JSON.parse(packageFile);
+  const candidates = [path.join(__dir, "../package.json"), path.join(__dir, "../../package.json")];
 
-  return {
-    version: packageJson["version"],
-  };
+  for (const candidate of candidates) {
+    if (await fileExists(candidate)) {
+      const packageFile = await fs.readFile(candidate, "utf8");
+      const packageJson = JSON.parse(packageFile);
+      return { version: packageJson["version"] };
+    }
+  }
+
+  throw new Error("Could not find package.json");
 }


### PR DESCRIPTION
`autocompact.test.test` fails with:

<img width="2636" height="768" alt="CleanShot 2026-04-28 at 17 41 23@2x" src="https://github.com/user-attachments/assets/aaf203b6-a1d4-4fc3-994f-a8421e891737" />

`path.join(__dir, "../../package.json")` works when run from `dist/` but not from source. This just steps up the tree twice to look for package.json.