### PR TITLE
Clarify glob and grep tool arguments

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -1224,9 +1224,9 @@ function GlobRenderer({ item }: { item: ParsedToolSchemaFrom<typeof glob> }) {
   return (
     <Box flexDirection="column">
       <Text color="gray">Octo searched for files using a glob pattern:</Text>
-      <GlobArg name="CWD" arg={item.arguments.cwd} />
-      <GlobArg name="Filename pattern" arg={item.arguments.name} />
-      <GlobArg name="Path pattern" arg={item.arguments.path} />
+      <GlobArg name="Path" arg={item.arguments.path} />
+      <GlobArg name="Filename pattern" arg={item.arguments.includeName} />
+      <GlobArg name="Path pattern" arg={item.arguments.includePath} />
       <GlobArg name="Max depth" arg={item.arguments.maxDepth} />
     </Box>
   );

--- a/source/tools/tool-defs/glob.ts
+++ b/source/tools/tool-defs/glob.ts
@@ -17,22 +17,31 @@ deeply-nested directories with large amounts of files). Do NOT search for overly
 like *.rb: instead, use targeted search terms for specifically what you want to find, like
 *user-data*.rb if you're searching for a file for user data for example.
 
-The glob tool automatically excludes common depedency directories such as node_modules, but do not
+The glob tool automatically excludes common dependency directories such as node_modules, but do not
 depend on this fact: there may be directories that it doesn't know it should ignore. Keep your glob
 terms scoped and specific.
 `.trim(),
   ArgumentsSchema: t.partial(
     t.subtype({
-      cwd: t.str,
-      name: t.str.comment("-name pattern (e.g. *file-pattern*.js)"),
-      caseInsensitive: t.bool.comment(
-        "Use case-insensitive matching for the name pattern (uses -iname instead of -name)",
+      path: t.str.comment(
+        "The directory to search from. Finds files recursively within this directory. Defaults to the current working directory.",
       ),
-      path: t.str.comment("-path pattern (e.g. */test/*)"),
+      includeName: t.str.comment(
+        "Filename (basename) glob pattern for files to include (e.g. *file-pattern*.js). Path segments should not be part of this pattern.",
+      ),
+      excludeName: t.str.comment(
+        "Filename (basename) glob pattern for files to exclude (e.g. *.d.ts). Path segments should not be part of this pattern.",
+      ),
+      includePath: t.str.comment(
+        "File path glob pattern for files to include (e.g. */src/* for files inside src directories).",
+      ),
+      excludePath: t.str.comment(
+        "File path glob pattern for files to exclude (e.g. */test/* for files inside test directories).",
+      ),
+      caseInsensitive: t.bool.comment(
+        "Use case-insensitive matching for the filename glob pattern. Exclusion patterns are not affected by this flag and are always case-sensitive.",
+      ),
       maxDepth: t.num.comment("The max depth of directories to search"),
-      type: t.value("file").or(t.value("directory")),
-      excludeFilename: t.str.comment("Exclude files matching this -name pattern (e.g. *.d.ts)"),
-      excludePath: t.str.comment("Exclude paths matching this -path pattern (e.g. */test/*)"),
       maxResults: t.num.comment("Max number of results to return"),
     }),
   ),
@@ -40,15 +49,7 @@ terms scoped and specific.
   async run({ signal, transport, toolCall, data }) {
     const search = toolCall.parsed.arguments;
     try {
-      const files = await findFiles(signal, transport, {
-        ...search,
-        type: (() => {
-          if (search.type == null) return undefined;
-          if (search.type === "file") return "f";
-          const _: "directory" = search.type;
-          return "d";
-        })(),
-      });
+      const files = await findFiles(signal, transport, { ...search });
       const text = files.join("\n");
       const { context } = getModelFromConfig(data, null);
       const tok = estimateTokens(text);

--- a/source/tools/tool-defs/grep.ts
+++ b/source/tools/tool-defs/grep.ts
@@ -11,9 +11,12 @@ export default TOOL.declare({
   description: "Searches file contents using grep. Prefer this to shelling out to `grep` directly.",
   ArgumentsSchema: t.partial(
     t.subtype({
-      cwd: t.str,
-      pattern: t.str.comment("The search pattern"),
-      path: t.str.comment("Directory or file to search (defaults to cwd)"),
+      pattern: t.str.comment(
+        "The search pattern. Internally uses grep with the -E flag (extended regex).",
+      ),
+      path: t.str.comment(
+        "Directory or file to search in. Defaults to the current working directory.",
+      ),
       caseInsensitive: t.bool.comment("Case-insensitive search"),
       context: t.num.comment("Number of context lines around each match"),
       maxResults: t.num.comment("Max number of results to return"),
@@ -24,7 +27,7 @@ export default TOOL.declare({
   async run({ signal, transport, toolCall, data }) {
     const search = toolCall.parsed.arguments;
     try {
-      const args: string[] = ["-n", "-r"];
+      const args: string[] = ["-n", "-r", "-E"];
 
       if (search.caseInsensitive) {
         args.push("-i");
@@ -36,7 +39,7 @@ export default TOOL.declare({
 
       args.push("--", quote([search.pattern ?? ""]));
 
-      const searchPath = search.path ?? search.cwd ?? transport.cwd;
+      const searchPath = search.path ?? transport.cwd;
       args.push(quote([searchPath]));
 
       const cmd = `grep ${args.join(" ")}`;
@@ -63,7 +66,7 @@ export default TOOL.declare({
         return err(USER_ABORTED_ERROR_MESSAGE);
       }
       if (e instanceof CommandFailedError) {
-        if (e.message.includes("exit code 1")) {
+        if (e.exitCode === 1) {
           return ok({
             type: "output",
             content: [{ type: "text", content: "" }],

--- a/source/transports/docker.ts
+++ b/source/transports/docker.ts
@@ -106,6 +106,7 @@ output: ${output}`,
             new CommandFailedError(
               `Command exited with code: ${code}
 output: ${output}`,
+              code,
             ),
           );
         }

