### PR TITLE
Web search context + perms improvements

### DIFF
--- a/source/tools/index.ts
+++ b/source/tools/index.ts
@@ -40,6 +40,7 @@ export const SKIP_CONFIRMATION_TOOLS: Array<keyof LoadedTools> = [
   "list",
   "skill",
   "web-search",
+  "fetch",
   "glob",
   "grep",
   "lsp-definition",

--- a/source/tools/tool-defs/web-search.ts
+++ b/source/tools/tool-defs/web-search.ts
@@ -8,7 +8,7 @@ const SearchResultsSchema = t.subtype({
     t.subtype({
       url: t.str,
       title: t.optional(t.str.or(t.nil)),
-      text: t.str,
+      highlights: t.array(t.str),
       published: t.optional(t.str.or(t.nil)),
     }),
   ),


### PR DESCRIPTION
This does two things:

1. Uses the `highlights` returned from Synthetic's web search API instead of the full text results, in order to conserve context space. Previously, web searches used massive context space and frequently just a couple would trigger autocompaction, since they read the full text of the result instead of the highlights.
2. Makes `fetch` not require perms in collaboration mode again. This mirrors how Codex + Codex CLI + Anthropic's Claude web UI all do web fetch permissions. We previously made it require perms due to theoretical prompt injection risk from `web-search`, where technically a web search could contain a poisoned instruction that tells the LLM to do a fetch to a specific attacked-controlled URL, and leak data via the `fetch`. However: 1) this is unlikely, and hard to keep secret, since it has to poison Exa's own search results, and would be poisoned for everyone since there's nothing we send that would allow the attacker to determine the user requesting it. 2) Making fetch require permissions is extremely annoying, especially when web search only returns highlighted context instead of full text, meaning a `web-search` almost always is followed by an actual `fetch` to read the correct page. Since other clients don't gate this, I don't think we should either; if you're working in an extremely security sensitive domain where someone might be publicly attacking you by poisoning Exa's web search index, you should probably use a different, more hardened tool than Octo (or Codex).

<img width="2858" height="1320" alt="image" src="https://github.com/user-attachments/assets/c1278d7d-28d8-47e0-baeb-d5f947ff0630" />
