### PR TITLE
Improve notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,22 +259,36 @@ OCTO_VERBOSE=1 octofriend
 
 ## Notify Finish Command
 
-You can configure a command to run whenever Octo finishes responding to a prompt.
-This is useful for desktop notifications, sounds, or other integrations.
+You can configure a command to run whenever Octo finishes responding to a
+prompt or needs input like permissions. This is useful for desktop
+notifications, sounds, or other integrations.
 
-This command will **not** run for tool call confirmations. It will only run when
-Octo is ready for a new prompt (eg. after responding to a prompt in unchained mode)
-
-Add a `notifyFinishCommand` to your `~/.config/octofriend/octofriend.json5`:
+Add a `notifications` block to your `~/.config/octofriend/octofriend.json5`:
 
 ```json5
-notifyFinishCommand: "notify-send Octo 'Finished responding!'",
+notifications: {
+  notifyCommand: "notify-send Octo 'Finished responding!'",
+},
 ```
 
 Or for macOS:
 
 ```json5
-notifyFinishCommand: 'osascript -e \'display notification "Octo finished!"\'',
+notifications: {
+  notifyCommand: 'osascript -e \'display notification "Octo finished!"\'',
+},
+```
+
+By default, Octo will wait 10 seconds before notifying you, and if it receives
+input during that time it'll skip the notification (so as to not spam you with
+notifications when you're actively attending to it and chatting). To change the
+wait time, set:
+
+```json5
+notification: {
+  notifyCommand: "some command",
+  notifyTimeoutMs: 20000, // Or however many milliseconds you want to wait
+},
 ```
 
 ## Opting into canary versions

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ underlying error messages from APIs or tool calls, run Octo with the
 OCTO_VERBOSE=1 octofriend
 ```
 
-## Notify Finish Command
+## Desktop notifications
 
 You can configure a command to run whenever Octo finishes responding to a
 prompt or needs input like permissions. This is useful for desktop

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ notifications when you're actively attending to it and chatting). To change the
 wait time, set:
 
 ```json5
