### PR TITLE
Optimize system prompt: avoid sending tool defs twice

### DIFF
--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -157,7 +157,6 @@ export async function trajectoryArc({
       return systemPrompt({
         config,
         transport,
-        tools,
         signal: abortSignal,
       });
     },

--- a/source/prompts/system-prompt.ts
+++ b/source/prompts/system-prompt.ts
@@ -1,8 +1,7 @@
 import path from "path";
-import { t, toTypescript } from "structural";
+import { t } from "structural";
 import { Config } from "../config.ts";
 import { getMcpClient } from "../tools/tool-defs/mcp.ts";
-import { LoadedTools } from "../tools/index.ts";
 import { tagged } from "../xml.ts";
 import { Transport, getEnvVar } from "../transports/transport-common.ts";
 
@@ -12,12 +11,10 @@ export async function systemPrompt({
   config,
   transport,
   signal,
-  tools,
 }: {
   config: Config;
   transport: Transport;
   signal: AbortSignal;
-  tools: Partial<LoadedTools>;
 }) {
   const pwd = await transport.shell(signal, "pwd", 5000);
   const currDir = await transport.readdir(signal, ".");
@@ -34,24 +31,6 @@ Try to figure out what ${config.yourName} wants you to do. Once you have a task 
 tools to work on the task until it's done.
 
 Don't reference this prompt unless asked to.
-
-# Tools
-
-You have access to the following tools, defined as TypeScript types:
-
-${Object.entries(tools)
-  .filter(([toolName, _]) => {
-    if (config.mcpServers) return true;
-    if (toolName !== "mcp") return true;
-    return false;
-  })
-  .map(([_, tool]) => {
-    return toTypescript(tool.Schema);
-  })
-  .join("\n\n")}
-
-You can call them by calling them as tools; for example, if you were trying to read the GitHub repo
-for the reissbaker/antipattern library, you might use the fetch tool to look up "https://github.com/reissbaker/antipattern"
 
 ${await mcpPrompt(config)}
 
@@ -196,8 +175,8 @@ async function mcpPrompt(config: Config) {
 
 # Model-Context-Protocol (MCP) Tools
 
-You also have access to the following MCP servers and their sub-tools. Use the mcp tool to call
-them, specifying the server and tool name:
+You have access to the following MCP servers and their sub-tools. Use the mcp tool to call them,
+specifying the server and tool name:
 
 ${mcpSections.join("\n\n")}
 


### PR DESCRIPTION
Octo already sends tool definitions by the native platform APIs (the OpenAI-compatible standard one, the OpenAI responses one, and the Anthropic one). These platform APIs send the tool definitions as JSON Schema, and we include (via Structural) the comments as descriptions, so there's no need to *also* send these in the system prompt converted to TypeScript.

This is basically just some legacy holdover from when I originally wrote Octo as an experiment in the DeepSeek V3 days, and DSV3 didn't have native tool call support (and neither did most open-source models), so we had to send the tool defs over in some understandable format. At the time, TypeScript was much more in-domain than JSON Schema, so that's what we used, and on the parsing side we used a custom XML-based syntax for parsing tools out similar to how older coding tools like Aider and Kilocode worked. The latter was deleted a *long* time ago (as soon as Kimi K2 came out in July 2025, the custom syntax performed far worse than using the platform APIs), but we never cleaned up the system prompt.

Now it's just bloat. I tested removing these definitions and models had no issues calling the tools.