### PR TITLE
Fix tool-failed UI message

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "build": "babel source -d dist/source --extensions \".ts,.tsx\" && tsc --emitDeclarationOnly",
+    "build": "rm -rf dist && babel source -d dist/source --extensions \".ts,.tsx\" && tsc --emitDeclarationOnly",
     "dev": "npm run build -- --watch",
     "exec": "npm run build && node ./dist/source/cli.js",
     "test": "vitest",

--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -308,7 +308,7 @@ export async function trajectoryArc({
             return abort([
               ...irs.slice(0, -1),
               {
-                role: "tool-error",
+                role: "tool-validation-error",
                 toolCall: toolCall,
                 error: e.message,
               },
@@ -357,7 +357,7 @@ export async function trajectoryArc({
       retryIrs = [
         ...retryIrs,
         {
-          role: "tool-error" as const,
+          role: "tool-validation-error" as const,
           toolCall: toolCall,
           error: e.message,
         },

--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -311,6 +311,7 @@ export async function trajectoryArc({
                 role: "tool-validation-error",
                 toolCall: toolCall,
                 error: e.message,
+                aborted: true,
               },
             ]);
           }

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -980,7 +980,7 @@ const MessageDisplayInner = React.memo(({ item }: { item: HistoryItem | Inflight
           <Text color="red">
             {displayLog({
               verbose: `Error: ${item.error}`,
-              info: "Tool validation failed...",
+              info: "Tool failed...",
             })}
           </Text>
         </Box>

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -973,6 +973,18 @@ const MessageDisplayInner = React.memo(({ item }: { item: HistoryItem | Inflight
       </Text>
     );
   }
+
+  if (item.type === "tool-validation-error") {
+    return (
+      <Text color="red">
+        {displayLog({
+          verbose: `Error: ${item.error}`,
+          info: "Tool call failed validation checks. Retrying...",
+        })}
+      </Text>
+    );
+  }
+
   if (item.type === "tool-failed") {
     return (
       <Box flexDirection="column">

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -975,11 +975,16 @@ const MessageDisplayInner = React.memo(({ item }: { item: HistoryItem | Inflight
   }
 
   if (item.type === "tool-validation-error") {
+    const message = (() => {
+      if (item.aborted) return "Tool call aborted.";
+      return "Tool call failed validation checks. Retrying...";
+    })();
+
     return (
       <Text color="red">
         {displayLog({
           verbose: `Error: ${item.error}`,
-          info: "Tool call failed validation checks. Retrying...",
+          info: message,
         })}
       </Text>
     );

--- a/source/compilers/anthropic.ts
+++ b/source/compilers/anthropic.ts
@@ -217,6 +217,20 @@ function modelMessageFromIr(
     };
   }
 
+  if (ir.role === "tool-validation-error") {
+    return {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: ir.toolCall.toolCallId,
+          is_error: true,
+          content: `Error: ${ir.error}`,
+        },
+      ],
+    };
+  }
+
   if (ir.role === "file-outdated") {
     return {
       role: "user",

--- a/source/compilers/responses.ts
+++ b/source/compilers/responses.ts
@@ -260,6 +260,23 @@ function modelMessageFromIr(
     };
   }
 
+  if (ir.role === "tool-validation-error") {
+    return {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: ir.toolCall.toolCallId,
+          toolName: ir.toolCall.call.original.name,
+          output: {
+            type: "text" as const,
+            value: `Error: ${ir.error}`,
+          },
+        },
+      ],
+    };
+  }
+
   if (ir.role === "file-outdated") {
     return {
       role: "tool",

--- a/source/compilers/standard.ts
+++ b/source/compilers/standard.ts
@@ -249,6 +249,14 @@ function llmFromIr(ir: LlmIR, seenPath: boolean, modalities?: MultimodalConfig):
     };
   }
 
+  if (ir.role === "tool-validation-error") {
+    return {
+      role: "tool",
+      tool_call_id: ir.toolCall.toolCallId,
+      content: "Error from tool call validation: " + tagged(TOOL_ERROR_TAG, {}, ir.error),
+    };
+  }
+
   if (ir.role === "tool-error") {
     return {
       role: "tool",

--- a/source/history.ts
+++ b/source/history.ts
@@ -22,6 +22,12 @@ export type ToolMalformedItem = SequenceIdTagged<{
   malformedRequest: MalformedRequest;
 }>;
 
+export type ToolValidationErrorItem = SequenceIdTagged<{
+  type: "tool-validation-error";
+  error: string;
+  toolCall: ToolCallRequest;
+}>;
+
 export type ToolFailedItem = SequenceIdTagged<{
   type: "tool-failed";
   error: string;
@@ -96,6 +102,7 @@ export type HistoryItem =
   | ToolOutputItem
   | ToolFailedItem
   | ToolMalformedItem
+  | ToolValidationErrorItem
   | ToolRejectItem
   | ToolSkipItem
   | FileOutdatedItem

--- a/source/history.ts
+++ b/source/history.ts
@@ -26,6 +26,7 @@ export type ToolValidationErrorItem = SequenceIdTagged<{
   type: "tool-validation-error";
   error: string;
   toolCall: ToolCallRequest;
+  aborted: boolean;
 }>;
 
 export type ToolFailedItem = SequenceIdTagged<{

--- a/source/ir/convert-history-ir.ts
+++ b/source/ir/convert-history-ir.ts
@@ -60,6 +60,7 @@ function singleOutputDecompile(output: TrajectoryOutputIR): HistoryItem[] {
         id: sequenceId(),
         toolCall: output.toolCall,
         error: output.error,
+        aborted: !!output.aborted,
       },
     ];
   }
@@ -210,6 +211,7 @@ function collapseToIR(prev: LlmIR | null, item: LoweredHistory): [LlmIR | null, 
         role: "tool-validation-error",
         toolCall: item.toolCall,
         error: item.error,
+        aborted: item.aborted,
       },
     ];
   }

--- a/source/ir/convert-history-ir.ts
+++ b/source/ir/convert-history-ir.ts
@@ -4,6 +4,7 @@ import {
   ToolCallItems,
   ToolOutputItem,
   ToolMalformedItem,
+  ToolValidationErrorItem,
   ToolFailedItem,
   ToolRejectItem,
   ToolSkipItem,
@@ -22,6 +23,7 @@ type LoweredHistory =
   | ToolCallItems
   | ToolOutputItem
   | ToolMalformedItem
+  | ToolValidationErrorItem
   | ToolFailedItem
   | ToolRejectItem
   | ToolSkipItem
@@ -50,16 +52,18 @@ function singleOutputDecompile(output: TrajectoryOutputIR): HistoryItem[] {
       },
     ];
   }
-  if (output.role === "tool-error") {
+
+  if (output.role === "tool-validation-error") {
     return [
       {
-        type: "tool-failed",
+        type: "tool-validation-error",
         id: sequenceId(),
-        error: output.error,
         toolCall: output.toolCall,
+        error: output.error,
       },
     ];
   }
+
   if (output.role === "file-outdated") {
     return [
       {
@@ -195,6 +199,17 @@ function collapseToIR(prev: LlmIR | null, item: LoweredHistory): [LlmIR | null, 
       {
         role: "tool-malformed",
         malformedRequest: item.malformedRequest,
+      },
+    ];
+  }
+
+  if (item.type === "tool-validation-error") {
+    return [
+      null,
+      {
+        role: "tool-validation-error",
+        toolCall: item.toolCall,
+        error: item.error,
       },
     ];
   }

--- a/source/ir/count-ir-tokens.ts
+++ b/source/ir/count-ir-tokens.ts
@@ -16,6 +16,8 @@ function getMessageText(msg: LlmIR): string {
       return msg.content;
     case "tool-error":
       return msg.error;
+    case "tool-validation-error":
+      return msg.error;
     case "tool-malformed":
       return (
         (msg.malformedRequest.call.original.arguments ?? "") + (msg.malformedRequest.error ?? "")

--- a/source/ir/llm-ir.ts
+++ b/source/ir/llm-ir.ts
@@ -89,6 +89,7 @@ export type ToolValidationErrorMessage = {
   role: "tool-validation-error";
   toolCall: ToolCallRequest;
   error: string;
+  aborted?: boolean;
 };
 
 export type ToolSkipMessage = {

--- a/source/ir/llm-ir.ts
+++ b/source/ir/llm-ir.ts
@@ -85,6 +85,12 @@ export type ToolErrorMessage = {
   error: string;
 };
 
+export type ToolValidationErrorMessage = {
+  role: "tool-validation-error";
+  toolCall: ToolCallRequest;
+  error: string;
+};
+
 export type ToolSkipMessage = {
   role: "tool-skip";
   toolCall: ToolCallRequest;
@@ -127,12 +133,12 @@ export type InputIR =
   | FileUnreadableMessage
   | CompactionCheckpoint;
 
-export type LlmIR = AssistantMessage | InputIR;
+export type LlmIR = AssistantMessage | ToolValidationErrorMessage | InputIR;
 
 export type TrajectoryOutputIR =
   | AssistantMessage
   | ToolMalformedMessage
-  | ToolErrorMessage
+  | ToolValidationErrorMessage
   | ToolSkipMessage
   | FileOutdatedMessage
   | FileUnreadableMessage


### PR DESCRIPTION
#184 accidentally introduced a UI bug for tool call failures: instead of saying the tool call failed, it says the tool call *validation* failed. For example, if Octo tries to run `npx tsc`, and it runs, but `tsc` notices a type error in the codebase, instead of saying the tool failed, instead it will say that tool call validation failed. But it didn't fail validation: it validated fine, and even ran the command. The command just exited with a non-zero status code, since there's a type error.

This is because we reuse the same `tool-error` IR for both validation failures, and for failures when the tool call itself has an error, e.g. a shell command exits with a non-zero status code. The UI can't tell the difference, since the IR is overloaded and could mean either scenario.

This PR adds a new IR to distinguish between validation errors and actual underlying tool run failures. Here's what it now renders as:

<img width="2432" height="1024" alt="image" src="https://github.com/user-attachments/assets/b270c3b5-c263-4861-b4e3-d49816ad2614" />

Arguably I could've reused the malformed tool IRs. However, the nice thing that #184 introduced with those is better type safety: they reference the original MalformedRequest from the assistant message. But for tool call *validation* failures, there is no MalformedRequest! The request was well-formed, but some validation code decided it was no good anyway. Adding the new IR type helps preserve the type safety niceties there while still allowing us to distinguish in the UI between different failure points for tool calls.