### PR TITLE
Fix horizontal scrollbars sometimes appearing

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -325,6 +325,7 @@ export default function App({
                               flexDirection: "column",
                               minHeight: "100%",
                               flexShrink: 0,
+                              overflowWrap: "anywhere",
                             }}
                           >
                             <TerminalFlex


### PR DESCRIPTION
Artifact of the Paintcannon port: a native terminal emulator will simply wrap text when it exceeds the width of the terminal. Paintcannon, like a browser, will present horizontal scrollbars. However, we generally want Octo's own app-like content to wrap, rather than generating horizontal scroll, so we set a transcript-level `overflowWrap: anywhere` to preserve terminal-like wrap behavior at the app level.