### PR TITLE
Add grep tool

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -29,6 +29,7 @@ import fetchTool from "./tools/tool-defs/fetch.ts";
 import skill from "./tools/tool-defs/skill.ts";
 import webSearch from "./tools/tool-defs/web-search.ts";
 import glob from "./tools/tool-defs/glob.ts";
+import grep from "./tools/tool-defs/grep.ts";
 import { ALWAYS_REQUEST_PERMISSION_TOOLS, SKIP_CONFIRMATION_TOOLS } from "./tools/index.ts";
 import { ParsedSchema as EditParsedSchema } from "./tools/tool-defs/edit.ts";
 import { ParsedToolSchemaFrom } from "./tools/common.ts";
@@ -743,6 +744,7 @@ function ToolRequestRenderer({
       case "shell":
       case "fetch":
       case "glob":
+      case "grep":
       case "web-search":
         return `${fn.name}:*`;
     }
@@ -776,6 +778,7 @@ function ToolRequestRenderer({
       case "list":
       case "mcp":
       case "glob":
+      case "grep":
       case "web-search":
         return null;
     }
@@ -1105,6 +1108,8 @@ function ToolMessageRenderer({ item }: { item: ToolCallItems["tools"][number] })
       return <WebSearchToolRenderer item={item.call.parsed} />;
     case "glob":
       return <GlobRenderer item={item.call.parsed} />;
+    case "grep":
+      return <GrepRenderer item={item.call.parsed} />;
   }
 }
 
@@ -1119,7 +1124,20 @@ function GlobRenderer({ item }: { item: ParsedToolSchemaFrom<typeof glob> }) {
     </Box>
   );
 }
