### PR TITLE
Simpler enter scrolling

### DIFF
--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -3,7 +3,6 @@ import type { PaintFile, TextAreaElement } from "paintcannon";
 import { Div, Span, Textarea, useApp } from "paintcannon-react";
 import { useVimKeyHandler } from "./vim-mode.tsx";
 import { ImageInfo } from "../utils/image-utils.ts";
-import { useScrollTranscriptToBottom } from "../transcript-scroll.ts";
 
 function getImageBadgeText(index: number): string {
   return `⟦ 📎 Image Attachment #${index + 1} ⟧`;
@@ -51,7 +50,6 @@ export default function TextInput({
   const { paintCannon } = useApp();
   const textareaRef = useRef<TextAreaElement>(null);
   const vimHandler = useVimKeyHandler(vimMode, setVimMode ?? (() => {}));
-  const scrollTranscriptToBottom = useScrollTranscriptToBottom();
 
   useEffect(() => {
     if (focus) textareaRef.current?.focus();
@@ -117,14 +115,7 @@ export default function TextInput({
           }
         }}
         onKeyDown={event => {
-          const hasModifier = event.ctrlKey || event.altKey || event.metaKey || event.shiftKey;
-          const scrolledTranscript =
-            (event.key === "Enter" || !hasModifier) && scrollTranscriptToBottom();
-          if (event.key === "Enter" && scrolledTranscript) {
-            event.preventDefault();
-            event.stopPropagation();
-            return;
-          }
+          if (event.key === "Enter") event.stopPropagation();
 
           const textarea = textareaRef.current;
           if (!textarea) return;


### PR DESCRIPTION
I found the behavior in #229 a little too annoying in practice; often I wanted to scroll back in history and type while looking at older messages. And since the input box is always visible even when you've scrolled back, I think it's reasonable to allow that. This makes the enter-means-scroll not true for the input box, and removes the scroll-on-typing from the input box. It keeps the default enter-means-scroll stuff though to prevent accidental accepts of permissions.