### PR TITLE
feat: remove 'rm -rf dist' from npm run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "node": ">=16"
   },
   "scripts": {
-    "build": "rm -rf dist && babel source -d dist/source --extensions \".ts,.tsx\" && tsc --emitDeclarationOnly",
+    "clean": "rm -rf dist",
+    "build": "babel source -d dist/source --extensions \".ts,.tsx\" && tsc --emitDeclarationOnly",
+    "rebuild": "npm run clean && npm run build",
     "dev": "npm run build -- --watch",
     "exec": "npm run build && node ./dist/source/cli.js",
     "test": "vitest",


### PR DESCRIPTION
Small proposal to change

```
    "build": "rm -rf dist && babel source -d dist/source --extensions \".ts,.tsx\" && tsc --emitDeclarationOnly",
```

to

```
    "clean": "rm -rf dist",
    "build": "babel source -d dist/source --extensions \".ts,.tsx\" && tsc --emitDeclarationOnly",
    "rebuild": "npm run clean && npm run build",
```

to avoid running `rm -rf dist` and forcing full rebuild on every `npm run build` (eg. for `canary-octo` or `npm run exec`)