-notification: {
+notifications: {
   notifyCommand: "some command",
   notifyTimeoutMs: 20000, // Or however many milliseconds you want to wait
 },

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -154,14 +154,19 @@ export default function App({
   const [tempNotification, setTempNotification] = useState<string | null>(
     isUnchained ? UNCHAINED_NOTIF : CHAINED_NOTIF,
   );
-  const { history, modeData, setVimMode, clearNonce } = useAppStore(
+  const { history, modeData, setVimMode, clearNonce, cancelNotifyReadyForInput } = useAppStore(
     useShallow(state => ({
       history: state.history,
       modeData: state.modeData,
       setVimMode: state.setVimMode,
       clearNonce: state.clearNonce,
+      cancelNotifyReadyForInput: state.cancelNotifyReadyForInput,
     })),
   );
+
+  useInput(() => {
+    cancelNotifyReadyForInput();
+  });
 
   useEffect(() => {
     if (updates != null) markUpdatesSeen();
@@ -342,6 +347,7 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
     setVimMode,
     query,
     setQuery,
+    notifyReadyForInput,
   } = useAppStore(
     useShallow(state => ({
       modeData: state.modeData,
@@ -353,11 +359,18 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
       setVimMode: state.setVimMode,
       query: state.query,
       setQuery: state.setQuery,
+      notifyReadyForInput: state.notifyReadyForInput,
     })),
   );
 
   const vimMode =
     vimEnabled && vimEnabled && modeData.mode === "input" ? modeData.vimMode : "NORMAL";
+
+  useEffect(() => {
+    if (modeData.mode === "input") {
+      notifyReadyForInput(config);
+    }
+  }, [config, modeData.mode]);
 
   useCtrlC(() => {
     if (vimEnabled) return;
@@ -701,12 +714,13 @@ function ToolRequestRenderer({
   onDone: () => void;
 } & RunArgs) {
   const themeColor = useColor();
-  const { runTool, rejectTool, isWhitelisted, addToWhitelist } = useAppStore(
+  const { runTool, rejectTool, isWhitelisted, addToWhitelist, notifyReadyForInput } = useAppStore(
     useShallow(state => ({
       runTool: state.runTool,
       rejectTool: state.rejectTool,
       isWhitelisted: state.isWhitelisted,
       addToWhitelist: state.addToWhitelist,
+      notifyReadyForInput: state.notifyReadyForInput,
     })),
   );
   const unchained = useUnchained();
@@ -833,6 +847,8 @@ function ToolRequestRenderer({
   useEffect(() => {
     if (noConfirmationNeeded) {
       runTool({ toolReq, config, transport }).then(onDone);
+    } else {
+      notifyReadyForInput(config);
     }
   }, [toolReq, noConfirmationNeeded, config, transport, onDone]);
 

--- a/source/config.ts
+++ b/source/config.ts
@@ -32,6 +32,19 @@ const MIGRATIONS: Record<number, Migration> = {
       return model;
     }),
   }),
+  2: raw => {
+    const notifyCommand = raw["notifyFinishCommand"];
+    if (notifyCommand === undefined) {
+      return raw;
+    }
+    delete raw["notifyFinishCommand"];
+    return {
+      ...raw,
+      notifications: {
+        notifyCommand,
+      },
+    };
+  },
 };
 
 function migrateConfig(raw: Record<string, any>): Record<string, any> {
@@ -130,6 +143,12 @@ const ConfigSchema = t.exact({
   skills: t.optional(
     t.exact({
       paths: t.optional(t.array(t.str)),
+    }),
+  ),
+  notifications: t.optional(
+    t.subtype({
+      notifyCommand: t.str,
+      notifyTimeoutMs: t.optional(t.num),
     }),
   ),
   notifyFinishCommand: t.optional(t.str),

--- a/source/config.ts
+++ b/source/config.ts
@@ -17,7 +17,7 @@ const KeyConfigSchema = t.dict(t.str);
 export const DEFAULT_AUTOCOMPACT_THRESHOLD = 0.8;
 
 export const APP_METADATA = await readMetadata();
-export const CURRENT_CONFIG_VERSION = 1;
+export const CURRENT_CONFIG_VERSION = 2;
 
 type Migration = (raw: Record<string, any>) => Record<string, any>;
 
@@ -151,7 +151,6 @@ const ConfigSchema = t.exact({
       notifyTimeoutMs: t.optional(t.num),
     }),
   ),
-  notifyFinishCommand: t.optional(t.str),
 });
 export type Config = t.GetType<typeof ConfigSchema>;
 export const AUTOFIX_KEYS = ["diffApply", "fixJson"] as const;
@@ -165,7 +164,7 @@ const AUTH_COMMAND_MAX_OUTPUT_BYTES = 16 * 1024;
 const NOTIFY_COMMAND_TIMEOUT_MS = 10_000;
 
 export async function runNotifyCommand(config: Config): Promise<void> {
-  const cmd = config.notifyFinishCommand;
+  const cmd = config.notifications?.notifyCommand;
   if (!cmd || cmd.trim() === "") return;
   const shell = process.env["SHELL"] || "/bin/sh";
 

--- a/source/state.ts
+++ b/source/state.ts
@@ -37,6 +37,8 @@ export type RunArgs = {
 export type InflightResponseType = Omit<AssistantItem, "id" | "tokenUsage" | "outputTokens">;
 export type UiState = {
   preMenuVimMode: "NORMAL" | "INSERT" | null;
+  hasNotifiedPrompt: boolean;
+  _notifyTimer: NodeJS.Timeout | null;
   modeData:
     | {
         mode: "input";
@@ -99,6 +101,8 @@ export type UiState = {
   clearNonce: number;
   lastUserPromptId: bigint | null;
   whitelist: Set<string>;
+  notifyReadyForInput: (config: Config) => void;
+  cancelNotifyReadyForInput: () => void;
   input: (args: RunArgs & { query: string; images?: ImageInfo[] }) => Promise<void>;
   runTool: (args: RunArgs & { toolReq: ToolCallRequest }) => Promise<void>;
   rejectTool: (toolCall: ToolCallRequest) => void;
@@ -125,6 +129,8 @@ export type UiState = {
 
 export const useAppStore = create<UiState>((set, get) => ({
   preMenuVimMode: null,
+  hasNotifiedPrompt: false,
+  _notifyTimer: null,
   modeData: {
     mode: "input" as const,
     vimMode: "INSERT" as const,
@@ -137,6 +143,28 @@ export const useAppStore = create<UiState>((set, get) => ({
   clearNonce: 0,
   lastUserPromptId: null,
   whitelist: new Set<string>(),
+
+  notifyReadyForInput: config => {
+    const { hasNotifiedPrompt } = get();
+    // The first time Octo launches, skip notifying: no one's entered a prompt yet
+    if (!hasNotifiedPrompt) {
+      set({ hasNotifiedPrompt: true });
+      return;
+    }
+
+    const notifyTimeout = config.notifications?.notifyTimeoutMs ?? 10_000;
+    const timer = setTimeout(async () => {
+      await runNotifyCommand(config);
+    }, notifyTimeout);
+    set({ _notifyTimer: timer });
+  },
+
+  cancelNotifyReadyForInput: () => {
+    const { _notifyTimer } = get();
+    if (_notifyTimer) {
+      clearTimeout(_notifyTimer);
+    }
+  },
 
   input: async ({ config, query, transport, images }) => {
     const userMessage: UserItem = {
@@ -545,9 +573,6 @@ export const useAppStore = create<UiState>((set, get) => ({
       const finishReason = finish.reason;
       if (finishReason.type === "abort" || finishReason.type === "needs-response") {
         set({ modeData: { mode: "input", vimMode: "INSERT" } });
-        if (finishReason.type === "needs-response") {
-          runNotifyCommand(config).catch(() => {});
-        }
         return;
       }
 


### PR DESCRIPTION
#183 was pretty nice, but I think it's a little confusing that we don't send notifications when Octo is waiting for things like tool prompts/permissions. Also, it's a little spammy, since it notifies *every* time Octo is done responding, even if you're actively interacting with it.

This PR improves notifications for Octo by:

1. Notifying for any state where Octo needs input from you, including tool prompts
2. Waiting a configurable amount of time before sending notifications, and canceling the notifications on input. By default, the wait time is 10s. This feels like a reasonable default in terms of not wasting *too* much time waiting, while also avoiding most notification spam.