### PR TITLE
Fix Synthetic quota display

### DIFF
--- a/source/components/menu-quota-indicator.tsx
+++ b/source/components/menu-quota-indicator.tsx
@@ -99,7 +99,7 @@ export const MenuQuotaIndicator = () => {
           <WeeklyQuotaRow label="Weekly credits" entry={quota.weeklyTokenLimit} />
         ) : null}
         {quota.rollingFiveHourLimit ? (
-          <QuotaRow label="Rolling 5h" entry={quota.rollingFiveHourLimit} />
+          <QuotaRow label="5h request limit" entry={quota.rollingFiveHourLimit} />
         ) : null}
       </Box>
     </Box>

--- a/source/components/menu-quota-indicator.tsx
+++ b/source/components/menu-quota-indicator.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Text, Box } from "ink";
 import { assertKeyForModel, useConfig } from "../config.ts";
 import { useModel, useAppStore } from "../state.ts";
-import { QuotaData, QuotaEntry } from "../utils/quota.ts";
+import type { QuotaData, QuotaEntry, WeeklyEntry } from "../utils/quota.ts";
 import { parseQuotaJson } from "../utils/quota.ts";
 import { formatTimeUntil } from "../time.ts";
 
@@ -23,11 +23,41 @@ type QuotaRowProps = {
   entry: QuotaEntry;
 };
 
+function formatQuotaNumber(value: number): string {
+  if (Number.isInteger(value)) return value.toString();
+  return Math.floor(value * 10) / 10 + "";
+}
+
 function QuotaRow({ label, entry }: QuotaRowProps) {
+  const tickPercent = formatQuotaNumber(entry.tickPercent * 100);
+  const showNextRegen = entry.remaining < entry.max;
+
   return (
-    <Box flexDirection="row" flexWrap="wrap">
-      <Text>{`${label}: ${entry.used} / ${entry.limit}`}</Text>
-      <Text color="gray">{` · refreshes ${formatTimeUntil(entry.renewsAt)}`}</Text>
+    <Box flexDirection="column">
+      <Text>{`${label}: ${formatQuotaNumber(entry.remaining)} / ${formatQuotaNumber(entry.max)} remaining`}</Text>
+      {showNextRegen ? (
+        <Text color="gray">{`Next regen: ${tickPercent}% ${formatTimeUntil(entry.nextTickAt)}`}</Text>
+      ) : null}
+    </Box>
+  );
+}
+
+type WeeklyQuotaRowProps = {
+  label: string;
+  entry: WeeklyEntry;
+};
+
+function WeeklyQuotaRow({ label, entry }: WeeklyQuotaRowProps) {
+  const showNextRegen = entry.remainingCredits !== entry.maxCredits;
+
+  return (
+    <Box flexDirection="column">
+      <Text>{`${label}: ${entry.remainingCredits} / ${entry.maxCredits} remaining`}</Text>
+      {showNextRegen ? (
+        <Text color="gray">
+          {`Next regen: ${entry.nextRegenCredits} ${formatTimeUntil(entry.nextRegenAt)}`}
+        </Text>
+      ) : null}
     </Box>
   );
 }
