### PR TITLE
Add a 'write curl file' alongside the 'copy curl command' option

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -68,6 +68,7 @@ import {
   UNCHAINED_PRIORITY,
 } from "./hooks/use-priority-input.tsx";
 import { readFileSync, writeFileSync } from "fs";
+import os from "os";
 import path from "path";
 import { CwdContext, useCwd } from "./hooks/use-cwd.tsx";
 import { LspToolRenderer } from "./components/lsp-tool-renderer.tsx";
@@ -504,7 +505,6 @@ function RequestErrorScreen({
 }) {
   const config = useConfig();
   const transport = useContext(TransportContext);
-  const cwd = useCwd();
   const themeColor = useColor();
   const { retryFrom, editAndRetryFrom } = useAppStore(
     useShallow(state => ({
@@ -581,7 +581,7 @@ function RequestErrorScreen({
         }
       } else if (item.value === "write-curl") {
         try {
-          const filePath = path.join(cwd, "octo-curl-request.sh");
+          const filePath = path.join(os.tmpdir(), "octo-curl-request.sh");
           writeFileSync(filePath, curlCommand || "Failed to generate cURL command");
           setCurlFilePath(filePath);
           setWroteCurl(true);
@@ -597,7 +597,7 @@ function RequestErrorScreen({
         exit();
       }
     },
-    [curlCommand, cwd, mode, config, transport],
+    [curlCommand, mode, config, transport],
   );
 
   return (

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -67,7 +67,8 @@ import {
   usePriorityInput,
   UNCHAINED_PRIORITY,
 } from "./hooks/use-priority-input.tsx";
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
+import path from "path";
 import { CwdContext, useCwd } from "./hooks/use-cwd.tsx";
 import { LspToolRenderer } from "./components/lsp-tool-renderer.tsx";
 
@@ -503,6 +504,8 @@ function RequestErrorScreen({
 }) {
   const config = useConfig();
   const transport = useContext(TransportContext);
+  const cwd = useCwd();
+  const themeColor = useColor();
   const { retryFrom, editAndRetryFrom } = useAppStore(
     useShallow(state => ({
       retryFrom: state.retryFrom,
@@ -514,8 +517,14 @@ function RequestErrorScreen({
   const [viewError, setViewError] = useState(false);
   const [copiedCurl, setCopiedCurl] = useState(false);
   const [clipboardError, setClipboardError] = useState<string | null>(null);
+  const [wroteCurl, setWroteCurl] = useState(false);
+  const [curlFilePath, setCurlFilePath] = useState<string | null>(null);
+  const [writeError, setWriteError] = useState<string | null>(null);
 
-  const mapping: Record<string, Item<"view" | "copy-curl" | "retry" | "edit-retry" | "quit">> = {};
+  const mapping: Record<
+    string,
+    Item<"view" | "copy-curl" | "write-curl" | "retry" | "edit-retry" | "quit">
+  > = {};
 
   if (!viewError) {
     mapping["v"] = {
@@ -528,6 +537,10 @@ function RequestErrorScreen({
     mapping["c"] = {
       label: copiedCurl ? "Copied cURL!" : "Copy failed request as cURL",
       value: "copy-curl",
+    };
+    mapping["w"] = {
+      label: wroteCurl ? "Wrote cURL to file!" : "Write cURL to file",
+      value: "write-curl",
     };
   }
 
@@ -546,7 +559,9 @@ function RequestErrorScreen({
     value: "quit",
   };
 
-  const shortcutItems: ShortcutArray<"view" | "copy-curl" | "retry" | "edit-retry" | "quit"> = [
+  const shortcutItems: ShortcutArray<
+    "view" | "copy-curl" | "write-curl" | "retry" | "edit-retry" | "quit"
+  > = [
     {
       type: "key" as const,
       mapping,
@@ -554,7 +569,7 @@ function RequestErrorScreen({
   ];
 
   const onSelect = useCallback(
-    (item: Item<"view" | "copy-curl" | "retry" | "edit-retry" | "quit">) => {
+    (item: Item<"view" | "copy-curl" | "write-curl" | "retry" | "edit-retry" | "quit">) => {
       if (item.value === "view") {
         setViewError(true);
       } else if (item.value === "copy-curl") {
@@ -563,6 +578,15 @@ function RequestErrorScreen({
           setCopiedCurl(true);
         } catch (error) {
           setClipboardError(error instanceof Error ? error.message : "Failed to copy to clipboard");
+        }
+      } else if (item.value === "write-curl") {
+        try {
+          const filePath = path.join(cwd, "octo-curl-request.sh");
+          writeFileSync(filePath, curlCommand || "Failed to generate cURL command");
+          setCurlFilePath(filePath);
+          setWroteCurl(true);
+        } catch (error) {
+          setWriteError(error instanceof Error ? error.message : "Failed to write cURL to file");
         }
       } else if (item.value === "retry") {
         retryFrom(mode, { config, transport });
@@ -573,7 +597,7 @@ function RequestErrorScreen({
         exit();
       }
     },
-    [curlCommand, mode, config, transport],
+    [curlCommand, cwd, mode, config, transport],
   );
 
   return (
@@ -592,6 +616,18 @@ function RequestErrorScreen({
       {clipboardError && (
         <Box marginY={1}>
           <Text color="red">{clipboardError}</Text>
+        </Box>
+      )}
+      {wroteCurl && curlFilePath && (
+        <Box marginY={1}>
+          <Text>
+            Wrote cURL to <Text color={themeColor}>{curlFilePath}</Text>
+          </Text>
+        </Box>
+      )}
+      {writeError && (
+        <Box marginY={1}>
+          <Text color="red">{writeError}</Text>
         </Box>
       )}
     </KbShortcutPanel>


### PR DESCRIPTION
I can't use terminal clipboards since I ssh into a devserver. (I actually use a workaround so I *can* clipboard from my devserver to my macbook, but it doesn't use what octo uses (`xsel`), which requires X server forwarding to be set up :P)

This PR is a small proposal to add a "write curl file" option on errors.

Tested locally:
<img width="2914" height="436" alt="CleanShot 2026-06-30 at 21 59 53@2x" src="https://github.com/user-attachments/assets/974d37f9-d5f7-4dbb-8e9c-707bb1c01354" />
<img width="2914" height="518" alt="CleanShot 2026-06-30 at 22 03 36@2x" src="https://github.com/user-attachments/assets/ea3454fd-b8f6-4e04-9553-7e79090a2796" />