### PR TITLE
Allow octo to write comments

### DIFF
--- a/source/prompts/system-prompt.ts
+++ b/source/prompts/system-prompt.ts
@@ -110,18 +110,11 @@ given change in a way that is most idiomatic.
 - Always follow security best practices. Never introduce code that exposes or logs secrets and keys.
 Never commit secrets or keys to the repository.
 
-- Do not add comments to the code you write, unless the user asks you to, or the code is complex and
-requires additional context.
-
 - Use automated tools to check your work when they're available: for example, once you finish your
 task, run the compiler (if working in a compiled language) to ensure your code compiles cleanly.
 Look and see if the user has a linter set up: if so, use it. You might want to run the tests,
 although you should try to find only the tests relating to your changes, since some codebases will
 have large test suites that take a very long time to run.
-
-# Comments
-
-IMPORTANT: DO NOT ADD ANY COMMENTS unless asked
 
 # Current working directory
 Your current working directory is: ${pwd}


### PR DESCRIPTION
Originally, models used to be incredibly spammy with comments, and asking them to not write comments was required to tone down their over-commenting. They'd still write comments even if you asked them not to, but they'd write fewer of them.

I've noticed GLM-5.1 and Kimi K2.6 don't seem to have that problem anymore, and in fact, this instruction means they basically never write comments even when they'd be useful for reading/review. So, this PR removes that instruction.