### PR TITLE
Allow outdated file writes

### DIFF
--- a/source/libocto/result.test.ts
+++ b/source/libocto/result.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { err, flatten, ok } from "./result.ts";
+import { err, flatten, ok, unwrap } from "./result.ts";
 
 describe("flatten", () => {
   it("leaves a flat ok alone", () => {
@@ -43,5 +43,15 @@ describe("flatten", () => {
 
     expect(result.success).toBe(true);
     if (result.success) expect(result.data).toBe(payload);
+  });
+});
+
+describe("unwrap", () => {
+  it("returns ok data", () => {
+    expect(unwrap(ok(1))).toBe(1);
+  });
+
+  it("throws err messages", () => {
+    expect(() => unwrap(err("boom"))).toThrow("boom");
   });
 });

--- a/source/libocto/result.ts
+++ b/source/libocto/result.ts
@@ -10,6 +10,11 @@ export function err<E>(e: E) {
   return new Err<E>(e);
 }
 
+export function unwrap<T, E>(result: Result<T, E>): T {
+  if (result.success) return result.data;
+  throw new Error(errorToString(result.error));
+}
+
 export async function attempt<T, E>(
   errMessage: string,
   callback: () => Promise<Result<T, E>>,

--- a/source/tools/file-tracker.ts
+++ b/source/tools/file-tracker.ts
@@ -55,14 +55,14 @@ export class FileTracker {
     return absolutePath;
   }
 
-  async canEdit(transport: Transport, signal: AbortSignal, filePath: string): Promise<boolean> {
+  async isOutdated(transport: Transport, signal: AbortSignal, filePath: string): Promise<boolean> {
     const absolutePath = await transport.resolvePath(signal, filePath);
     if (!this.readTimestamps.has(absolutePath)) return false;
 
     const lastReadTime = this.readTimestamps.get(absolutePath)!;
     try {
       const currentModified = await transport.modTime(signal, absolutePath);
-      return currentModified <= lastReadTime;
+      return currentModified > lastReadTime;
     } catch {
       // File was deleted or is otherwise inaccessible
       return false;

--- a/source/tools/tool-defs/append.ts
+++ b/source/tools/tool-defs/append.ts
@@ -1,13 +1,8 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import {
-  attemptUntrackedRead,
-  TOOL,
-  FILE_OUTDATED_ERROR_MESSAGE,
-  fileMutateIR,
-} from "../common.ts";
+import { attemptUntrackedRead, TOOL, fileMutateIR } from "../common.ts";
 import { Transport } from "../../transports/transport-common.ts";
-import { ok, err } from "../../libocto/result.ts";
+import { ok } from "../../libocto/result.ts";
 
 const ArgumentsSchema = t.subtype({
   filePath: t.str.comment("The path to the file"),
@@ -45,8 +40,6 @@ async function validate(
   transport: Transport,
   args: t.GetType<typeof ArgumentsSchema>,
 ) {
-  const canEdit = await fileTracker.canEdit(transport, signal, args.filePath);
-  if (!canEdit) return err(FILE_OUTDATED_ERROR_MESSAGE);
   const file = await attemptUntrackedRead(transport, signal, args.filePath);
   if (!file.success) return file;
   return ok(null);

--- a/source/tools/tool-defs/edit.test.ts
+++ b/source/tools/tool-defs/edit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import editToolFactory from "./edit.ts";
 import { FILE_OUTDATED_ERROR_MESSAGE } from "../common.ts";
 import { fileTracker } from "../file-tracker.ts";
-import type { Result } from "../../libocto/result.ts";
+import { unwrap } from "../../libocto/result.ts";
 import type { Transport } from "../../transports/transport-common.ts";
 
 function createTransport(files: Record<string, string>): Transport {
@@ -60,14 +60,6 @@ async function createEditTool(transport: Transport) {
     throw new Error("edit tool did not load");
   }
   return tool;
-}
-
-function unwrap<T>(result: Result<T, string>): T {
-  expect(result.success).toBe(true);
-  if (!result.success) {
-    throw new Error(result.error);
-  }
-  return result.data;
 }
 
 function editToolCall(args: { filePath: string; search: string; replace: string }) {

--- a/source/tools/tool-defs/edit.test.ts
+++ b/source/tools/tool-defs/edit.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import editToolFactory from "./edit.ts";
+import { FILE_OUTDATED_ERROR_MESSAGE } from "../common.ts";
+import { fileTracker } from "../file-tracker.ts";
+import type { Result } from "../../libocto/result.ts";
+import type { Transport } from "../../transports/transport-common.ts";
+
+function createTransport(files: Record<string, string>): Transport {
+  const resolve = (file: string) => (file.startsWith("/") ? file : `/repo/${file}`);
+  const modTimes = new Map(Object.keys(files).map((file, index) => [resolve(file), index + 1]));
+
+  return {
+    cwd: "/repo",
+    async writeFile(_signal, file, contents) {
+      const resolved = resolve(file);
+      files[resolved] = contents;
+      modTimes.set(resolved, (modTimes.get(resolved) ?? 0) + 1);
+    },
+    async readFile(_signal, file) {
+      const content = files[resolve(file)];
+      if (content == null) {
+        throw new Error(`No such file: ${file}`);
+      }
+      return content;
+    },
+    async pathExists(_signal, file) {
+      return files[resolve(file)] != null;
+    },
+    async isDirectory() {
+      return false;
+    },
+    async mkdir() {},
+    async readdir() {
+      return [];
+    },
+    async modTime(_signal, file) {
+      const modTime = modTimes.get(resolve(file));
+      if (modTime == null) {
+        throw new Error(`No such file: ${file}`);
+      }
+      return modTime;
+    },
+    async resolvePath(_signal, file) {
+      return resolve(file);
+    },
+    async shell() {
+      return "";
+    },
+    async close() {},
+  };
+}
+
+async function createEditTool(transport: Transport) {
+  const tool = await editToolFactory({
+    signal: new AbortController().signal,
+    transport,
+    data: {} as never,
+  });
+  if (!tool) {
+    throw new Error("edit tool did not load");
+  }
+  return tool;
+}
+
+function unwrap<T>(result: Result<T, string>): T {
+  expect(result.success).toBe(true);
+  if (!result.success) {
+    throw new Error(result.error);
+  }
+  return result.data;
+}
+
+function editToolCall(args: { filePath: string; search: string; replace: string }) {
+  return {
+    toolCallId: "test-call",
+    original: { name: "edit" as const, arguments: args },
+    parsed: {
+      name: "edit" as const,
+      arguments: {
+        ...args,
+        originalFileContents: "",
+      },
+    },
+  };
+}
+
+describe("edit tool", () => {
+  it("edits stale files optimistically when the search string still matches", async () => {
+    const signal = new AbortController().signal;
+    const transport = createTransport({
+      "/repo/optimistic.txt": "one\ntwo\nthree",
+    });
+    const tool = await createEditTool(transport);
+
+    await fileTracker.read(transport, signal, "optimistic.txt");
+    await transport.writeFile(signal, "optimistic.txt", "zero\none\ntwo\nthree");
+    await expect(fileTracker.isOutdated(transport, signal, "optimistic.txt")).resolves.toBe(true);
+
+    const result = unwrap(
+      await tool.run({
+        signal,
+        transport,
+        toolCall: editToolCall({
+          filePath: "optimistic.txt",
+          search: "two",
+          replace: "TWO",
+        }),
+        data: {} as never,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      type: "custom-ir",
+      data: {
+        role: "file-mutate",
+        path: "optimistic.txt",
+      },
+    });
+    await expect(transport.readFile(signal, "optimistic.txt")).resolves.toBe(
+      "zero\none\nTWO\nthree",
+    );
+  });
+
+  it("returns an outdated error only when a failed edit is stale", async () => {
+    const signal = new AbortController().signal;
+    const freshTransport = createTransport({
+      "/repo/fresh-missing.txt": "current contents",
+    });
+    const staleTransport = createTransport({
+      "/repo/stale-missing.txt": "before edit",
+    });
+    const freshTool = await createEditTool(freshTransport);
+    const staleTool = await createEditTool(staleTransport);
+
+    const freshResult = await freshTool.run({
+      signal,
+      transport: freshTransport,
+      toolCall: editToolCall({
+        filePath: "fresh-missing.txt",
+        search: "missing text",
+        replace: "replacement",
+      }),
+      data: {} as never,
+    });
+
+    expect(freshResult.success).toBe(false);
+    if (freshResult.success) return;
+    expect(freshResult.error).toContain("Could not find search string");
+    expect(freshResult.error).not.toBe(FILE_OUTDATED_ERROR_MESSAGE);
+
+    await fileTracker.read(staleTransport, signal, "stale-missing.txt");
+    await staleTransport.writeFile(signal, "stale-missing.txt", "after edit");
+
+    const staleResult = await staleTool.run({
+      signal,
+      transport: staleTransport,
+      toolCall: editToolCall({
+        filePath: "stale-missing.txt",
+        search: "before edit",
+        replace: "replacement",
+      }),
+      data: {} as never,
+    });
+
+    expect(staleResult.success).toBe(false);
+    if (staleResult.success) return;
+    expect(staleResult.error).toBe(FILE_OUTDATED_ERROR_MESSAGE);
+    await expect(staleTransport.readFile(signal, "stale-missing.txt")).resolves.toBe("after edit");
+  });
+});

--- a/source/tools/tool-defs/edit.ts
+++ b/source/tools/tool-defs/edit.ts
@@ -55,10 +55,12 @@ export default edit.withCustomIR({ fileMutateIR }).define(async () => ({
 
     const file = await attemptUntrackedRead(transport, signal, filePath);
     if (!file.success) return file;
-    const replaced = runEdit({
+    const replaced = await runEdit({
+      transport,
+      signal,
+      diff,
       path: filePath,
       file: file.data,
-      diff,
     });
     if (!replaced.success) return replaced;
     await fileTracker.write(transport, signal, filePath, replaced.data);
@@ -71,37 +73,51 @@ async function validate(
   transport: Transport,
   args: t.GetType<typeof ArgumentsSchema>,
 ) {
-  const canEdit = await fileTracker.canEdit(transport, signal, args.filePath);
-  if (!canEdit) return err(FILE_OUTDATED_ERROR_MESSAGE);
   const file = await attemptUntrackedRead(transport, signal, args.filePath);
   if (!file.success) return file;
-  return validateDiff({ file: file.data, diff: args, path: args.filePath });
+  return await validateDiff({
+    transport,
+    signal,
+    file: file.data,
+    diff: args,
+    path: args.filePath,
+  });
 }
 
-function runEdit({
+async function runEdit({
+  transport,
+  signal,
   path,
   file,
   diff,
 }: {
+  transport: Transport;
+  signal: AbortSignal;
   path: string;
   file: string;
   diff: t.GetType<typeof ArgumentsSchema>;
 }) {
-  const validation = validateDiff({ path, file, diff });
+  const validation = await validateDiff({ transport, signal, path, file, diff });
   if (!validation.success) return validation;
   return ok(file.replace(diff.search, diff.replace));
 }
 
-function validateDiff({
+async function validateDiff({
+  transport,
+  signal,
   path,
   file,
   diff,
 }: {
+  transport: Transport;
+  signal: AbortSignal;
   path: string;
   file: string;
   diff: t.GetType<typeof ArgumentsSchema>;
 }) {
   if (!file.includes(diff.search)) {
+    const isOutdated = await fileTracker.isOutdated(transport, signal, path);
+    if (isOutdated) return err(FILE_OUTDATED_ERROR_MESSAGE);
     return err(
       `
 Could not find search string in file ${path}: ${diff.search}

--- a/source/tools/tool-defs/prepend.ts
+++ b/source/tools/tool-defs/prepend.ts
@@ -1,13 +1,8 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import {
-  attemptUntrackedRead,
-  TOOL,
-  FILE_OUTDATED_ERROR_MESSAGE,
-  fileMutateIR,
-} from "../common.ts";
+import { attemptUntrackedRead, TOOL, fileMutateIR } from "../common.ts";
 import { Transport } from "../../transports/transport-common.ts";
-import { ok, err } from "../../libocto/result.ts";
+import { ok } from "../../libocto/result.ts";
 
 const ArgumentsSchema = t.subtype({
   filePath: t.str.comment("The path to the file"),
@@ -46,8 +41,6 @@ async function validate(
   transport: Transport,
   args: t.GetType<typeof ArgumentsSchema>,
 ) {
-  const canEdit = await fileTracker.canEdit(transport, signal, args.filePath);
-  if (!canEdit) return err(FILE_OUTDATED_ERROR_MESSAGE);
   const file = await attemptUntrackedRead(transport, signal, args.filePath);
   if (!file.success) return file;
   return ok(null);

--- a/source/tools/tool-defs/read.test.ts
+++ b/source/tools/tool-defs/read.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import readToolFactory from "./read.ts";
 import { fileTracker } from "../file-tracker.ts";
+import { unwrap } from "../../libocto/result.ts";
 import type { Transport } from "../../transports/transport-common.ts";
-import type { Result } from "../../libocto/result.ts";
 
 function createTransport(files: Record<string, string>): Transport {
   const resolve = (file: string) => (file.startsWith("/") ? file : `/repo/${file}`);
@@ -59,14 +59,6 @@ async function createReadTool(transport: Transport) {
     throw new Error("read tool did not load");
   }
   return tool;
-}
-
-function unwrap<T>(result: Result<T, string>): T {
-  expect(result.success).toBe(true);
-  if (!result.success) {
-    throw new Error(result.error);
-  }
-  return result.data;
 }
 
 function readToolCall(args: { filePath: string; offset?: number; limit?: number }) {

--- a/source/tools/tool-defs/read.test.ts
+++ b/source/tools/tool-defs/read.test.ts
@@ -112,15 +112,14 @@ describe("read tool", () => {
       "/repo/full.txt": "one\ntwo\nthree",
     });
     const tool = await createReadTool(transport);
+    const toolResult = await tool.run({
+      signal,
+      transport,
+      toolCall: readToolCall({ filePath: "full.txt" }),
+      data: {} as never,
+    });
 
-    const result = unwrap(
-      await tool.run({
-        signal,
-        transport,
-        toolCall: readToolCall({ filePath: "full.txt" }),
-        data: {} as never,
-      }),
-    );
+    const result = unwrap(toolResult);
 
     expect(result.type).toBe("custom-ir");
     if (result.type !== "custom-ir") return;
@@ -131,7 +130,7 @@ describe("read tool", () => {
     });
   });
 
-  it("does not allow edits after only a partial read", async () => {
+  it("does not mark files outdated after only a partial read", async () => {
     const signal = new AbortController().signal;
     const transport = createTransport({
       "/repo/partial-only.txt": "one\ntwo\nthree",
@@ -147,7 +146,9 @@ describe("read tool", () => {
       }),
     );
 
-    await expect(fileTracker.canEdit(transport, signal, "partial-only.txt")).resolves.toBe(false);
+    await expect(fileTracker.isOutdated(transport, signal, "partial-only.txt")).resolves.toBe(
+      false,
+    );
   });
 
   it("keeps edit permission after a later partial read", async () => {
@@ -184,6 +185,8 @@ describe("read tool", () => {
         },
       ],
     });
-    await expect(fileTracker.canEdit(transport, signal, "already-full.txt")).resolves.toBe(true);
+    await expect(fileTracker.isOutdated(transport, signal, "already-full.txt")).resolves.toBe(
+      false,
+    );
   });
 });

--- a/source/tools/tool-defs/rewrite.ts
+++ b/source/tools/tool-defs/rewrite.ts
@@ -1,14 +1,8 @@
 import { t } from "structural";
 import { fileTracker } from "../file-tracker.ts";
-import {
-  attemptUntrackedRead,
-  TOOL,
-  FILE_OUTDATED_ERROR_MESSAGE,
-  fileMutateIR,
-  parseOriginalFile,
-} from "../common.ts";
+import { attemptUntrackedRead, TOOL, fileMutateIR, parseOriginalFile } from "../common.ts";
 import { Transport } from "../../transports/transport-common.ts";
-import { ok, err } from "../../libocto/result.ts";
+import { ok } from "../../libocto/result.ts";
 
 const ArgumentsSchema = t.subtype({
   filePath: t.str.comment("The path to the file"),
@@ -57,8 +51,6 @@ async function validate(
   transport: Transport,
   args: t.GetType<typeof ArgumentsSchema>,
 ) {
-  const canEdit = await fileTracker.canEdit(transport, signal, args.filePath);
-  if (!canEdit) return err(FILE_OUTDATED_ERROR_MESSAGE);
   const file = await attemptUntrackedRead(transport, signal, args.filePath);
   if (!file.success) return file;
   return ok(null);


### PR DESCRIPTION
Minor annoyance we talked about previously: Octo is very picky about forcing up-to-date full-file reads before allowing writes. Other coding agent harnesses don't seem to mind this as much, and e.g. when working with Codex, it's fine if I'm editing a file at the same time as Codex is. This has gotten especially annoying with partial file reads, since partial file reads aren't considered to un-dirty the file (since the change might not make its way into Octo if only part of the file was read).

This changes the file edit tool to allow writes to files that have been modified, and only returns the stale-file error message if the file is outdated *and* the edit can't be applied (e.g. because of a search string mismatch caused by an unseen-to-Octo file change).

Since appends and prepends can't have failed edits due to content changes (they only can fail if the entire file is deleted, which we catch separately), this means appends and prepends no longer check file staleness at all.