### PR TITLE
Fix multi-line input Static Rendering

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -55,6 +55,7 @@ import { InputHistory } from "./input-history/index.ts";
 import { MultimediaInput } from "./components/multimedia-input.tsx";
 import { ImageInfo } from "./utils/image-utils.ts";
 import { Markdown } from "./markdown/index.tsx";
+import { LINE_SPLIT_REGEX } from "./str.ts";
 import { countLines } from "./str.ts";
 import { VimModeIndicator } from "./components/vim-mode.tsx";
 import { ScrollView, IsScrollableContext } from "./components/scroll-view.tsx";
@@ -1038,6 +1039,8 @@ const MessageDisplayInner = React.memo(({ item }: { item: HistoryItem | Inflight
 
   const _: "user" = item.type;
 
+  const contentLines = item.content.split(LINE_SPLIT_REGEX);
+
   return (
     <Box flexDirection="column" marginY={1}>
       <Box flexDirection="row">
@@ -1051,7 +1054,13 @@ const MessageDisplayInner = React.memo(({ item }: { item: HistoryItem | Inflight
             </Text>
           </Box>
         )}
-        <Text>{item.content}</Text>
+        <Box flexDirection="column">
+          {contentLines.map((line, i) => (
+            <Box key={i}>
+              <Text>{line}</Text>
+            </Box>
+          ))}
+        </Box>
       </Box>
     </Box>
   );

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -7,6 +7,7 @@ import { wrapTextWithMapping } from "../text-wrap.ts";
 import stringWidth from "string-width";
 import { ImageInfo, parseImagePaths } from "../utils/image-utils.ts";
 import { MultimodalConfig } from "../providers.ts";
+import { LINE_SPLIT_REGEX } from "../str.ts";
 
 function getImageBadgeText(index: number): string {
   return `⟦ 📎 Image Attachment #${index + 1} ⟧`;
@@ -54,8 +55,6 @@ function computeImageBadgeLayout(imageCount: number, isLoading: boolean, contain
 
   return { badgeRows, remainingWidthForText };
 }
-
-export const LINE_SPLIT_REGEX = /\r\n|\r|\n/;
 
 type Props = {
   readonly placeholder?: string;

--- a/source/str.ts
+++ b/source/str.ts
@@ -25,3 +25,5 @@ export function extractTrim(line: string) {
 
   return [spaceBefore, line.trim(), spaceAfter];
 }
+
+export const LINE_SPLIT_REGEX = /\r\n|\r|\n/;

--- a/source/text-wrap.ts
+++ b/source/text-wrap.ts
@@ -1,5 +1,5 @@
 import stringWidth from "string-width";
-import { LINE_SPLIT_REGEX } from "./components/text-input.tsx";
+import { LINE_SPLIT_REGEX } from "./str.ts";
 
 export type WrapResult = {
   wrapped: string;


### PR DESCRIPTION
### Before fix:
| Input | Static Content |
|----------|----------|
| ![Screenshot 2026-05-04 at 3 56 10 PM](https://github.com/user-attachments/assets/bf4bb03d-84a9-4e9e-b2b7-173d7962fbda) | ![Screenshot 2026-05-04 at 3 56 15 PM](https://github.com/user-attachments/assets/934d84de-4a1b-4975-89bf-27e3cadbc85f) |

### After fix:
| Input | Static Content |
|----------|----------|
| ![Screenshot 2026-05-04 at 4 26 49 PM](https://github.com/user-attachments/assets/b9f30faf-868b-43d6-9f8b-2cd019a0de4d) | ![Screenshot 2026-05-04 at 4 26 54 PM](https://github.com/user-attachments/assets/b26a694b-e008-4faa-a8e3-1d4a62ab25eb) |

Pasting content with several newlines in them would lead to weird character removal behavior and spacing issues. By splitting on the same regex we use for the input, the Static Content afterwards looks good! 