-function GlobArg({ name, arg }: { name: string; arg: string | number | undefined }) {
+function GrepRenderer({ item }: { item: ParsedToolSchemaFrom<typeof grep> }) {
+  return (
+    <Box flexDirection="column">
+      <Text color="gray">Octo searched file contents:</Text>
+      <GlobArg name="Pattern" arg={item.arguments.search.pattern} />
+      <GlobArg name="Path" arg={item.arguments.search.path} />
+      <GlobArg name="Case insensitive" arg={item.arguments.search.caseInsensitive} />
+      <GlobArg name="Context lines" arg={item.arguments.search.context} />
+      <GlobArg name="Max results" arg={item.arguments.search.maxResults} />
+    </Box>
+  );
+}
+
+function GlobArg({ name, arg }: { name: string; arg: string | number | boolean | undefined }) {
   const color = useColor();
   if (arg == null) return null;
   return (
@@ -1319,6 +1337,8 @@ function WhitelistAllowDescription({ toolCallRequest }: { toolCallRequest: ToolC
   switch (fn.name) {
     case "glob":
       return <Text> local glob searches in this session.</Text>;
+    case "grep":
+      return <Text> local grep searches in this session.</Text>;
     case "shell": {
       return (
         <Text>

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -1133,6 +1133,7 @@ function GrepRenderer({ item }: { item: ParsedToolSchemaFrom<typeof grep> }) {
       <GlobArg name="Case insensitive" arg={item.arguments.search.caseInsensitive} />
       <GlobArg name="Context lines" arg={item.arguments.search.context} />
       <GlobArg name="Max results" arg={item.arguments.search.maxResults} />
+      <GlobArg name="Timeout" arg={item.arguments.search.timeout} />
     </Box>
   );
 }

--- a/source/ir/convert-history-ir.ts
+++ b/source/ir/convert-history-ir.ts
@@ -265,6 +265,7 @@ function collapseToIR(prev: LlmIR | null, item: LoweredHistory): [LlmIR | null, 
       case "mcp":
       case "web-search":
       case "glob":
+      case "grep":
         return [
           null,
           {

--- a/source/tools/index.ts
+++ b/source/tools/index.ts
@@ -44,6 +44,7 @@ export const SKIP_CONFIRMATION_TOOLS: Array<keyof LoadedTools> = [
   "skill",
   "web-search",
   "glob",
+  "grep",
 ];
 
 export const ALWAYS_REQUEST_PERMISSION_TOOLS: Array<keyof LoadedTools> = ["shell"];

--- a/source/tools/tool-defs/grep.ts
+++ b/source/tools/tool-defs/grep.ts
@@ -14,6 +14,7 @@ const ArgumentsSchema = t.subtype({
       caseInsensitive: t.bool.comment("Case-insensitive search"),
       context: t.num.comment("Number of context lines around each match"),
       maxResults: t.num.comment("Max number of results to return"),
+      timeout: t.num.comment("Timeout in milliseconds (defaults to 30000)"),
     }),
   ),
 });
@@ -49,7 +50,8 @@ export default defineTool(Schema, ArgumentsSchema, async () => ({
       args.push(quote([searchPath]));
 
       const cmd = `grep ${args.join(" ")}`;
-      const output = await transport.shell(signal, cmd, 30000);
+      const timeout = search.timeout ?? 30000;
+      const output = await transport.shell(signal, cmd, timeout);
 
       let results = output.split("\n").filter(line => line.length > 0);
 

--- a/source/tools/tool-defs/grep.ts
+++ b/source/tools/tool-defs/grep.ts
@@ -1,0 +1,80 @@
+import { quote } from "shell-quote";
+import { t } from "structural";
+import { ToolError, defineTool, USER_ABORTED_ERROR_MESSAGE, autoparse } from "../common.ts";
+import { getModelFromConfig } from "../../config.ts";
+import { AbortError, CommandFailedError } from "../../transports/transport-common.ts";
+import { estimateTokens } from "../../ir/count-ir-tokens.ts";
+
+const ArgumentsSchema = t.subtype({
+  cwd: t.optional(t.str),
+  search: t.partial(
+    t.subtype({
+      pattern: t.str.comment("The search pattern"),
+      path: t.str.comment("Directory or file to search (defaults to cwd)"),
+      caseInsensitive: t.bool.comment("Case-insensitive search"),
+      context: t.num.comment("Number of context lines around each match"),
+      maxResults: t.num.comment("Max number of results to return"),
+    }),
+  ),
+});
+
+const Schema = t.subtype({
+  name: t.value("grep"),
+  arguments: ArgumentsSchema,
+}).comment(`
+Searches file contents using grep. Prefer this to shelling out to \`grep\` directly.
+`);
+
+export default defineTool(Schema, ArgumentsSchema, async () => ({
+  Schema,
+  ArgumentsSchema,
+  validate: async () => null,
+  ...autoparse(ArgumentsSchema),
+  async run(signal, transport, call, config, modelOverride) {
+    const { cwd, search } = call.parsed.arguments;
+    try {
+      const args: string[] = ["-n", "-r"];
+
+      if (search.caseInsensitive) {
+        args.push("-i");
+      }
+
+      if (search.context !== undefined && search.context > 0) {
+        args.push(`-C${search.context}`);
+      }
+
+      args.push("--", quote([search.pattern ?? ""]));
+
+      const searchPath = search.path ?? cwd ?? transport.cwd;
+      args.push(quote([searchPath]));
+
+      const cmd = `grep ${args.join(" ")}`;
+      const output = await transport.shell(signal, cmd, 30000);
+
+      let results = output.split("\n").filter(line => line.length > 0);
+
+      if (search.maxResults !== undefined && search.maxResults > 0) {
+        results = results.slice(0, search.maxResults);
+      }
+
+      const text = results.join("\n");
+      const { context } = getModelFromConfig(config, modelOverride);
+      const tok = estimateTokens(text);
+      if (tok > context) {
+        throw new ToolError(`Grep content was too large: approx ${tok} tokens returned`);
+      }
+      return { content: text };
+    } catch (e) {
+      if (e instanceof AbortError || signal.aborted) {
+        throw new ToolError(USER_ABORTED_ERROR_MESSAGE);
+      }
+      if (e instanceof CommandFailedError) {
+        if (e.message.includes("exit code 1")) {
+          return { content: "" };
+        }
+        throw new ToolError(e.message);
+      }
+      throw e;
+    }
+  },
+}));

--- a/source/tools/tool-defs/index.ts
+++ b/source/tools/tool-defs/index.ts
@@ -11,6 +11,7 @@ import rewrite from "./rewrite.ts";
 import skill from "./skill.ts";
 import webSearch from "./web-search.ts";
 import glob from "./glob.ts";
+import grep from "./grep.ts";
 
 export default {
   read,
@@ -26,4 +27,5 @@ export default {
   skill,
   "web-search": webSearch,
   glob,
+  grep,
 };


### PR DESCRIPTION
Adds a `grep` tool similar to our `glob` tool, based on native POSIX grep. Closes https://github.com/synthetic-lab/octofriend/issues/138

Useful so that Octo doesn't prompt for perms when it's just trying to do safe filesystem searching.