### PR TITLE
Fix aborted tool calls for Responses API

### DIFF
--- a/source/libocto/compilers/responses.ts
+++ b/source/libocto/compilers/responses.ts
@@ -130,6 +130,13 @@ async function toResponseInput<A extends Agent<any, any, any>>(
     items.push(...responseInputFromIr(ir, modalities));
   }
 
+  /*
+   * The OpenAI Responses API mandates that all function calls *must* have function call outputs
+   * associated with them on requests, unlike other APIs which allow you to simply leave them out if
+   * you want to (e.g. if you didn't run them). To normalize this behavior, we insert "Aborted"
+   * function call outputs that are synthesized if the LLMIR has no tool output for the tool call;
+   * this can happen e.g. if Octo crashed.
+   */
   const answeredCalls = new Set<string>();
   for (const item of items) {
     if (item.type === "function_call_output") answeredCalls.add(item.call_id);

--- a/source/libocto/compilers/responses.ts
+++ b/source/libocto/compilers/responses.ts
@@ -125,10 +125,22 @@ async function toResponseInput<A extends Agent<any, any, any>>(
   messages: Array<CompilerIR<A>>,
   modalities?: CompilerModalities,
 ): Promise<ResponseInput> {
-  const output: ResponseInput = [];
-
+  const items: ResponseInput = [];
   for (const ir of messages) {
-    output.push(...responseInputFromIr(ir, modalities));
+    items.push(...responseInputFromIr(ir, modalities));
+  }
+
+  const answeredCalls = new Set<string>();
+  for (const item of items) {
+    if (item.type === "function_call_output") answeredCalls.add(item.call_id);
+  }
+
+  const output: ResponseInput = [];
+  for (const item of items) {
+    output.push(item);
+    if (item.type === "function_call" && !answeredCalls.has(item.call_id)) {
+      output.push({ type: "function_call_output", call_id: item.call_id, output: "Aborted" });
+    }
   }
 
   return output;


### PR DESCRIPTION
Minor but annoying bug with session resume: if Octo crashes mid-tool-call, and you resume Octo later, it will perma-break OpenAI models using the Responses compiler. OpenAI expects *all* function calls to have function output, even if the output is just e.g. "Aborted." However, if Octo crashed and never generated a response, on resume we'll still have the same assistant requests stored in the DB, but we'll never insert function call outputs indicating that we didn't run the function.

Chat completions are generally a looser API: it's alright to not have a response to a function call. But apparently this isn't okay in the Responses API.

The ideal fix IMO is that we should resume any attempted function calls on session resume. But for now, this patches the perma-break for OpenAI models by auto-inserting "Aborted" function call outputs in the Responses compiler for any function calls that lack output.

Tested on a perma-broken session with GPT-5.6-Sol, and this unbroke the session.