### PR TITLE
Fix input suggestion box

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -1519,6 +1519,8 @@ function ToolRequestRenderer({
         items={items}
         onSelect={onSelect}
         onKeyDown={event => {
+          // If you're scrolled offscreen during the permission prompt rendering, Enter should not
+          // accept the permission request, and should instead scroll to the bottom
           if (event.key === "Enter" && scrollTranscriptToBottomIfNeeded()) {
             event.preventDefault();
           }

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -94,7 +94,10 @@ import { HistoryNode } from "./session-history/index.ts";
 import { Span, useAnimation, useApp } from "paintcannon-react";
 import { useKeyboard } from "./hooks/use-keyboard.ts";
 import { TerminalFlex } from "./components/terminal-flex.tsx";
-import { ScrollTranscriptToBottomContext } from "./transcript-scroll.ts";
+import {
+  ScrollTranscriptToBottomContext,
+  useScrollTranscriptToBottom,
+} from "./transcript-scroll.ts";
 type LoadedToolFrom<T extends (...args: any) => any> = Exclude<Awaited<ReturnType<T>>, null>;
 type ParsedToolSchemaFrom<T extends (...args: any) => any> = {
   name: LoadedToolFrom<T>["name"];
@@ -342,12 +345,6 @@ export default function App({
                     <CwdContext.Provider value={cwd}>
                       <ExitOnDoubleCtrlC>
                         <TerminalFlex
-                          onKeyDown={event => {
-                            if (event.key === "Enter" && scrollTranscriptToBottomIfNeeded()) {
-                              event.preventDefault();
-                              event.stopPropagation();
-                            }
-                          }}
                           style={{
                             flexDirection: "column",
                             width: "100%",
@@ -1316,6 +1313,7 @@ function ToolRequestRenderer({
   onContentLayout: () => void;
 } & RunArgs) {
   const themeColor = useColor();
+  const scrollTranscriptToBottomIfNeeded = useScrollTranscriptToBottom();
   const { runTool, rejectTool, isWhitelisted, addToWhitelist, notifyReadyForInput } = useAppStore(
     useShallow(state => ({
       runTool: state.runTool,
@@ -1520,6 +1518,11 @@ function ToolRequestRenderer({
       <SelectInput
         items={items}
         onSelect={onSelect}
+        onKeyDown={event => {
+          if (event.key === "Enter" && scrollTranscriptToBottomIfNeeded()) {
+            event.preventDefault();
+          }
+        }}
         indicatorComponent={IndicatorComponent}
         itemComponent={ToolRequestItem}
       />

--- a/source/components/input-with-history.tsx
+++ b/source/components/input-with-history.tsx
@@ -175,6 +175,9 @@ export const InputWithHistory = (props: Props) => {
           onRemoveLastImage={props.onRemoveLastImage}
           onImageFilesAttached={props.onImageFilesAttached}
           onSubmit={handleSubmit}
+          onKeyDown={event => {
+            if (event.key === "Enter" && suggestionState?.isVisible) event.preventDefault();
+          }}
           vimEnabled={props.vimEnabled}
           vimMode={props.vimMode}
           setVimMode={props.setVimMode}

--- a/source/components/input-with-history.tsx
+++ b/source/components/input-with-history.tsx
@@ -176,6 +176,7 @@ export const InputWithHistory = (props: Props) => {
           onImageFilesAttached={props.onImageFilesAttached}
           onSubmit={handleSubmit}
           onKeyDown={event => {
+            // Prevent literal newlines from being inserted when accepting suggestions
             if (event.key === "Enter" && suggestionState?.isVisible) event.preventDefault();
           }}
           vimEnabled={props.vimEnabled}

--- a/source/components/selection/select-input.tsx
+++ b/source/components/selection/select-input.tsx
@@ -1,5 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
 import React, { type FC, useState, useEffect, useRef, useCallback } from "react";
+import type { PaintKeyboardEvent } from "paintcannon";
 import arrayToRotated from "to-rotated";
 import Indicator, { type Props as IndicatorProps } from "./select-indicator.tsx";
 import ItemComponent, { type Props as ItemProps } from "./select-item.tsx";
@@ -50,6 +51,8 @@ type Props<V> = {
    * Function to call when user highlights an item. Item object is passed to that function as an argument.
    */
   readonly onHighlight?: (item: Item<V>) => void;
+
+  readonly onKeyDown?: (event: PaintKeyboardEvent) => void;
 };
 export type Item<V> = {
   key?: string;
@@ -65,6 +68,7 @@ function SelectInput<V>({
   limit: customLimit,
   onSelect,
   onHighlight,
+  onKeyDown,
 }: Props<V>) {
   const hasLimit = typeof customLimit === "number" && items.length > customLimit;
   const limit = hasLimit ? Math.min(customLimit, items.length) : items.length;
@@ -91,6 +95,9 @@ function SelectInput<V>({
   useKeyboard(
     useCallback(
       event => {
+        onKeyDown?.(event);
+        if (event.defaultPrevented) return;
+
         if (event.key === "k" || event.key === "ArrowUp") {
           event.preventDefault();
           const lastIndex = (hasLimit ? limit : items.length) - 1;
@@ -145,7 +152,7 @@ function SelectInput<V>({
           }
         }
       },
-      [hasLimit, limit, rotateIndex, selectedIndex, items, onSelect, onHighlight],
+      [hasLimit, limit, rotateIndex, selectedIndex, items, onSelect, onHighlight, onKeyDown],
     ),
     isFocused,
   );

--- a/source/components/text-input.tsx
+++ b/source/components/text-input.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from "react";
-import type { PaintFile, TextAreaElement } from "paintcannon";
+import type { PaintFile, PaintKeyboardEvent, TextAreaElement } from "paintcannon";
 import { Div, Span, Textarea, useApp } from "paintcannon-react";
 import { useVimKeyHandler } from "./vim-mode.tsx";
 import { ImageInfo } from "../utils/image-utils.ts";
@@ -23,6 +23,7 @@ type Props = {
   readonly setVimMode?: (mode: "NORMAL" | "INSERT") => void;
   readonly attachedImages?: ImageInfo[];
   readonly onRemoveLastImage?: () => unknown;
+  readonly onKeyDown?: (event: PaintKeyboardEvent) => void;
 };
 
 function characterIndexToStringIndex(value: string, characterIndex: number): number {
@@ -46,6 +47,7 @@ export default function TextInput({
   vimEnabled = false,
   vimMode = "NORMAL",
   setVimMode,
+  onKeyDown,
 }: Props) {
   const { paintCannon } = useApp();
   const textareaRef = useRef<TextAreaElement>(null);
@@ -115,7 +117,8 @@ export default function TextInput({
           }
         }}
         onKeyDown={event => {
-          if (event.key === "Enter") event.stopPropagation();
+          onKeyDown?.(event);
+          if (event.defaultPrevented) return;
 
           const textarea = textareaRef.current;
           if (!textarea) return;


### PR DESCRIPTION
Previously during the Paintcannon port I made Enter do a bunch of complex scrolling stuff, to prevent it from accidentally accepting perms when you're scrolled offscreen (some native terminals, and tmux, already prevent this when using native non-alt-screen rendering). Slowly I pared back each of the scrolling things it did because I ended up finding "always scroll to the bottom when you press enter or type" to be *very* annoying, and now it's scoped just to the permissions prompt: if you can't see it, pressing enter scrolls down until you can see it instead of accepting the permissions request.

Anyway, at some point all of this broke the input @-suggestion box, where it would end up having enter ignored.

This fixes that, and also refactors enter handling to be much more sane now that the only behavior left that is non-annoying is "If you press Enter while the permissions prompt is open, and you're scrolled up away from the perms prompt, scroll down instead of accepting the perms request."