--- a/source/transports/local.ts
+++ b/source/transports/local.ts
@@ -168,6 +168,7 @@ output: ${output}`,
               new CommandFailedError(
                 `Command exited with code: ${code}
 output: ${output}`,
+                code,
               ),
             );
           }

--- a/source/transports/transport-common.ts
+++ b/source/transports/transport-common.ts
@@ -56,18 +56,18 @@ export async function findFiles(
   signal: AbortSignal,
   transport: Transport,
   options: {
-    cwd?: string;
-    name?: string; // -name pattern (e.g. "*.js")
-    caseInsensitive?: boolean; // use -iname instead of -name
-    path?: string; // -path pattern (e.g. "*/test/*")
-    maxDepth?: number; // -maxdepth N
-    type?: "f" | "d"; // -type f or -type d
-    excludeFilename?: string; // ! -name pattern
+    path?: string; // The directory to search from (defaults to transport.cwd)
+    includeName?: string; // -name pattern (e.g. "*.js")
+    includePath?: string; // -path pattern (e.g. "*/test/*")
+    excludeName?: string; // ! -name pattern
     excludePath?: string; // ! -path pattern
+    caseInsensitive?: boolean; // use -iname instead of -name
+    type?: "f" | "d"; // -type f or -type d
+    maxDepth?: number; // -maxdepth N
     maxResults?: number; // cap output count
   } = {},
 ): Promise<string[]> {
-  const cwd = options.cwd || transport.cwd;
+  const cwd = options.path || transport.cwd;
 
   // Build find command with directory pruning
   const pruneArgs = EXCLUDED_DIRS.map(d => `-name ${quote([d])} -prune`).join(" -o ");
@@ -83,29 +83,27 @@ export async function findFiles(
     predicates.push(`-maxdepth ${options.maxDepth}`);
   }
 
-  if (options.name !== undefined) {
+  if (options.includeName !== undefined) {
     const nameFlag = options.caseInsensitive ? "-iname" : "-name";
-    predicates.push(`${nameFlag} ${quote([options.name])}`);
+    predicates.push(`${nameFlag} ${quote([options.includeName])}`);
   }
 
-  if (options.path !== undefined) {
-    predicates.push(`-path ${quote([options.path])}`);
+  if (options.includePath !== undefined) {
+    predicates.push(`-path ${quote([options.includePath])}`);
   }
 
-  if (options.type === "f" || options.type === "d") {
-    predicates.push(`-type ${options.type}`);
-  }
-
-  if (options.excludeFilename !== undefined) {
-    predicates.push(`! -name ${quote([options.excludeFilename])}`);
+  if (options.excludeName !== undefined) {
+    predicates.push(`! -name ${quote([options.excludeName])}`);
   }
 
   if (options.excludePath !== undefined) {
     predicates.push(`! -path ${quote([options.excludePath])}`);
   }
 
-  // Default to -type f if no type specified
-  if (predicates.length === 0) {
+  if (options.type === "f" || options.type === "d") {
+    predicates.push(`-type ${options.type}`);
+  } else {
+    // Default to -type f if no type specified
     predicates.push("-type f");
   }
 
@@ -141,7 +139,13 @@ export class TransportError extends Error {
     this.name = this.constructor.name;
   }
 }
-export class CommandFailedError extends TransportError {}
+export class CommandFailedError extends TransportError {
+  exitCode?: number;
+  constructor(msg: string, exitCode?: number) {
+    super(msg);
+    this.exitCode = exitCode;
+  }
+}
 export class AbortError extends TransportError {
   constructor() {
     super("Aborted");


### PR DESCRIPTION
It seems that LLMs didn't understand the different arguments so renamed them and was more explicit about their usecases in their `comment`s.

### Glob argument changes

| New | Old | Notes |
|-----|-----|-------|
| `path` | ~`cwd`~ ||
| `includeName` | ~`name`~ ||
| `excludeName` | ~`excludeFilename`~||
| `includePath` | ~`path`~ ||
| _removed_ | ~`type`~ |All comments referenced finding files, so seemed unnecessary to surface the option|

### Grep argument changes

| New | Old | Notes |
|-----|-----|-------|
| `path` | ~`cwd`~ ||
| `pattern` || Internals & comment updated to allow extended regex with `-E` flag|

### Other changes
- Grep used to check the error string for `"exit code 1"` for empty results but the actual string was actually "`Command exited with code: 1`"
  - We now check the `exitCode` passed through in the error