@@ -59,15 +89,18 @@ export const MenuQuotaIndicator = () => {
   const quota = storeQuota ?? fetchedQuota;
 
   if (!quota) return null;
+  if (!quota.weeklyTokenLimit && !quota.rollingFiveHourLimit) return null;
 
   return (
     <Box flexDirection="column" alignItems="center">
-      <Text bold>Synthetic Subscription</Text>
+      <Text bold>Synthetic Quota</Text>
       <Box flexDirection="column">
-        <QuotaRow label="Requests" entry={quota.subscription} />
-        {quota.freeToolCalls && quota.freeToolCalls.limit > 0 && (
-          <QuotaRow label="Free Tool Calls" entry={quota.freeToolCalls} />
-        )}
+        {quota.weeklyTokenLimit ? (
+          <WeeklyQuotaRow label="Weekly credits" entry={quota.weeklyTokenLimit} />
+        ) : null}
+        {quota.rollingFiveHourLimit ? (
+          <QuotaRow label="Rolling 5h" entry={quota.rollingFiveHourLimit} />
+        ) : null}
       </Box>
     </Box>
   );

--- a/source/utils/quota.ts
+++ b/source/utils/quota.ts
@@ -1,41 +1,69 @@
 import { t } from "structural";
 
-export type QuotaEntry = {
-  used: number;
-  limit: number;
-  renewsAt: Date;
+const QuotaEntryRawSchema = t.subtype({
+  remaining: t.num,
+  max: t.num,
+  nextTickAt: t.str,
+  tickPercent: t.num,
+});
+
+const WeeklyEntryRawSchema = t.subtype({
+  nextRegenAt: t.str,
+  percentRemaining: t.num,
+  maxCredits: t.str,
+  remainingCredits: t.str,
+  nextRegenCredits: t.str,
+});
+
+type WithDateFields<T extends {}, K extends keyof T> = Omit<T, K> & {
+  [P in K]: Date;
 };
+
+export type QuotaEntry = WithDateFields<t.GetType<typeof QuotaEntryRawSchema>, "nextTickAt">;
+export type WeeklyEntry = WithDateFields<t.GetType<typeof WeeklyEntryRawSchema>, "nextRegenAt">;
 
 export type QuotaData = {
-  subscription: QuotaEntry;
-  freeToolCalls?: QuotaEntry;
+  rollingFiveHourLimit?: QuotaEntry;
+  weeklyTokenLimit?: WeeklyEntry;
 };
 
-const QuotaEntryRawSchema = t.subtype({
-  limit: t.num,
-  requests: t.num,
-  renewsAt: t.str,
-});
+function parseOptionalQuotaEntry(raw: unknown): QuotaEntry | undefined {
+  if (raw == null) return undefined;
+  const result = QuotaEntryRawSchema.sliceResult(raw);
+  if (result instanceof t.Err) return undefined;
+  const nextTickAt = new Date(result.nextTickAt);
+  if (isNaN(nextTickAt.getTime())) return undefined;
+  return {
+    ...result,
+    nextTickAt,
+  };
+}
 
-const QuotaDataRawSchema = t.subtype({
-  subscription: QuotaEntryRawSchema,
-  freeToolCalls: t.optional(QuotaEntryRawSchema),
-});
-
-function parseQuotaEntry(raw: t.GetType<typeof QuotaEntryRawSchema>): QuotaEntry | undefined {
-  const renewsAt = new Date(raw.renewsAt);
-  if (isNaN(renewsAt.getTime())) return undefined;
-  return { limit: raw.limit, used: raw.requests, renewsAt };
+function parseOptionalWeeklyEntry(raw: unknown): WeeklyEntry | undefined {
+  if (raw == null) return undefined;
+  const result = WeeklyEntryRawSchema.sliceResult(raw);
+  if (result instanceof t.Err) return undefined;
+  const nextRegenAt = new Date(result.nextRegenAt);
+  if (isNaN(nextRegenAt.getTime())) return undefined;
+  return {
+    ...result,
+    nextRegenAt,
+  };
 }
 
 export function parseQuotaJson(data: string): QuotaData | undefined {
   try {
-    const result = QuotaDataRawSchema.sliceResult(JSON.parse(data));
-    if (result instanceof t.Err) return undefined;
-    const subscription = parseQuotaEntry(result.subscription);
-    if (!subscription) return undefined;
-    const freeToolCalls = result.freeToolCalls ? parseQuotaEntry(result.freeToolCalls) : undefined;
-    return { subscription, freeToolCalls };
+    const raw = JSON.parse(data);
+    if (raw == null || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+
+    const rollingFiveHourLimit = parseOptionalQuotaEntry(raw["rollingFiveHourLimit"]);
+    const weeklyTokenLimit = parseOptionalWeeklyEntry(raw["weeklyTokenLimit"]);
+    if (!rollingFiveHourLimit && !weeklyTokenLimit) return undefined;
+
+    return {
+      ...(rollingFiveHourLimit ? { rollingFiveHourLimit } : {}),
+      ...(weeklyTokenLimit ? { weeklyTokenLimit } : {}),
+    };
   } catch {
     /* ignore errors, they're out-of-place in the menu */
     return undefined;


### PR DESCRIPTION
When we changed to a weekly credit limit and a rolling five-hour window for requests, we never updated Octo, and so Octo always kept saying you had used zero requests (since it kept checking the old, deprecated fields).

This fixes that:

<img width="978" height="246" alt="image" src="https://github.com/user-attachments/assets/b1e5a9d3-9733-41d0-8683-dda97d7f3321" />