### PR TITLE
Simplify compilers

### DIFF
--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -186,13 +186,13 @@ export async function trajectoryArc({
       irs: maybeBufferedMessage(),
       reason: {
         type: "request-error",
-        requestError: result.requestError,
-        curl: result.curl,
+        requestError: result.error.requestError,
+        curl: result.error.curl,
       },
     };
   }
 
-  let assistantMessage = result.output;
+  let assistantMessage = result.data.output;
   irs = [...irs, assistantMessage];
 
   // Retry malformed tool calls

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -295,7 +295,7 @@ bench
       if (!result.success) {
         return {
           success: false,
-          error: result.requestError,
+          error: result.error.requestError,
         };
       }
 
@@ -311,7 +311,7 @@ bench
       const ttft = (firstToken as Date).getTime() - start.getTime();
       const tokenElapsed = end.getTime() - (firstToken as Date).getTime();
 
-      const tokens = result.output.outputTokens;
+      const tokens = result.data.output.outputTokens;
 
       const interTokenLatencies: number[] = [];
       for (let i = 1; i < tokenTimestamps.length; i++) {
@@ -487,8 +487,8 @@ cli
       transport,
     });
     if (!result.success) {
-      console.error(result.requestError);
-      console.error(`cURL: ${result.curl}`);
+      console.error(result.error.requestError);
+      console.error(`cURL: ${result.error.curl}`);
       process.exit(1);
     }
 

--- a/source/compilers/anthropic.ts
+++ b/source/compilers/anthropic.ts
@@ -1,10 +1,10 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { t, toJSONSchema } from "structural";
 import { Compiler } from "./compiler-interface.ts";
