### PR TITLE
Move current model name into input box

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -125,7 +125,6 @@ type TranscriptItem =
   | {
       type: "version";
       metadata: Metadata;
-      config: Config;
     }
   | {
       type: "updates";
@@ -278,7 +277,6 @@ export default function App({
       {
         type: "version" as const,
         metadata,
-        config: currConfig,
       },
       ...skillNotifs.map(s => ({
         type: "boot-notification" as const,
@@ -294,7 +292,7 @@ export default function App({
         : []),
     ];
     return items;
-  }, [currConfig, skillNotifs, updates]);
+  }, [metadata, skillNotifs, updates]);
   const inflightResponse =
     modeData.mode === "responding" || modeData.mode === "compacting"
       ? modeData.inflightResponse
@@ -754,9 +752,16 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
       <TerminalFlex
         style={{
           marginLeft: 1,
-          justifyContent: "flex-end",
+          justifyContent: "space-between",
         }}
       >
+        <Span
+          style={{
+            color: "gray",
+          }}
+        >
+          Model: {model.nickname}
+        </Span>
         <Span
           style={{
             color: "gray",
@@ -1523,7 +1528,6 @@ function ToolRequestRenderer({
 }
 const TranscriptItemRenderer = ({ item }: { item: TranscriptItem }) => {
   const themeColor = useColor();
-  const model = useModel();
   const unchained = useUnchained();
   if (item.type === "header") return <Header unchained={unchained} />;
   if (item.type === "version") {
@@ -1535,13 +1539,6 @@ const TranscriptItemRenderer = ({ item }: { item: TranscriptItem }) => {
           alignItems: "center",
         }}
       >
-        <Span
-          style={{
-            color: "gray",
-          }}
-        >
-          Model: {model.nickname}
-        </Span>
         <Span
           style={{
             color: "gray",


### PR DESCRIPTION
Helps remind me which model I'm actually using currently, which is especially helpful with session resume.

<img width="3840" height="586" alt="image" src="https://github.com/user-attachments/assets/2deb28a9-2e25-4a7a-9501-3245a3814972" />

On boot:

<img width="3840" height="2096" alt="image" src="https://github.com/user-attachments/assets/4c42c4fc-7fae-4a59-b5df-c2a25cefc449" />

Previously it showed it in the splash screen, which was especially weird since now that we're using Paintcannon, all the historical items are able to auto-update, and so the splash itself would update as you changed models even though it looked historical! It seems more useful to have the auto-updating thing in the input box, which is also where most other CLI agents put it.