### PR TITLE
Less spammy notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,11 +259,9 @@ OCTO_VERBOSE=1 octofriend
 
 ## Desktop notifications
 
-You can configure a command to run whenever Octo finishes responding to a
-prompt or needs input like permissions. This is useful for desktop
-notifications, sounds, or other integrations.
-
-Add a `notifications` block to your `~/.config/octofriend/octofriend.json5`:
+There's a hidden "Notifications" menu that only appears if you've configured
+desktop notifications. To configure desktop notifications, add a block like
+this to your `octofriend.json5`:
 
 ```json5
 notifications: {
@@ -279,10 +277,19 @@ notifications: {
 },
 ```
 
-By default, Octo will wait 10 seconds before notifying you, and if it receives
-input during that time it'll skip the notification (so as to not spam you with
-notifications when you're actively attending to it and chatting). To change the
-wait time, set:
+This enables the Notifications submenu in the main `ctrl-p` menu. You can set
+it to the following three settings:
+
+- Notify the next time Octo needs input
+- Notify any time Octo needs input this session
+- Always notify any time Octo needs input
+
+The last option will be persisted to your config file, if you set it.
+
+By default, for the session-level and persistent notifications, Octo will wait
+10 seconds before notifying you, and if it receives input during that time
+it'll skip the notification (so as to not spam you with notifications when
+you're actively attending to it and chatting). To change the wait time, set:
 
 ```json5
 notifications: {

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -348,7 +348,6 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
     setVimMode,
     query,
     setQuery,
-    notifyReadyForInput,
   } = useAppStore(
     useShallow(state => ({
       modeData: state.modeData,
@@ -360,18 +359,11 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
       setVimMode: state.setVimMode,
       query: state.query,
       setQuery: state.setQuery,
-      notifyReadyForInput: state.notifyReadyForInput,
     })),
   );
 
   const vimMode =
     vimEnabled && vimEnabled && modeData.mode === "input" ? modeData.vimMode : "NORMAL";
-
-  useEffect(() => {
-    if (modeData.mode === "input") {
-      notifyReadyForInput(config);
-    }
-  }, [config, modeData.mode]);
 
   useCtrlC(() => {
     if (vimEnabled) return;

--- a/source/components/kb-select/kb-shortcut-select.tsx
+++ b/source/components/kb-select/kb-shortcut-select.tsx
@@ -162,6 +162,8 @@ export function KbShortcutSelect<V>({ shortcutItems, onSelect }: KbSelectProps<V
   );
 
   useInput((input, key) => {
+    if (key.ctrl) return;
+
     if (input === "l") {
       const hasNext = items.some(item => item.shortcut === "l" && item.isNavItem);
       if (hasNext) {

--- a/source/config.ts
+++ b/source/config.ts
@@ -149,6 +149,7 @@ const ConfigSchema = t.exact({
     t.subtype({
       notifyCommand: t.str,
       notifyTimeoutMs: t.optional(t.num),
+      alwaysNotify: t.optional(t.bool),
     }),
   ),
 });

--- a/source/menu.tsx
+++ b/source/menu.tsx
@@ -376,8 +376,8 @@ function MainMenu() {
       label: "+ Add a new model",
       value: "add-model" as const,
     },
-    o: {
-      label: "✕ New conversation",
+    c: {
+      label: "⦿ New conversation",
       value: "clear-confirm" as const,
     },
   };
@@ -386,7 +386,7 @@ function MainMenu() {
     items = {
       ...items,
       e: {
-        label: "- Switch to Emacs mode",
+        label: "♺ Switch to Emacs mode",
         value: "vim-toggle" as const,
       },
     };
@@ -394,7 +394,7 @@ function MainMenu() {
     items = {
       ...items,
       v: {
-        label: "- Switch to Vim mode",
+        label: "♺ Switch to Vim mode",
         value: "vim-toggle" as const,
       },
     };
@@ -419,12 +419,22 @@ function MainMenu() {
     };
   }
 
+  if (config.notifications?.notifyCommand) {
+    items = {
+      ...items,
+      n: {
+        label: "🕭 Notifications",
+        value: "notifications-menu" as const,
+      },
+    };
+  }
+
   const settings = filterSettings(config);
   if (Object.values(settings).length !== 0) {
     items = {
       ...items,
       t: {
-        label: "* Settings",
+        label: "⛭ Settings",
         value: "settings-menu" as const,
       },
     };
@@ -432,10 +442,6 @@ function MainMenu() {
 
   items = {
     ...items,
-    n: {
-      label: "🔔 Notifications",
-      value: "notifications-menu" as const,
-    },
     b: {
       label: "⟵ Back to Octo",
       value: "return" as const,
@@ -546,9 +552,11 @@ function NotificationsMenu() {
 
   const alwaysNotify = config.notifications?.alwaysNotify;
   const items: Keymap<NotificationValue> = {
-    a: {
-      label: alwaysNotify ? "Stop always auto-notifying" : "Always auto-notify",
-      value: "always-notify" as const,
+    o: {
+      label: notifyOnce
+        ? "Do not notify the next time Octo needs input"
+        : "Notify the next time Octo needs input",
+      value: "notify-once" as const,
     },
     s: {
       label: sessionAutoNotify
@@ -556,11 +564,9 @@ function NotificationsMenu() {
         : "Auto-notify for the rest of this session",
       value: "session-notify" as const,
     },
-    o: {
-      label: notifyOnce
-        ? "Do not notify the next time Octo needs input"
-        : "Notify the next time Octo needs input",
-      value: "notify-once" as const,
+    a: {
+      label: alwaysNotify ? "Stop always auto-notifying" : "Always auto-notify",
+      value: "always-notify" as const,
     },
     b: {
       label: "Back",

--- a/source/menu.tsx
+++ b/source/menu.tsx
@@ -82,11 +82,10 @@ function AutofixToggle({
       setMenuMode: state.setMenuMode,
     })),
   );
-  const { toggleMenu, notify, resetPreMenuVimMode } = useAppStore(
+  const { toggleMenu, notify } = useAppStore(
     useShallow(state => ({
       toggleMenu: state.toggleMenu,
       notify: state.notify,
-      resetPreMenuVimMode: state.resetPreMenuVimMode,
     })),
   );
 

--- a/source/menu.tsx
+++ b/source/menu.tsx
@@ -24,7 +24,8 @@ type MenuMode =
   | "set-default-model"
   | "quit-confirm"
   | "remove-model"
-  | "clear-confirm";
+  | "clear-confirm"
+  | "notifications-menu";
 
 type MenuState = {
   menuMode: MenuMode;
@@ -54,6 +55,7 @@ export function Menu() {
   if (menuMode === "remove-model") return <RemoveModelMenu />;
   if (menuMode === "diff-apply-toggle") return <DiffApplyToggle />;
   if (menuMode === "fix-json-toggle") return <FixJsonToggle />;
+  if (menuMode === "notifications-menu") return <NotificationsMenu />;
   const _: "add-model" = menuMode;
   return <AddModelMenuFlow />;
 }
@@ -362,14 +364,15 @@ function MainMenu() {
     | "fix-json-toggle"
     | "diff-apply-toggle"
     | "settings-menu"
-    | "clear-confirm";
+    | "clear-confirm"
+    | "notifications-menu";
 
   let items: Keymap<Value> = {
     m: {
       label: "⤭ Switch model",
       value: "model-select" as const,
     },
-    n: {
+    a: {
       label: "+ Add a new model",
       value: "add-model" as const,
     },
@@ -429,6 +432,10 @@ function MainMenu() {
 
   items = {
     ...items,
+    n: {
+      label: "🔔 Notifications",
+      value: "notifications-menu" as const,
+    },
     b: {
       label: "⟵ Back to Octo",
       value: "return" as const,
@@ -506,6 +513,87 @@ function SettingsMenu() {
   return (
     <KbShortcutPanel
       title="Settings Menu"
+      shortcutItems={[{ type: "key" as const, mapping: items }]}
+      onSelect={onSelect}
+    />
+  );
+}
+
+type NotificationValue = "always-notify" | "session-notify" | "notify-once" | "back";
+
+function NotificationsMenu() {
+  const { setMenuMode } = useMenuState(
+    useShallow(state => ({
+      setMenuMode: state.setMenuMode,
+    })),
+  );
+  const config = useConfig();
+  const setConfig = useSetConfig();
+  const { sessionAutoNotify, notifyOnce, toggleMenu, setNotifyOnce, setNotifySession } =
+    useAppStore(
+      useShallow(state => ({
+        sessionAutoNotify: state.sessionAutoNotify,
+        notifyOnce: state.notifyOnce,
+        toggleMenu: state.toggleMenu,
+        setNotifyOnce: state.setNotifyOnce,
+        setNotifySession: state.setNotifySession,
+      })),
+    );
+
+  useInput((_, key) => {
+    if (key.escape) setMenuMode("main-menu");
+  });
+
+  const alwaysNotify = config.notifications?.alwaysNotify;
+  const items: Keymap<NotificationValue> = {
+    a: {
+      label: alwaysNotify ? "Stop always auto-notifying" : "Always auto-notify",
+      value: "always-notify" as const,
+    },
+    s: {
+      label: sessionAutoNotify
+        ? "Stop auto-notifying this session"
+        : "Auto-notify for the rest of this session",
+      value: "session-notify" as const,
+    },
+    o: {
+      label: notifyOnce
+        ? "Do not notify the next time Octo needs input"
+        : "Notify the next time Octo needs input",
+      value: "notify-once" as const,
+    },
+    b: {
+      label: "Back",
+      value: "back" as const,
+    },
+  };
+
+  const onSelect = useCallback(
+    async (item: Item<NotificationValue>) => {
+      if (item.value === "always-notify") {
+        await setConfig({
+          ...config,
+          notifications: {
+            ...config.notifications,
+            alwaysNotify: !alwaysNotify,
+          } as Config["notifications"],
+        });
+      } else if (item.value === "session-notify") {
+        setNotifySession(!sessionAutoNotify);
+      } else if (item.value === "notify-once") {
+        setNotifyOnce(!notifyOnce);
+        setMenuMode("main-menu");
+        toggleMenu();
+      } else if (item.value === "back") {
+        setMenuMode("main-menu");
+      }
+    },
+    [config, setConfig, alwaysNotify, sessionAutoNotify, notifyOnce, toggleMenu],
+  );
+
+  return (
+    <KbShortcutPanel
+      title="Notifications"
       shortcutItems={[{ type: "key" as const, mapping: items }]}
       onSelect={onSelect}
     />

--- a/source/state.ts
+++ b/source/state.ts
@@ -36,9 +36,10 @@ export type RunArgs = {
 
 export type InflightResponseType = Omit<AssistantItem, "id" | "tokenUsage" | "outputTokens">;
 export type UiState = {
-  preMenuVimMode: "NORMAL" | "INSERT" | null;
-  hasNotifiedPrompt: boolean;
+  preMenuModeData: UiState["modeData"] | null;
   _notifyTimer: NodeJS.Timeout | null;
+  sessionAutoNotify: boolean;
+  notifyOnce: boolean;
   modeData:
     | {
         mode: "input";
@@ -103,6 +104,8 @@ export type UiState = {
   whitelist: Set<string>;
   notifyReadyForInput: (config: Config) => void;
   cancelNotifyReadyForInput: () => void;
+  setNotifyOnce: (notifyOnce: boolean) => void;
+  setNotifySession: (notifySession: boolean) => void;
   input: (args: RunArgs & { query: string; images?: ImageInfo[] }) => Promise<void>;
   runTool: (args: RunArgs & { toolReq: ToolCallRequest }) => Promise<void>;
   rejectTool: (toolCall: ToolCallRequest) => void;
@@ -128,9 +131,10 @@ export type UiState = {
 };
 
 export const useAppStore = create<UiState>((set, get) => ({
-  preMenuVimMode: null,
-  hasNotifiedPrompt: false,
+  preMenuModeData: null,
   _notifyTimer: null,
+  sessionAutoNotify: false,
+  notifyOnce: false,
   modeData: {
     mode: "input" as const,
     vimMode: "INSERT" as const,
@@ -144,18 +148,35 @@ export const useAppStore = create<UiState>((set, get) => ({
   lastUserPromptId: null,
   whitelist: new Set<string>(),
 
+  setNotifyOnce: notifyOnce => {
+    set({ notifyOnce });
+  },
+
+  setNotifySession: sessionAutoNotify => {
+    set({ sessionAutoNotify });
+  },
+
   notifyReadyForInput: config => {
-    const { hasNotifiedPrompt } = get();
-    // The first time Octo launches, skip notifying: no one's entered a prompt yet
-    if (!hasNotifiedPrompt) {
-      set({ hasNotifiedPrompt: true });
+    const { sessionAutoNotify, notifyOnce } = get();
+
+    if (notifyOnce) {
+      set({ notifyOnce: false });
+      // fall through to schedule notification
+    } else if (config.notifications?.alwaysNotify || sessionAutoNotify) {
+      // fall through to schedule notification
+    } else {
       return;
     }
 
-    const notifyTimeout = config.notifications?.notifyTimeoutMs ?? 10_000;
+    const notifyTimeout = (() => {
+      if (notifyOnce) return 0;
+      return config.notifications?.notifyTimeoutMs ?? 10_000;
+    })();
+
     const timer = setTimeout(async () => {
       await runNotifyCommand(config);
     }, notifyTimeout);
+
     set({ _notifyTimer: timer });
   },
 
@@ -163,6 +184,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     const { _notifyTimer } = get();
     if (_notifyTimer) {
       clearTimeout(_notifyTimer);
+      set({ _notifyTimer: null });
     }
   },
 
@@ -300,29 +322,28 @@ export const useAppStore = create<UiState>((set, get) => ({
     if (modeData.mode === "input") {
       set({
         modeData: { mode: "menu" },
-        preMenuVimMode: modeData.vimMode,
+        preMenuModeData: modeData,
       });
     } else if (modeData.mode === "menu") {
-      const { preMenuVimMode } = get();
+      const { preMenuModeData } = get();
       set({
-        modeData: { mode: "input", vimMode: preMenuVimMode ?? "INSERT" },
-        preMenuVimMode: null,
+        modeData: preMenuModeData ?? { mode: "input", vimMode: "INSERT" },
+        preMenuModeData: null,
       });
     }
   },
   closeMenu: () => {
-    const { preMenuVimMode } = get();
+    const { preMenuModeData } = get();
     set({
-      modeData: { mode: "input", vimMode: preMenuVimMode ?? "INSERT" },
-      preMenuVimMode: null,
+      modeData: preMenuModeData ?? { mode: "input", vimMode: "INSERT" },
+      preMenuModeData: null,
     });
   },
   openMenu: () => {
     const { modeData } = get();
-    const currentVimMode = modeData.mode === "input" ? modeData.vimMode : "INSERT";
     set({
       modeData: { mode: "menu" },
-      preMenuVimMode: currentVimMode,
+      preMenuModeData: modeData,
     });
   },
 
@@ -336,7 +357,10 @@ export const useAppStore = create<UiState>((set, get) => ({
   },
 
   resetPreMenuVimMode: () => {
-    set({ preMenuVimMode: "INSERT" });
+    const { preMenuModeData } = get();
+    if (preMenuModeData?.mode === "input") {
+      set({ preMenuModeData: { ...preMenuModeData, vimMode: "INSERT" } });
+    }
   },
 
   setQuery: query => {
@@ -456,7 +480,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     const model = getModelFromConfig(config, get().modelOverride);
     const apiKey = await assertKeyForModel(model, config);
 
-    const throttle = throttledBuffer<Partial<Parameters<typeof set>[0]>>(200, set);
+    const throttle = throttledBuffer<Partial<Parameters<typeof set>[0]>>(300, set);
 
     try {
       const finish = await trajectoryArc({
@@ -572,6 +596,7 @@ export const useAppStore = create<UiState>((set, get) => ({
       set({ history: [...historyCopy] });
       const finishReason = finish.reason;
       if (finishReason.type === "abort" || finishReason.type === "needs-response") {
+        get().notifyReadyForInput(config);
         set({ modeData: { mode: "input", vimMode: "INSERT" } });
         return;
       }


### PR DESCRIPTION
Take two on reducing notification spam.

So, playing around with the notifications, it still feels a little spammy. Generally speaking I want to get notified when I'm off doing something else and Octo's waiting: but if I'm actively supervising it, I *don't* also want desktop notifications, and — annoyingly — I still sometimes get them. The chief villain here is the edit tool. Consider:

1. Octo proposes a decent-sized edit
2. I start reading it
3. There's no indication to Octo I'm doing anything: I haven't touched my keyboard, it's just me visually scanning the diff
4. Ten seconds pass
5. *Ding!* A desktop notification appears

This is annoying and generates a bunch of useless notifications.

To get around this, I'm changing notifications to, by default, not notify at all. Instead, adding the `notifyCommand` in your `octofriend.json5` enables  a menu item called "Notifications":

<img width="854" height="566" alt="image" src="https://github.com/user-attachments/assets/e8505b92-1640-412a-a460-9f1f97990c2b" />

In the sub-menu there are three settings:

<img width="978" height="576" alt="image" src="https://github.com/user-attachments/assets/9d66fe88-ba12-4961-92ca-77f5fa5722e8" />

This allows granular control over how you want Octo to notify you. If you're running a mainly hands-off headless session in the background, you can set it to always notify you during the current session. And if you're in a fairly attentive state but want to occasionally multitask when Octo is taking a while, you can just set it to notify the next time it needs input. And if you really, always run it in the background headless, you can set it to always notify and it'll persist that to a flag in your config file.

Since the menu is super hotkey-ed, the "notify the next time" setting actually feels pretty good. You can kick off a long thing for Octo to do, hit ctrl-p n o, and then you're dropped back into Octo's main flow and can go alt-tab away and do whatever while Octo does its thing. Once it notifies you, and you switch back and give more focused feedback, it doesn't spam you with useless notifications until you're ready to kick off another long task when you can ctrl-p n o again.

I cleaned up the menu a little and changed some hotkeys to free up `n` for notifications, and fixed a menu-closing bug that appeared when you opened and closed the menu while Octo was doing stuff.
