### PR TITLE
Improve grep tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react": "^19.2.6",
         "shell-quote": "^1.8.3",
         "string-width": "^7.2.0",
-        "structural": "^0.0.29",
+        "structural": "^0.0.33",
         "to-rotated": "^1.0.0",
         "vscode-languageserver-types": "^3.17.5",
         "which": "^6.0.1",
@@ -5633,9 +5633,9 @@
       }
     },
     "node_modules/structural": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/structural/-/structural-0.0.29.tgz",
-      "integrity": "sha512-WwzhBo6xONxeRt4rZAr2DmVgRWOmzRKE6JsuFV7ysEKT0GlftXWu5eGwwx8l3UpVfvIoJoJBmUGcRZbJIOS/KA==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/structural/-/structural-0.0.33.tgz",
+      "integrity": "sha512-RrdPEmJauuwLR6MP4QU2THPVrMnBbSEkqE1FV2uBPLPCG/0jhaia4+KKyU9z4BHe8FD6yiz1bYvQ+fq7KPSpIg==",
       "license": "MIT"
     },
     "node_modules/system-architecture": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react": "^19.2.6",
         "shell-quote": "^1.8.3",
         "string-width": "^7.2.0",
-        "structural": "^0.0.33",
+        "structural": "^0.0.34",
         "to-rotated": "^1.0.0",
         "vscode-languageserver-types": "^3.17.5",
         "which": "^6.0.1",
@@ -5633,9 +5633,9 @@
       }
     },
     "node_modules/structural": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/structural/-/structural-0.0.33.tgz",
-      "integrity": "sha512-RrdPEmJauuwLR6MP4QU2THPVrMnBbSEkqE1FV2uBPLPCG/0jhaia4+KKyU9z4BHe8FD6yiz1bYvQ+fq7KPSpIg==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/structural/-/structural-0.0.34.tgz",
+      "integrity": "sha512-VB6Lva0m6csfJpiEw7iBgzSEcqQwOHtlXV1xH4v/x1GlUmB/XAaF9WPcAd+rIlX3O7OrPyU7Ar1w9t/65pDH7w==",
       "license": "MIT"
     },
     "node_modules/system-architecture": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react": "^19.2.6",
         "shell-quote": "^1.8.3",
         "string-width": "^7.2.0",
-        "structural": "^0.0.34",
+        "structural": "^0.0.35",
         "to-rotated": "^1.0.0",
         "vscode-languageserver-types": "^3.17.5",
         "which": "^6.0.1",
@@ -75,6 +75,15 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "../structural": {
+      "version": "0.0.35",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.10",
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -5633,10 +5642,8 @@
       }
     },
     "node_modules/structural": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/structural/-/structural-0.0.34.tgz",
-      "integrity": "sha512-VB6Lva0m6csfJpiEw7iBgzSEcqQwOHtlXV1xH4v/x1GlUmB/XAaF9WPcAd+rIlX3O7OrPyU7Ar1w9t/65pDH7w==",
-      "license": "MIT"
+      "resolved": "../structural",
+      "link": true
     },
     "node_modules/system-architecture": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react": "^19.2.6",
         "shell-quote": "^1.8.3",
         "string-width": "^7.2.0",
-        "structural": "^0.0.35",
+        "structural": "^0.0.34",
         "to-rotated": "^1.0.0",
         "vscode-languageserver-types": "^3.17.5",
         "which": "^6.0.1",
@@ -75,15 +75,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "../structural": {
-      "version": "0.0.35",
-      "license": "MIT",
-      "devDependencies": {
-        "@vitest/coverage-v8": "^4.1.10",
-        "typescript": "^7.0.2",
-        "vitest": "^4.1.10"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -5642,8 +5633,10 @@
       }
     },
     "node_modules/structural": {
-      "resolved": "../structural",
-      "link": true
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/structural/-/structural-0.0.34.tgz",
+      "integrity": "sha512-VB6Lva0m6csfJpiEw7iBgzSEcqQwOHtlXV1xH4v/x1GlUmB/XAaF9WPcAd+rIlX3O7OrPyU7Ar1w9t/65pDH7w==",
+      "license": "MIT"
     },
     "node_modules/system-architecture": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react": "^19.2.6",
         "shell-quote": "^1.8.3",
         "string-width": "^7.2.0",
-        "structural": "^0.0.34",
+        "structural": "^0.0.35",
         "to-rotated": "^1.0.0",
         "vscode-languageserver-types": "^3.17.5",
         "which": "^6.0.1",
@@ -5633,9 +5633,9 @@
       }
     },
     "node_modules/structural": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/structural/-/structural-0.0.34.tgz",
-      "integrity": "sha512-VB6Lva0m6csfJpiEw7iBgzSEcqQwOHtlXV1xH4v/x1GlUmB/XAaF9WPcAd+rIlX3O7OrPyU7Ar1w9t/65pDH7w==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/structural/-/structural-0.0.35.tgz",
+      "integrity": "sha512-eazlMYWcyFqqAumbZBMdunA9jCJp7BgTXxkepGqxj3eOxd83+as+xKlaGg9zNOJ7jhWPh/ny6vo/0/TwtAi9Zg==",
       "license": "MIT"
     },
     "node_modules/system-architecture": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react": "^19.2.6",
         "shell-quote": "^1.8.3",
         "string-width": "^7.2.0",
