### PR TITLE
Fix newlines getting inserted after selecting 'No'

### DIFF
--- a/source/components/selection/select-input.test.tsx
+++ b/source/components/selection/select-input.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+import { withMock } from "antipattern";
+import type { PaintKeyboardEvent } from "paintcannon";
+import { keyboardDeps } from "../../hooks/use-keyboard.ts";
+import SelectInput from "./select-input.tsx";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+describe("SelectInput", () => {
+  it("prevents the default Enter action when selecting an item", async () => {
+    let keyboardHandler: ((event: PaintKeyboardEvent) => void) | undefined;
+    const useKeyboard = vi.fn(
+      (callback: (event: PaintKeyboardEvent) => void, _isActive?: boolean) => {
+        keyboardHandler = callback;
+      },
+    );
+    const onSelect = vi.fn();
+    const preventDefault = vi.fn();
+
+    await withMock(keyboardDeps, "useKeyboard", useKeyboard, async () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      act(() => {
+        renderer = TestRenderer.create(
+          <SelectInput
+            items={[
+              { label: "Yes", value: "yes" },
+              { label: "No", value: "no" },
+            ]}
+            initialIndex={1}
+            onSelect={onSelect}
+          />,
+        );
+      });
+
+      act(() => {
+        keyboardHandler?.({
+          key: "Enter",
+          preventDefault,
+        } as unknown as PaintKeyboardEvent);
+      });
+
+      expect(preventDefault).toHaveBeenCalledOnce();
+      expect(onSelect).toHaveBeenCalledWith({ label: "No", value: "no" });
+      act(() => renderer!.unmount());
+    });
+  });
+});

--- a/source/components/selection/select-input.tsx
+++ b/source/components/selection/select-input.tsx
@@ -92,6 +92,7 @@ function SelectInput<V>({
     useCallback(
       event => {
         if (event.key === "k" || event.key === "ArrowUp") {
+          event.preventDefault();
           const lastIndex = (hasLimit ? limit : items.length) - 1;
           const atFirstIndex = selectedIndex === 0;
           const nextIndex = hasLimit ? selectedIndex : lastIndex;
@@ -107,6 +108,7 @@ function SelectInput<V>({
           }
         }
         if (event.key === "j" || event.key === "ArrowDown") {
+          event.preventDefault();
           const atLastIndex = selectedIndex === (hasLimit ? limit : items.length) - 1;
           const nextIndex = hasLimit ? selectedIndex : 0;
           const nextRotateIndex = atLastIndex ? rotateIndex - 1 : rotateIndex;
@@ -128,6 +130,7 @@ function SelectInput<V>({
             ? arrayToRotated(items, rotateIndex).slice(0, limit)
             : items;
           if (targetIndex >= 0 && targetIndex < visibleItems.length) {
+            event.preventDefault();
             const selectedItem = visibleItems[targetIndex];
             if (selectedItem) {
               onSelect?.(selectedItem);
@@ -135,6 +138,7 @@ function SelectInput<V>({
           }
         }
         if (event.key === "Enter") {
+          event.preventDefault();
           const slicedItems = hasLimit ? arrayToRotated(items, rotateIndex).slice(0, limit) : items;
           if (typeof onSelect === "function") {
             onSelect(slicedItems[selectedIndex]!);

--- a/source/hooks/use-keyboard.ts
+++ b/source/hooks/use-keyboard.ts
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import type { PaintKeyboardEvent } from "paintcannon";
 import { Div } from "paintcannon-react";
+import { registry } from "antipattern";
 
 type KeyboardListener = (event: PaintKeyboardEvent) => void;
 type KeyboardContextValue = {
@@ -39,7 +40,7 @@ export function KeyboardProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function useKeyboard(callback: (event: PaintKeyboardEvent) => void, isActive = true): void {
+function useKeyboardImpl(callback: (event: PaintKeyboardEvent) => void, isActive = true): void {
   const context = useContext(KeyboardContext);
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
@@ -53,4 +54,12 @@ export function useKeyboard(callback: (event: PaintKeyboardEvent) => void, isAct
     };
     return context.register(handleKeyDown);
   }, [context, isActive]);
+}
+
+export const keyboardDeps = registry({
+  useKeyboard: useKeyboardImpl,
+});
+
+export function useKeyboard(callback: (event: PaintKeyboardEvent) => void, isActive = true): void {
+  keyboardDeps.useKeyboard(callback, isActive);
 }


### PR DESCRIPTION
Post-Paintcannon-port, when you selected "No" in collaboration mode and hit Enter, it would:

1.  Select No (correctly)
2. Insert a newline in the input box (not correct)

This fixes that (and other possible similar bugs) by calling `event.preventDefault()` on the selection event handlers.