### PR TITLE
Fix list spacing discrepancy

### DIFF
--- a/source/markdown/index.tsx
+++ b/source/markdown/index.tsx
@@ -303,6 +303,7 @@ function ListRenderer({ token }: { token: Tokens.List }) {
           <Span
             style={{
               color: MARKDOWN_LIST_MARKER_COLOR,
+              flexShrink: 0,
             }}
           >
             {token.ordered


### PR DESCRIPTION
Before
<img width="55" height="70" alt="Screenshot 2026-07-21 at 6 41 23 PM" src="https://github.com/user-attachments/assets/b16ff72d-244a-420f-86bf-b9e8c5bdece9" />

After
<img width="103" height="78" alt="Screenshot 2026-07-21 at 6 41 57 PM" src="https://github.com/user-attachments/assets/e83a3601-e280-43b3-b39c-e900503d8af7" />

Ink / Yoga's [default flexShrink is 0](https://github.com/react/yoga/blob/main/yoga/style/Style.h#L46) which was why this wasn't a problem before.
Was wondering whether Paintcannon should also have its default `flexShrink` set to `0`, but noticed that the default for `flexShrink` for **web** in Yoga is actually `1`. Since Paintcannon aims to be as close to regular CSS as possible, we should keep the default as `1`.