-        "structural": "^0.0.35",
+        "structural": "^0.0.36",
         "to-rotated": "^1.0.0",
         "vscode-languageserver-types": "^3.17.5",
         "which": "^6.0.1",
@@ -5633,9 +5633,9 @@
       }
     },
     "node_modules/structural": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/structural/-/structural-0.0.35.tgz",
-      "integrity": "sha512-eazlMYWcyFqqAumbZBMdunA9jCJp7BgTXxkepGqxj3eOxd83+as+xKlaGg9zNOJ7jhWPh/ny6vo/0/TwtAi9Zg==",
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/structural/-/structural-0.0.36.tgz",
+      "integrity": "sha512-mS/dBKu3cadTF9QHyk9nS10bjI2oQSMFcu9B9xyQM3dGq9Sqji5RBdvJkSeL1sTPsE9cz6eNrBgaVUz17RJ0vw==",
       "license": "MIT"
     },
     "node_modules/system-architecture": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "^19.2.6",
     "shell-quote": "^1.8.3",
     "string-width": "^7.2.0",
-    "structural": "^0.0.33",
+    "structural": "^0.0.34",
     "to-rotated": "^1.0.0",
     "vscode-languageserver-types": "^3.17.5",
     "which": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "^19.2.6",
     "shell-quote": "^1.8.3",
     "string-width": "^7.2.0",
-    "structural": "^0.0.35",
+    "structural": "^0.0.34",
     "to-rotated": "^1.0.0",
     "vscode-languageserver-types": "^3.17.5",
     "which": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "^19.2.6",
     "shell-quote": "^1.8.3",
     "string-width": "^7.2.0",
-    "structural": "^0.0.34",
+    "structural": "^0.0.35",
     "to-rotated": "^1.0.0",
     "vscode-languageserver-types": "^3.17.5",
     "which": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "^19.2.6",
     "shell-quote": "^1.8.3",
     "string-width": "^7.2.0",
-    "structural": "^0.0.35",
+    "structural": "^0.0.36",
     "to-rotated": "^1.0.0",
     "vscode-languageserver-types": "^3.17.5",
     "which": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "^19.2.6",
     "shell-quote": "^1.8.3",
     "string-width": "^7.2.0",
-    "structural": "^0.0.29",
+    "structural": "^0.0.33",
     "to-rotated": "^1.0.0",
     "vscode-languageserver-types": "^3.17.5",
     "which": "^6.0.1",

--- a/source/tools/tool-defs/grep.ts
+++ b/source/tools/tool-defs/grep.ts
@@ -9,20 +9,18 @@ import { ok, err, toErrString } from "../../libocto/result.ts";
 export default TOOL.declare({
   name: "grep",
   description: "Searches file contents using grep. Prefer this to shelling out to `grep` directly.",
-  ArgumentsSchema: t.partial(
-    t.subtype({
-      pattern: t.str.comment(
-        "The search pattern. Internally uses grep with the -E flag (extended regex).",
-      ),
-      path: t.str.comment(
-        "Directory or file to search in. Defaults to the current working directory.",
-      ),
-      caseInsensitive: t.bool.comment("Case-insensitive search"),
-      context: t.num.comment("Number of context lines around each match"),
-      maxResults: t.num.comment("Max number of results to return"),
-      timeout: t.num.comment("Timeout in milliseconds (defaults to 30000)"),
-    }),
-  ),
+  ArgumentsSchema: t.subtype({
+    pattern: t.str.comment(
+      "The search pattern. Internally uses grep with the -E flag (extended regex).",
+    ),
+    path: t.optional(
+      t.str.comment("Directory or file to search in. Defaults to the current working directory."),
+    ),
+    caseInsensitive: t.optional(t.bool.comment("Case-insensitive search")),
+    context: t.optional(t.num.comment("Number of context lines around each match")),
+    maxResults: t.optional(t.num.comment("Max number of results to return")),
+    timeout: t.optional(t.num.comment("Timeout in milliseconds (defaults to 30000)")),
+  }),
 }).define(async () => ({
   async run({ signal, transport, toolCall, data }) {
     const search = toolCall.parsed.arguments;


### PR DESCRIPTION
I've noticed that GLM-5.2 often forgets to include a `pattern` for grep, and then subsequently gets annoyed by using the tool and swaps to shelling out to literal Unix `grep` via the `shell` tool. This is annoying, because the point of the `grep` tool is to avoid permissions prompts for safe grep usage in collaboration mode; using grep via `shell` always triggers permissions prompts in collaboration mode.

This makes the `pattern` field required for the grep tool. GLM-5.2 always uses it when it's required and seems to never forget. (And if it did forget, Structural would give a helpful error.)

This PR also updates Structural to the latest version, which includes much-improved error rendering. This should help LLMs recover from messed up tool calls more reliably (like `grep`), and also should help users who previously encountered inscrutable errors from accidentally-broken configs.