+import type { FileOptimizedLlmIR } from "./optimize-files.ts";
 import { sumAssistantTokens } from "../ir/count-ir-tokens.ts";
 import {
   AssistantMessage,
-  LlmIR,
   ToolCallRequest,
   MalformedRequest,
   AnthropicAssistantData,
@@ -17,7 +17,7 @@ import { errorToString } from "../errors.ts";
 import { compactionCompilerExplanation } from "./autocompact.ts";
 import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
-import { canDisplayImage, MultimodalConfig } from "../providers.ts";
+import type { MultimodalConfig } from "../providers.ts";
 import { Transport } from "../transports/transport-common.ts";
 
 const ThinkingBlockSchema = t.subtype({
@@ -27,33 +27,20 @@ const ThinkingBlockSchema = t.subtype({
 });
 
 function toModelMessage(
-  messages: LlmIR[],
+  messages: FileOptimizedLlmIR[],
   modalities?: MultimodalConfig,
 ): Array<Anthropic.MessageParam> {
   const output: Anthropic.MessageParam[] = [];
 
-  const irs = [...messages];
-  irs.reverse();
-  const seenPaths = new Set<string>();
-
-  for (const ir of irs) {
-    if (ir.role === "file-read") {
-      let seen = seenPaths.has(ir.path);
-      seenPaths.add(ir.path);
-      output.push(modelMessageFromIr(ir, seen, modalities));
-    } else {
-      output.push(modelMessageFromIr(ir, false, modalities));
-    }
+  for (const ir of messages) {
+    output.push(modelMessageFromIr(ir, modalities));
   }
-
-  output.reverse();
 
   return output;
 }
 
 function modelMessageFromIr(
-  ir: LlmIR,
-  seenPath: boolean,
+  ir: FileOptimizedLlmIR,
   modalities?: MultimodalConfig,
 ): Anthropic.MessageParam {
   if (ir.role === "assistant") {
@@ -105,57 +92,14 @@ function modelMessageFromIr(
     };
   }
 
-  if (ir.role === "file-read") {
-    const imageCheck = ir.image ? canDisplayImage(modalities, ir.image) : null;
-    if (ir.image && imageCheck?.ok) {
-      return {
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            tool_use_id: ir.toolCall.toolCallId,
-            content: [
-              { type: "text", text: ir.content },
-              {
-                type: "image",
-                source: {
-                  type: "base64",
-                  media_type: ir.image.mimeType,
-                  data: ir.image.base64Data,
-                },
-              },
-            ],
-          },
-        ],
-      };
-    }
+  if (ir.role === "tool-output") {
     return {
       role: "user",
       content: [
         {
           type: "tool_result",
           tool_use_id: ir.toolCall.toolCallId,
-          content: irPrompts.fileRead(ir.content, seenPath, imageCheck),
-        },
-      ],
-    };
-  }
-
-  if (ir.role === "tool-output" || ir.role === "file-mutate") {
-    let content: string;
-    if (ir.role === "file-mutate") {
-      content = irPrompts.fileMutation(ir.path);
-    } else {
-      content = ir.content;
-    }
-
-    return {
-      role: "user",
-      content: [
-        {
-          type: "tool_result",
-          tool_use_id: ir.toolCall.toolCallId,
-          content,
+          content: ir.content,
         },
       ],
     };
@@ -231,20 +175,6 @@ function modelMessageFromIr(
     };
   }
 
-  if (ir.role === "file-outdated") {
-    return {
-      role: "user",
-      content: [
-        {
-          type: "tool_result",
-          tool_use_id: ir.toolCall.toolCallId,
-          is_error: true,
-          content: ir.error,
-        },
-      ],
-    };
-  }
-
   if (ir.role === "compaction-checkpoint") {
     return {
       role: "user",
@@ -252,19 +182,8 @@ function modelMessageFromIr(
     };
   }
 
-  // file-unreadable case
-  const _: "file-unreadable" = ir.role;
-  return {
-    role: "user",
-    content: [
-      {
-        type: "tool_result",
-        tool_use_id: ir.toolCall.toolCallId,
-        is_error: true,
-        content: ir.error,
-      },
-    ],
-  };
+  const _: never = ir;
+  return _;
 }
 
 function generateCurlFrom(params: {

--- a/source/compilers/anthropic.ts
+++ b/source/compilers/anthropic.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { t, toJSONSchema } from "structural";
 import { Compiler } from "./compiler-interface.ts";
 import type { FileOptimizedLlmIR } from "./optimize-files.ts";
+import { parseToolCall } from "./parse-tool-call.ts";
 import { sumAssistantTokens } from "../ir/count-ir-tokens.ts";
 import {
   AssistantMessage,
@@ -9,16 +10,11 @@ import {
   MalformedRequest,
   AnthropicAssistantData,
 } from "../ir/llm-ir.ts";
-import { ToolDef } from "../tools/common.ts";
-import * as logger from "../logger.ts";
-import { tryexpr } from "../tryexpr.ts";
 import { trackTokens } from "../token-tracker.ts";
 import { errorToString } from "../errors.ts";
 import { compactionCompilerExplanation } from "./autocompact.ts";
-import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
 import type { MultimodalConfig } from "../providers.ts";
-import { Transport } from "../transports/transport-common.ts";
 
 const ThinkingBlockSchema = t.subtype({
   type: t.value("thinking"),
@@ -492,13 +488,13 @@ export const runAnthropicAgent: Compiler = async ({
         toolName: inProgressTool.name,
         args: inProgressTool.partialJson,
       };
-      const parseResult = await parseTool(
-        chatToolCall,
+      const parseResult = await parseToolCall({
+        toolCall: chatToolCall,
         toolDefs,
         autofixJson,
         abortSignal,
         transport,
-      );
+      });
 
       if (parseResult.status === "error") {
         toolCalls.push({
@@ -529,94 +525,3 @@ export const runAnthropicAgent: Compiler = async ({
     };
   }
 };
-
-type ParseToolResult =
-  | {
-      status: "success";
-      tool: ToolCallRequest;
-    }
-  | {
-      status: "error";
-      message: string;
-    };
-
-async function parseTool(
-  toolCall: { toolCallId: string; toolName: string; args: any },
-  toolDefs: Record<string, ToolDef<any, any, any>>,
-  autofixJson: (badJson: string, signal: AbortSignal) => Promise<JsonFixResponse>,
-  abortSignal: AbortSignal,
-  transport: Transport,
-): Promise<ParseToolResult> {
-  const name = toolCall.toolName;
-  const toolDef = toolDefs[name];
-
-  if (!toolDef) {
-    return {
-      status: "error",
-      message: `
-Unknown tool ${name}. The only valid tool names are:
-
-- ${Object.keys(toolDefs).join("\n- ")}
-
-Please try calling a valid tool.
-      `.trim(),
-    };
-  }
-
-  const toolSchema = toolDef.Schema;
-  let args = toolCall.args;
-
-  // If args is a string, try to parse as JSON
-  if (typeof args === "string") {
-    let [err, parsedArgs] = tryexpr(() => {
-      return JSON.parse(args);
-    });
-
-    if (err) {
-      const fixPromise = autofixJson(args, abortSignal);
-      const fixResponse = await fixPromise;
-      if (!fixResponse.success) {
-        return {
-          status: "error",
-          message: "Syntax error: invalid JSON in tool call arguments",
-        };
-      }
-      args = fixResponse.fixed;
-    } else {
-      args = parsedArgs;
-    }
-  }
-
-  try {
-    const sliced = toolSchema.slice({
-      name: toolCall.toolName,
-      arguments: args,
-    });
-    const parsed = await toolDef.parse(abortSignal, transport, sliced);
-
-    if (parsed.success) {
-      return {
-        status: "success",
-        tool: {
-          type: "tool-request",
-          call: parsed.data,
-          toolCallId: toolCall.toolCallId,
-        },
-      };
-    }
-    return {
-      status: "error",
-      message: parsed.error,
-    };
-  } catch (e: unknown) {
-    logger.error("verbose", e);
-    logger.error("verbose", toolCall);
-    const error = e instanceof Error ? e.message : "Invalid arguments in tool call";
-    return {
-      status: "error",
-      message: `
-Failed to parse tool call: ${error}. Make sure your arguments are valid and match the expected format.
-      `.trim(),
-    };
-  }
-}

--- a/source/compilers/anthropic.ts
+++ b/source/compilers/anthropic.ts
@@ -11,6 +11,7 @@ import {
   AnthropicAssistantData,
 } from "../ir/llm-ir.ts";
 import { trackTokens } from "../token-tracker.ts";
+import { result } from "../result.ts";
 import { errorToString } from "../errors.ts";
 import { compactionCompilerExplanation } from "./autocompact.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
@@ -286,7 +287,7 @@ export const runAnthropicAgent: Compiler = async ({
 
   try {
     const system = sysPrompt == null ? {} : { system: sysPrompt };
-    const result = await client.messages.create({
+    const stream = await client.messages.create({
       ...system,
       model: model.model,
       messages,
@@ -329,7 +330,7 @@ export const runAnthropicAgent: Compiler = async ({
     >();
 
     // Handle streaming chunks
-    for await (const chunk of result) {
+    for await (const chunk of stream) {
       if (abortSignal.aborted) break;
 
       switch (chunk.type) {
@@ -467,12 +468,12 @@ export const runAnthropicAgent: Compiler = async ({
     if (abortSignal.aborted) {
       // Success is only false when the request fails,
       // therefore success value is true here
-      return { success: true, output: assistantMessage, curl };
+      return result.ok({ output: assistantMessage, curl });
     }
 
     // No tools? Return
     if (inProgressTools.size === 0) {
-      return { success: true, output: assistantMessage, curl };
+      return result.ok({ output: assistantMessage, curl });
     }
 
     // Sort tool calls by their content block index to preserve ordering
@@ -516,12 +517,11 @@ export const runAnthropicAgent: Compiler = async ({
 
     if (toolCalls.length > 0) assistantMessage.toolCalls = toolCalls;
 
-    return { success: true, output: assistantMessage, curl };
+    return result.ok({ output: assistantMessage, curl });
   } catch (e) {
-    return {
-      success: false,
+    return result.err({
       requestError: errorToString(e),
       curl,
-    };
+    });
   }
 };

--- a/source/compilers/autocompact.ts
+++ b/source/compilers/autocompact.ts
@@ -95,7 +95,7 @@ export async function generateCompactionSummary({
   if (abortSignal.aborted) return null;
 
   if (!result.success) {
-    throw new CompactionRequestError(result.requestError, result.curl);
+    throw new CompactionRequestError(result.error.requestError, result.error.curl);
   }
 
   const summary = processCompactedHistory(result);
@@ -113,7 +113,7 @@ export function processCompactedHistory(
   if (!compactSummaryAgentResult.success) {
     return;
   }
-  const assistantMessage = compactSummaryAgentResult.output;
+  const assistantMessage = compactSummaryAgentResult.data.output;
 
   if (assistantMessage.content) {
     return assistantMessage.content;

--- a/source/compilers/compiler-interface.ts
+++ b/source/compilers/compiler-interface.ts
@@ -2,15 +2,15 @@ import { ModelConfig } from "../config.ts";
 import { AgentResult } from "../ir/llm-ir.ts";
 import { QuotaData } from "../utils/quota.ts";
 import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
-import { LlmIR } from "../ir/llm-ir.ts";
 import { LoadedTools } from "../tools/index.ts";
 import { Transport } from "../transports/transport-common.ts";
+import type { FileOptimizedLlmIR } from "./optimize-files.ts";
 
 export type Compiler = (params: {
   systemPrompt?: () => Promise<string>;
   model: ModelConfig;
   apiKey: string;
-  irs: LlmIR[];
+  irs: FileOptimizedLlmIR[];
   onTokens: (t: string, type: "reasoning" | "content" | "tool") => any;
   onQuotaUpdated?: (quota: QuotaData) => void;
   abortSignal: AbortSignal;

--- a/source/compilers/optimize-files.test.ts
+++ b/source/compilers/optimize-files.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { LlmIR, ToolCallRequest } from "../ir/llm-ir.ts";
+import { ImageInfo } from "../utils/image-utils.ts";
+import { optimizeFiles } from "./optimize-files.ts";
+
+function toolCall(id: string): ToolCallRequest {
+  return {
+    type: "tool-request",
+    toolCallId: id,
+    call: {
+      original: {
+        name: "read",
+        arguments: {},
+      },
+    },
+  } as ToolCallRequest;
+}
+
+describe("optimizeFiles", () => {
+  it("keeps the newest read for a path and strips older reads", () => {
+    const messages: LlmIR[] = [
+      {
+        role: "file-read",
+        path: "/tmp/a.txt",
+        content: "old contents",
+        toolCall: toolCall("old"),
+      },
+      {
+        role: "file-read",
+        path: "/tmp/a.txt",
+        content: "new contents",
+        toolCall: toolCall("new"),
+      },
+    ];
+
+    expect(optimizeFiles(messages)).toEqual([
+      {
+        role: "tool-output",
+        toolCall: toolCall("old"),
+        content: "File was successfully read.",
+      },
+      {
+        role: "tool-output",
+        toolCall: toolCall("new"),
+        content: "new contents",
+      },
+    ]);
+  });
+
+  it("turns displayable image reads into user messages with images", () => {
+    const image: ImageInfo = {
+      mimeType: "image/png",
+      base64Data: "abc",
+      dataUrl: "data:image/png;base64,abc",
+      filePath: "/tmp/a.png",
+      sizeBytes: 3,
+    };
+
+    expect(
+      optimizeFiles(
+        [
+          {
+            role: "file-read",
+            path: "/tmp/a.png",
+            content: "image contents",
+            image,
+            toolCall: toolCall("image-read"),
+          },
+        ],
+        {
+          image: {
+            enabled: true,
+            acceptedMimeTypes: ["image/png"],
+            maxSizeMB: 1,
+          },
+        },
+      ),
+    ).toEqual([
+      {
+        role: "user",
+        content: "[Tool result for call image-read]: image contents",
+        images: [image],
+      },
+    ]);
+  });
+
+  it("rewrites file mutation and file errors to base tool messages", () => {
+    expect(
+      optimizeFiles([
+        {
+          role: "file-mutate",
+          path: "/tmp/a.txt",
+          content: "raw mutate output",
+          toolCall: toolCall("mutate"),
+        },
+        {
+          role: "file-unreadable",
+          path: "/tmp/b.txt",
+          error: "could not read file",
+          toolCall: toolCall("unreadable"),
+        },
+      ]),
+    ).toEqual([
+      {
+        role: "tool-output",
+        toolCall: toolCall("mutate"),
+        content: "/tmp/a.txt was updated successfully.",
+      },
+      {
+        role: "tool-error",
+        toolCall: toolCall("unreadable"),
+        error: "could not read file",
+      },
+    ]);
+  });
+});

--- a/source/compilers/optimize-files.ts
+++ b/source/compilers/optimize-files.ts
@@ -1,0 +1,72 @@
+import type {
+  FileMutateMethod,
+  FileOutdatedMessage,
+  FileReadMessage,
+  FileUnreadableMessage,
+  LlmIR,
+} from "../ir/llm-ir.ts";
+import * as irPrompts from "../prompts/ir-prompts.ts";
+import { canDisplayImage } from "../providers.ts";
+import type { MultimodalConfig } from "../providers.ts";
+
+type FileIR = FileReadMessage | FileMutateMethod | FileOutdatedMessage | FileUnreadableMessage;
+
+export type FileOptimizedLlmIR = Exclude<LlmIR, FileIR>;
+
+export function optimizeFiles(
+  messages: LlmIR[],
+  modalities?: MultimodalConfig,
+): FileOptimizedLlmIR[] {
+  const output: FileOptimizedLlmIR[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const ir of [...messages].reverse()) {
+    output.push(optimizeFileIR(ir, seenPaths, modalities));
+  }
+
+  return output.reverse();
+}
+
+function optimizeFileIR(
+  ir: LlmIR,
+  seenPaths: Set<string>,
+  modalities?: MultimodalConfig,
+): FileOptimizedLlmIR {
+  if (ir.role === "file-read") {
+    const seenPath = seenPaths.has(ir.path);
+    seenPaths.add(ir.path);
+
+    const imageCheck = ir.image ? canDisplayImage(modalities, ir.image) : null;
+    if (ir.image && imageCheck?.ok) {
+      return {
+        role: "user",
+        content: `[Tool result for call ${ir.toolCall.toolCallId}]: ${ir.content}`,
+        images: [ir.image],
+      };
+    }
+
+    return {
+      role: "tool-output",
+      toolCall: ir.toolCall,
+      content: irPrompts.fileRead(ir.content, seenPath, imageCheck),
+    };
+  }
+
+  if (ir.role === "file-mutate") {
+    return {
+      role: "tool-output",
+      toolCall: ir.toolCall,
+      content: irPrompts.fileMutation(ir.path),
+    };
+  }
+
+  if (ir.role === "file-outdated" || ir.role === "file-unreadable") {
+    return {
+      role: "tool-error",
+      toolCall: ir.toolCall,
+      error: ir.error,
+    };
+  }
+
+  return ir;
+}

--- a/source/compilers/parse-tool-call.test.ts
+++ b/source/compilers/parse-tool-call.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { t } from "structural";
+import { result } from "../result.ts";
+import { ToolDef } from "../tools/common.ts";
+import { parseToolCall } from "./parse-tool-call.ts";
+
+const ArgumentsSchema = t.subtype({
+  query: t.str,
+});
+
+const Schema = t.subtype({
+  name: t.value("search"),
+  arguments: ArgumentsSchema,
+});
+
+function searchTool(): ToolDef<"search", { query: string }, { query: string }> {
+  return {
+    ArgumentsSchema,
+    ParsedSchema: ArgumentsSchema,
+    Schema,
+    parse: async (_signal, _transport, original) => result.ok({ original, parsed: original }),
+    validate: async () => null,
+    run: async () => ({ content: "" }),
+  };
+}
+
+describe("parseToolCall", () => {
+  it("parses JSON arguments and validates them against the tool schema", async () => {
+    const parsed = await parseToolCall({
+      toolCall: {
+        toolCallId: "call-1",
+        toolName: "search",
+        args: JSON.stringify({ query: "needle" }),
+      },
+      toolDefs: { search: searchTool() },
+      autofixJson: vi.fn(),
+      abortSignal: new AbortController().signal,
+      transport: {} as any,
+    });
+
+    expect(parsed).toEqual({
+      status: "success",
+      tool: {
+        type: "tool-request",
+        toolCallId: "call-1",
+        call: {
+          original: {
+            name: "search",
+            arguments: { query: "needle" },
+          },
+          parsed: {
+            name: "search",
+            arguments: { query: "needle" },
+          },
+        },
+      },
+    });
+  });
+
+  it("uses autofixed JSON when raw arguments are invalid", async () => {
+    const parsed = await parseToolCall({
+      toolCall: {
+        toolCallId: "call-1",
+        toolName: "search",
+        args: "{query:",
+      },
+      toolDefs: { search: searchTool() },
+      autofixJson: vi.fn(async () => ({ success: true, fixed: { query: "fixed" } })),
+      abortSignal: new AbortController().signal,
+      transport: {} as any,
+    });
+
+    expect(parsed.status).toBe("success");
+    if (parsed.status === "success") {
+      expect(parsed.tool.call.original.arguments).toEqual({ query: "fixed" });
+    }
+  });
+
+  it("reports unknown tools before parsing arguments", async () => {
+    const parsed = await parseToolCall({
+      toolCall: {
+        toolCallId: "call-1",
+        toolName: "missing",
+        args: "{not json",
+      },
+      toolDefs: { search: searchTool() },
+      autofixJson: vi.fn(),
+      abortSignal: new AbortController().signal,
+      transport: {} as any,
+    });
+
+    expect(parsed.status).toBe("error");
+    if (parsed.status === "error") {
+      expect(parsed.message).toContain("Unknown tool missing");
+    }
+  });
+});

--- a/source/compilers/parse-tool-call.ts
+++ b/source/compilers/parse-tool-call.ts
@@ -1,0 +1,131 @@
+import { toTypescript } from "structural";
+import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
+import { ToolCallRequest } from "../ir/llm-ir.ts";
+import { ToolDef } from "../tools/common.ts";
+import { Transport } from "../transports/transport-common.ts";
+import * as logger from "../logger.ts";
+import { tryexpr } from "../tryexpr.ts";
+
+export type ParsedToolCallResult =
+  | {
+      status: "success";
+      tool: ToolCallRequest;
+    }
+  | {
+      status: "error";
+      message: string;
+    };
+
+export type ToolCallToParse = {
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+};
+
+export async function parseToolCall({
+  toolCall,
+  toolDefs,
+  autofixJson,
+  abortSignal,
+  transport,
+}: {
+  toolCall: ToolCallToParse;
+  toolDefs: Partial<Record<string, ToolDef<any, any, any>>>;
+  autofixJson: (badJson: string, signal: AbortSignal) => Promise<JsonFixResponse>;
+  abortSignal: AbortSignal;
+  transport: Transport;
+}): Promise<ParsedToolCallResult> {
+  const name = toolCall.toolName;
+  const toolDef = toolDefs[name];
+
+  if (!toolDef) {
+    return {
+      status: "error",
+      message: `
+Unknown tool ${name}. The only valid tool names are:
+
+- ${Object.keys(toolDefs).join("\n- ")}
+
+Please try calling a valid tool.
+      `.trim(),
+    };
+  }
+
+  const toolSchema = toolDef.Schema;
+  let args = toolCall.args;
+
+  if (typeof args === "string") {
+    const parsedArgs = await parseJsonArguments(args, autofixJson, abortSignal);
+    if (!parsedArgs.success) return parsedArgs;
+    args = parsedArgs.args;
+  }
+
+  try {
+    const sliced = toolSchema.slice({
+      name,
+      arguments: args,
+    });
+    const parsed = await toolDef.parse(abortSignal, transport, sliced);
+
+    if (parsed.success) {
+      return {
+        status: "success",
+        tool: {
+          type: "tool-request",
+          call: parsed.data,
+          toolCallId: toolCall.toolCallId,
+        },
+      };
+    }
+    return {
+      status: "error",
+      message: parsed.error,
+    };
+  } catch (e: unknown) {
+    logger.error("verbose", e);
+    logger.error("verbose", toolCall);
+    const error = e instanceof Error ? e.message : "Invalid arguments in tool call";
+    return {
+      status: "error",
+      message: `
+Failed to parse tool call: ${error}. Make sure your arguments are valid and match the expected format.
+
+Your arguments were:
+${JSON.stringify(args)}
+
+Expected:
+${toTypescript(toolSchema)}
+      `.trim(),
+    };
+  }
+}
+
+async function parseJsonArguments(
+  rawArgs: string,
+  autofixJson: (badJson: string, signal: AbortSignal) => Promise<JsonFixResponse>,
+  abortSignal: AbortSignal,
+): Promise<
+  { success: true; args: unknown } | { success: false; status: "error"; message: string }
+> {
+  const source = rawArgs === "" ? "{}" : rawArgs;
+  let [err, args] = tryexpr(() => JSON.parse(source));
+
+  if (err) {
+    const fixResponse = await autofixJson(source, abortSignal);
+    if (!fixResponse.success) {
+      return {
+        success: false,
+        status: "error",
+        message: "Syntax error: invalid JSON in tool call arguments",
+      };
+    }
+    args = fixResponse.fixed;
+  }
+
+  if (typeof args === "string") {
+    const [doubleEncodedErr, doubleDecodedArgs] = tryexpr(() => JSON.parse(args));
+    if (!doubleEncodedErr) args = doubleDecodedArgs;
+  }
+
+  return { success: true, args };
+}

--- a/source/compilers/responses.ts
+++ b/source/compilers/responses.ts
@@ -3,19 +3,15 @@ import { streamText, tool, ModelMessage, jsonSchema } from "ai";
 import { t, toJSONSchema } from "structural";
 import { Compiler } from "./compiler-interface.ts";
 import type { FileOptimizedLlmIR } from "./optimize-files.ts";
+import { parseToolCall } from "./parse-tool-call.ts";
 import { ToolCallRequest, MalformedRequest, AssistantMessage } from "../ir/llm-ir.ts";
-import { ToolDef } from "../tools/common.ts";
-import { tryexpr } from "../tryexpr.ts";
 import { trackTokens } from "../token-tracker.ts";
 import { sumAssistantTokens } from "../ir/count-ir-tokens.ts";
-import * as logger from "../logger.ts";
 import { errorToString } from "../errors.ts";
 import { compactionCompilerExplanation } from "./autocompact.ts";
-import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
 import type { MultimodalConfig } from "../providers.ts";
 import { APP_METADATA } from "../config.ts";
-import { Transport } from "../transports/transport-common.ts";
 
 async function toModelMessage(
   messages: FileOptimizedLlmIR[],
@@ -445,13 +441,13 @@ export const runResponsesAgent: Compiler = async ({
         toolName: toolCall.toolName,
         args: toolCall.input,
       };
-      const parseResult = await parseTool(
-        chatToolCall,
+      const parseResult = await parseToolCall({
+        toolCall: chatToolCall,
         toolDefs,
         autofixJson,
         abortSignal,
         transport,
-      );
+      });
 
       if (parseResult.status === "error") {
         parsedToolCalls.push({
@@ -482,94 +478,3 @@ export const runResponsesAgent: Compiler = async ({
     };
   }
 };
-
-type ParseToolResult =
-  | {
-      status: "success";
-      tool: ToolCallRequest;
-    }
-  | {
-      status: "error";
-      message: string;
-    };
-
-async function parseTool(
-  toolCall: { toolCallId: string; toolName: string; args: any },
-  toolDefs: Record<string, ToolDef<any, any, any>>,
-  autofixJson: (badJson: string, signal: AbortSignal) => Promise<JsonFixResponse>,
-  abortSignal: AbortSignal,
-  transport: Transport,
-): Promise<ParseToolResult> {
-  const name = toolCall.toolName;
-  const toolDef = toolDefs[name];
-
-  if (!toolDef) {
-    return {
-      status: "error",
-      message: `
-Unknown tool ${name}. The only valid tool names are:
-
-- ${Object.keys(toolDefs).join("\n- ")}
-
-Please try calling a valid tool.
-      `.trim(),
-    };
-  }
-
-  const toolSchema = toolDef.Schema;
-  let args = toolCall.args;
-
-  // If args is a string, try to parse as JSON
-  if (typeof args === "string") {
-    let [err, parsedArgs] = tryexpr(() => {
-      return JSON.parse(args);
-    });
-
-    if (err) {
-      const fixPromise = autofixJson(args, abortSignal);
-      const fixResponse = await fixPromise;
-      if (!fixResponse.success) {
-        return {
-          status: "error",
-          message: "Syntax error: invalid JSON in tool call arguments",
-        };
-      }
-      args = fixResponse.fixed;
-    } else {
-      args = parsedArgs;
-    }
-  }
-
-  try {
-    const sliced = toolSchema.slice({
-      name: toolCall.toolName,
-      arguments: args,
-    });
-    const parsed = await toolDef.parse(abortSignal, transport, sliced);
-
-    if (parsed.success) {
-      return {
-        status: "success",
-        tool: {
-          type: "tool-request",
-          call: parsed.data,
-          toolCallId: toolCall.toolCallId,
-        },
-      };
-    }
-    return {
-      status: "error",
-      message: parsed.error,
-    };
-  } catch (e: unknown) {
-    logger.error("verbose", e);
-    logger.error("verbose", toolCall);
-    const error = e instanceof Error ? e.message : "Invalid arguments in tool call";
-    return {
-      status: "error",
-      message: `
-Failed to parse tool call: ${error}. Make sure your arguments are valid and match the expected format.
-      `.trim(),
-    };
-  }
-}

--- a/source/compilers/responses.ts
+++ b/source/compilers/responses.ts
@@ -2,7 +2,8 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { streamText, tool, ModelMessage, jsonSchema } from "ai";
 import { t, toJSONSchema } from "structural";
 import { Compiler } from "./compiler-interface.ts";
-import { LlmIR, ToolCallRequest, MalformedRequest, AssistantMessage } from "../ir/llm-ir.ts";
+import type { FileOptimizedLlmIR } from "./optimize-files.ts";
+import { ToolCallRequest, MalformedRequest, AssistantMessage } from "../ir/llm-ir.ts";
 import { ToolDef } from "../tools/common.ts";
 import { tryexpr } from "../tryexpr.ts";
 import { trackTokens } from "../token-tracker.ts";
@@ -12,32 +13,20 @@ import { errorToString } from "../errors.ts";
 import { compactionCompilerExplanation } from "./autocompact.ts";
 import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
-import { canDisplayImage, MultimodalConfig } from "../providers.ts";
+import type { MultimodalConfig } from "../providers.ts";
 import { APP_METADATA } from "../config.ts";
 import { Transport } from "../transports/transport-common.ts";
 
 async function toModelMessage(
-  messages: LlmIR[],
+  messages: FileOptimizedLlmIR[],
   systemPrompt?: () => Promise<string>,
   modalities?: MultimodalConfig,
 ): Promise<Array<ModelMessage>> {
   const output: ModelMessage[] = [];
 
-  const irs = [...messages];
-  irs.reverse();
-  const seenPaths = new Set<string>();
-
-  for (const ir of irs) {
-    if (ir.role === "file-read") {
-      let seen = seenPaths.has(ir.path);
-      seenPaths.add(ir.path);
-      output.push(modelMessageFromIr(ir, seen, modalities));
-    } else {
-      output.push(modelMessageFromIr(ir, false, modalities));
-    }
+  for (const ir of messages) {
+    output.push(modelMessageFromIr(ir, modalities));
   }
-
-  output.reverse();
 
   if (systemPrompt) {
     const prompt = await systemPrompt();
@@ -51,11 +40,7 @@ async function toModelMessage(
   return output;
 }
 
-function modelMessageFromIr(
-  ir: LlmIR,
-  seenPath: boolean,
-  modalities?: MultimodalConfig,
-): ModelMessage {
+function modelMessageFromIr(ir: FileOptimizedLlmIR, modalities?: MultimodalConfig): ModelMessage {
   if (ir.role === "assistant") {
     if (ir.reasoningContent || ir.openai) {
       let openai = {};
@@ -138,20 +123,7 @@ function modelMessageFromIr(
     };
   }
 
-  if (ir.role === "file-read") {
-    const imageCheck = ir.image ? canDisplayImage(modalities, ir.image) : null;
-    if (ir.image && imageCheck?.ok) {
-      return {
-        role: "user",
-        content: [
-          { type: "text", text: `[Tool result for call ${ir.toolCall.toolCallId}]: ${ir.content}` },
-          {
-            type: "image" as const,
-            image: ir.image.dataUrl,
-          },
-        ],
-      };
-    }
+  if (ir.role === "tool-output") {
     return {
       role: "tool",
       content: [
@@ -161,31 +133,7 @@ function modelMessageFromIr(
           toolCallId: ir.toolCall.toolCallId,
           output: {
             type: "text" as const,
-            value: irPrompts.fileRead(ir.content, seenPath, imageCheck),
-          },
-        },
-      ],
-    };
-  }
-
-  if (ir.role === "tool-output" || ir.role === "file-mutate") {
-    let content: string;
-    if (ir.role === "file-mutate") {
-      content = irPrompts.fileMutation(ir.path);
-    } else {
-      content = ir.content;
-    }
-
-    return {
-      role: "tool",
-      content: [
-        {
-          type: "tool-result" as const,
-          toolName: ir.toolCall.call.original.name,
-          toolCallId: ir.toolCall.toolCallId,
-          output: {
-            type: "text" as const,
-            value: content,
+            value: ir.content,
           },
         },
       ],
@@ -277,23 +225,6 @@ function modelMessageFromIr(
     };
   }
 
-  if (ir.role === "file-outdated") {
-    return {
-      role: "tool",
-      content: [
-        {
-          type: "tool-result",
-          toolCallId: ir.toolCall.toolCallId,
-          toolName: ir.toolCall.call.original.name,
-          output: {
-            type: "text",
-            value: ir.error,
-          },
-        },
-      ],
-    };
-  }
-
   if (ir.role === "compaction-checkpoint") {
     return {
       role: "user",
@@ -301,21 +232,8 @@ function modelMessageFromIr(
     };
   }
 
-  const _: "file-unreadable" = ir.role;
-  return {
-    role: "tool",
-    content: [
-      {
-        type: "tool-result",
-        toolCallId: ir.toolCall.toolCallId,
-        toolName: ir.toolCall.call.original.name,
-        output: {
-          type: "text",
-          value: ir.error,
-        },
-      },
-    ],
-  };
+  const _: never = ir;
+  return _;
 }
 
 function generateCurlFrom(params: {

--- a/source/compilers/responses.ts
+++ b/source/compilers/responses.ts
@@ -7,6 +7,7 @@ import { parseToolCall } from "./parse-tool-call.ts";
 import { ToolCallRequest, MalformedRequest, AssistantMessage } from "../ir/llm-ir.ts";
 import { trackTokens } from "../token-tracker.ts";
 import { sumAssistantTokens } from "../ir/count-ir-tokens.ts";
+import { result } from "../result.ts";
 import { errorToString } from "../errors.ts";
 import { compactionCompilerExplanation } from "./autocompact.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
@@ -318,7 +319,7 @@ export const runResponsesAgent: Compiler = async ({
       },
     });
 
-    const result = streamText({
+    const stream = streamText({
       model: openai.responses(model.model),
       messages,
       ...toolParams,
@@ -343,7 +344,7 @@ export const runResponsesAgent: Compiler = async ({
     let encryptedReasoningContent: string | undefined = undefined;
 
     // Handle streaming chunks
-    for await (const chunk of result.fullStream) {
+    for await (const chunk of stream.fullStream) {
       if (abortSignal.aborted) break;
 
       switch (chunk.type) {
@@ -424,13 +425,13 @@ export const runResponsesAgent: Compiler = async ({
 
     // If aborted, don't try to parse tool calls
     if (abortSignal.aborted) {
-      return { success: true, output: assistantHistoryItem, curl };
+      return result.ok({ output: assistantHistoryItem, curl });
     }
 
     // Get tool calls
-    const toolCalls = await result.toolCalls;
+    const toolCalls = await stream.toolCalls;
     if (toolCalls == null || toolCalls.length === 0) {
-      return { success: true, output: assistantHistoryItem, curl };
+      return result.ok({ output: assistantHistoryItem, curl });
     }
 
     const parsedToolCalls: Array<ToolCallRequest | MalformedRequest> = [];
@@ -469,12 +470,11 @@ export const runResponsesAgent: Compiler = async ({
 
     if (parsedToolCalls.length > 0) assistantHistoryItem.toolCalls = parsedToolCalls;
 
-    return { success: true, output: assistantHistoryItem, curl };
+    return result.ok({ output: assistantHistoryItem, curl });
   } catch (e) {
-    return {
-      success: false,
+    return result.err({
       requestError: errorToString(e),
       curl,
-    };
+    });
   }
 };

--- a/source/compilers/run.ts
+++ b/source/compilers/run.ts
@@ -8,6 +8,7 @@ import { findMostRecentCompactionCheckpointIndex } from "./autocompact.ts";
 import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import { LoadedTools } from "../tools/index.ts";
 import { Transport } from "../transports/transport-common.ts";
+import { optimizeFiles } from "./optimize-files.ts";
 
 export async function run({
   model,
@@ -43,13 +44,14 @@ export async function run({
 
   const checkpointIndex = findMostRecentCompactionCheckpointIndex(messages);
   const slicedMessages = messages.slice(checkpointIndex);
+  const optimizedMessages = optimizeFiles(slicedMessages, model.modalities);
 
   return await runInternal({
     model,
     apiKey,
     abortSignal,
     systemPrompt,
-    irs: slicedMessages,
+    irs: optimizedMessages,
     onTokens: handlers.onTokens,
     onQuotaUpdated: handlers.onQuotaUpdated,
     autofixJson: (badJson: string, signal: AbortSignal) => {

--- a/source/compilers/standard.ts
+++ b/source/compilers/standard.ts
@@ -1,8 +1,8 @@
 import { t, toJSONSchema, toTypescript } from "structural";
 import { Compiler } from "./compiler-interface.ts";
+import type { FileOptimizedLlmIR } from "./optimize-files.ts";
 import { StreamingXMLParser, tagged } from "../xml.ts";
 import {
-  LlmIR,
   AssistantMessage as AssistantIR,
   AgentResult,
   ToolCallRequest,
@@ -19,7 +19,7 @@ import { compactionCompilerExplanation } from "./autocompact.ts";
 import { ToolDef } from "../tools/common.ts";
 import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
-import { canDisplayImage, MultimodalConfig } from "../providers.ts";
+import type { MultimodalConfig } from "../providers.ts";
 import { getDefaultOpenaiClient } from "./openai.ts";
 import { Transport } from "../transports/transport-common.ts";
 
@@ -104,26 +104,16 @@ JSON`;
 }
 
 async function toLlmMessages(
-  messages: LlmIR[],
+  messages: FileOptimizedLlmIR[],
   systemPrompt?: () => Promise<string>,
   modalities?: MultimodalConfig,
 ): Promise<Array<LlmMessage>> {
   const output: LlmMessage[] = [];
-  const irs = [...messages];
 
-  irs.reverse();
-  const seenPaths = new Set<string>();
-  for (const ir of irs) {
-    if (ir.role === "file-read") {
-      let seen = seenPaths.has(ir.path);
-      seenPaths.add(ir.path);
-      output.push(llmFromIr(ir, seen, modalities));
-    } else {
-      output.push(llmFromIr(ir, false, modalities));
-    }
+  for (const ir of messages) {
+    output.push(llmFromIr(ir, modalities));
   }
 
-  output.reverse();
   if (systemPrompt) {
     const prompt = await systemPrompt();
     output.unshift({
@@ -135,7 +125,7 @@ async function toLlmMessages(
   return output;
 }
 
-function llmFromIr(ir: LlmIR, seenPath: boolean, modalities?: MultimodalConfig): LlmMessage {
+function llmFromIr(ir: FileOptimizedLlmIR, modalities?: MultimodalConfig): LlmMessage {
   if (ir.role === "assistant") {
     const { toolCalls } = ir;
     const reasoning: { reasoning_content?: string } = {};
@@ -196,35 +186,6 @@ function llmFromIr(ir: LlmIR, seenPath: boolean, modalities?: MultimodalConfig):
     };
   }
 
-  if (ir.role === "file-read") {
-    const imageCheck = ir.image ? canDisplayImage(modalities, ir.image) : null;
-    if (ir.image && imageCheck?.ok) {
-      return {
-        role: "user",
-        content: [
-          { type: "text", text: `[Tool result for call ${ir.toolCall.toolCallId}]: ${ir.content}` },
-          {
-            type: "image_url",
-            image_url: { url: ir.image.dataUrl },
-          },
-        ],
-      };
-    }
-    return {
-      role: "tool",
-      tool_call_id: ir.toolCall.toolCallId,
-      content: irPrompts.fileRead(ir.content, seenPath, imageCheck),
-    };
-  }
-
-  if (ir.role === "file-mutate") {
-    return {
-      role: "tool",
-      tool_call_id: ir.toolCall.toolCallId,
-      content: irPrompts.fileMutation(ir.path),
-    };
-  }
-
   if (ir.role === "tool-reject") {
     return {
       role: "tool",
@@ -265,14 +226,6 @@ function llmFromIr(ir: LlmIR, seenPath: boolean, modalities?: MultimodalConfig):
     };
   }
 
-  if (ir.role === "file-outdated") {
-    return {
-      role: "tool",
-      tool_call_id: ir.toolCall.toolCallId,
-      content: `\n${tagged(TOOL_ERROR_TAG, {}, ir.error)}`,
-    };
-  }
-
   if (ir.role === "compaction-checkpoint") {
     return {
       role: "user",
@@ -280,13 +233,8 @@ function llmFromIr(ir: LlmIR, seenPath: boolean, modalities?: MultimodalConfig):
     };
   }
 
-  const _: "file-unreadable" = ir.role;
-
-  return {
-    role: "tool",
-    tool_call_id: ir.toolCall.toolCallId,
-    content: tagged(TOOL_ERROR_TAG, {}, ir.error),
-  };
+  const _: never = ir;
+  return _;
 }
 
 const PaymentErrorSchema = t.subtype({

--- a/source/compilers/standard.ts
+++ b/source/compilers/standard.ts
@@ -1,6 +1,7 @@
-import { t, toJSONSchema, toTypescript } from "structural";
+import { t, toJSONSchema } from "structural";
 import { Compiler } from "./compiler-interface.ts";
 import type { FileOptimizedLlmIR } from "./optimize-files.ts";
+import { parseToolCall } from "./parse-tool-call.ts";
 import { StreamingXMLParser, tagged } from "../xml.ts";
 import {
   AssistantMessage as AssistantIR,
@@ -11,17 +12,12 @@ import {
 import { QuotaData } from "../utils/quota.ts";
 import { parseQuotaJson } from "../utils/quota.ts";
 import { sumAssistantTokens } from "../ir/count-ir-tokens.ts";
-import { tryexpr } from "../tryexpr.ts";
 import { trackTokens } from "../token-tracker.ts";
-import * as logger from "../logger.ts";
 import { errorToString, PaymentError, RateLimitError } from "../errors.ts";
 import { compactionCompilerExplanation } from "./autocompact.ts";
-import { ToolDef } from "../tools/common.ts";
-import { JsonFixResponse } from "../prompts/autofix-prompts.ts";
 import * as irPrompts from "../prompts/ir-prompts.ts";
 import type { MultimodalConfig } from "../providers.ts";
 import { getDefaultOpenaiClient } from "./openai.ts";
-import { Transport } from "../transports/transport-common.ts";
 
 type Content =
   | string
@@ -520,13 +516,17 @@ export const runAgent: Compiler = async ({
         continue;
       }
 
-      const parseResult = await parseTool(
-        validatedTool,
+      const parseResult = await parseToolCall({
+        toolCall: {
+          toolCallId: validatedTool.id,
+          toolName: validatedTool.function.name,
+          args: validatedTool.function.arguments,
+        },
         toolDefs,
         autofixJson,
         abortSignal,
         transport,
-      );
+      });
 
       if (parseResult.status === "error") {
         toolCalls.push({
@@ -551,114 +551,3 @@ export const runAgent: Compiler = async ({
     return { success: true, output: assistantIr, curl };
   });
 };
-
-type ParseToolResult =
-  | {
-      status: "success";
-      tool: ToolCallRequest;
-    }
-  | {
-      status: "error";
-      message: string;
-    };
-
-async function parseTool(
-  toolCall: ResponseToolCall,
-  toolDefs: Record<string, ToolDef<any, any, any>>,
-  autofixJson: (badJson: string, signal: AbortSignal) => Promise<JsonFixResponse>,
-  abortSignal: AbortSignal,
-  transport: Transport,
-): Promise<ParseToolResult> {
-  const name = toolCall.function.name;
-  const toolDef = toolDefs[name];
-
-  if (!toolDef) {
-    return {
-      status: "error",
-      message: `
-Unknown tool ${name}. The only valid tool names are:
-
-- ${Object.keys(toolDefs).join("\n- ")}
-
-Please try calling a valid tool.
-      `.trim(),
-    };
-  }
-
-  const toolSchema = toolDef.Schema;
-  let [err, args] = tryexpr(() => {
-    return toolCall.function.arguments ? JSON.parse(toolCall.function.arguments) : {};
-  });
-
-  if (err) {
-    const fixPromise = autofixJson(toolCall.function.arguments, abortSignal);
-    const fixResponse = await fixPromise;
-    if (!fixResponse.success) {
-      return {
-        status: "error",
-        message: "Syntax error: invalid JSON in tool call arguments",
-      };
-    }
-    args = fixResponse.fixed;
-  }
-
-  // Handle double-encoded arguments, which models sometimes produce
-  if (typeof args === "string") {
-    let [err, argsParsed] = tryexpr(() => {
-      return toolCall.function.arguments ? JSON.parse(toolCall.function.arguments) : {};
-    });
-
-    if (err) {
-      const fixPromise = autofixJson(toolCall.function.arguments, abortSignal);
-      const fixResponse = await fixPromise;
-      if (!fixResponse.success) {
-        return {
-          status: "error",
-          message: "Syntax error: invalid JSON in tool call arguments",
-        };
-      }
-      args = fixResponse.fixed;
-    } else {
-      args = argsParsed;
-    }
-  }
-
-  try {
-    const sliced = toolSchema.slice({
-      name: toolCall.function.name,
-      arguments: args,
-    });
-    const parsed = await toolDef.parse(abortSignal, transport, sliced);
-    if (parsed.success) {
-      return {
-        status: "success",
-        tool: {
-          type: "tool-request",
-          call: parsed.data,
-          toolCallId: toolCall.id,
-        },
-      };
-    }
-    return {
-      status: "error",
-      message: parsed.error,
-    };
-  } catch (e: unknown) {
-    logger.error("verbose", e);
-    logger.error("verbose", toolCall);
-    const error = e instanceof Error ? e.message : "Invalid JSON in tool call";
-    return {
-      status: "error",
-      message: `
-Failed to parse tool call: ${error}. Make sure your JSON is valid and matches the expected format.
-Your JSON was:
-${JSON.stringify(toolCall.function)}
-Expected:
-${toTypescript(toolSchema)}
-
-This is an error in your JSON formatting. You MUST try again, correcting this error. Think about
-what the error is and fix it.
-      `.trim(),
-    };
-  }
-}

--- a/source/compilers/standard.ts
+++ b/source/compilers/standard.ts
@@ -12,6 +12,7 @@ import {
 import { QuotaData } from "../utils/quota.ts";
 import { parseQuotaJson } from "../utils/quota.ts";
 import { sumAssistantTokens } from "../ir/count-ir-tokens.ts";
+import { result } from "../result.ts";
 import { trackTokens } from "../token-tracker.ts";
 import { errorToString, PaymentError, RateLimitError } from "../errors.ts";
 import { compactionCompilerExplanation } from "./autocompact.ts";
@@ -255,15 +256,14 @@ async function handleKnownErrors(
     return await cb();
   } catch (e) {
     for (const [ErrorClass, schema] of ERROR_SCHEMAS) {
-      const result = schema.sliceResult(e);
-      if (!(result instanceof t.Err)) throw new ErrorClass(result.error);
+      const schemaResult = schema.sliceResult(e);
+      if (!(schemaResult instanceof t.Err)) throw new ErrorClass(schemaResult.error);
     }
     // If schema is not found, generate request error with associated curl
-    return {
-      success: false,
+    return result.err({
       requestError: errorToString(e),
       curl,
-    };
+    });
   }
 }
 
@@ -485,10 +485,10 @@ export const runAgent: Compiler = async ({
     };
 
     // If aborted, don't try to parse tool calls - just return the assistant response
-    if (abortSignal.aborted) return { success: true, output: assistantIr, curl };
+    if (abortSignal.aborted) return result.ok({ output: assistantIr, curl });
 
     // If no tool calls, we're done
-    if (toolCallMap.size === 0) return { success: true, output: assistantIr, curl };
+    if (toolCallMap.size === 0) return result.ok({ output: assistantIr, curl });
 
     // Sort tool calls by their streaming index to preserve ordering
     const currTools = Array.from(toolCallMap.entries())
@@ -548,6 +548,6 @@ export const runAgent: Compiler = async ({
 
     if (toolCalls.length > 0) assistantIr.toolCalls = toolCalls;
 
-    return { success: true, output: assistantIr, curl };
+    return result.ok({ output: assistantIr, curl });
   });
 };

--- a/source/ir/llm-ir.ts
+++ b/source/ir/llm-ir.ts
@@ -1,5 +1,6 @@
 import { ToolCall } from "../tools/index.ts";
 import { ImageInfo } from "../utils/image-utils.ts";
+import type { Result } from "../result.ts";
 
 export type ToolCallRequest = {
   type: "tool-request";
@@ -145,14 +146,13 @@ export type TrajectoryOutputIR =
   | FileUnreadableMessage
   | CompactionCheckpoint;
 
-export type AgentResult =
-  | {
-      success: true;
-      output: AssistantMessage;
-      curl: string;
-    }
-  | {
-      success: false;
-      requestError: string;
-      curl: string;
-    };
+export type AgentResult = Result<
+  {
+    output: AssistantMessage;
+    curl: string;
+  },
+  {
+    requestError: string;
+    curl: string;
+  }
+>;


### PR DESCRIPTION
This simplifies the LLM compilers ahead of a larger port from our existing non-generic IR to the new libocto generic IR.

There are three annoyances with the existing compilers:

1. They each have to reimplement the same file-read optimizations, where they track which paths have already been seen and remove all but the latest copy of the file.
2. The each reimplement tool call parsing + JSON autofix + schema validation, even though the logic is near-identical.
3. They use their own Result-like type for returns rather than using our (newer) standard Result type from `result.ts`

These are annoying but livable papercuts in a non-port world. However:

1. libocto doesn't directly expose file IR, and instead expects things like that to be defined as extensions to its IR. That means libocto compilers won't know about file IR, so we need to move the lowering process outside of the compilers.
2. libocto subtly changes tool call parsing and schema validation, so making that change 3x is more annoying than making that change 1x
3. libocto heavily uses our standard Result object

So, this PR simplifies the compilers by:

1. Pulling out file optimizations to a separate function, and making compilers not need to deal with that and enforcing it on a type level.
2. Pulling out tool call parsing + schema validation into a separate function that the compilers simply call, rather than copypasta in each compiler
3. Porting the compilers to use the standard Result type

It also adds a bunch of tests, which is nice since this functionality was largely untested before. Despite the added tests, this PR overall *reduces* lines of code since it removes so much duplication!