### PR TITLE
Add "octo session list" command

### DIFF
--- a/drizzle/0005_clean_red_shift.sql
+++ b/drizzle/0005_clean_red_shift.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `previews` (
+	`session_id` text PRIMARY KEY NOT NULL,
+	`preview` text,
+	`preview_type` text NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`session_id`) REFERENCES `trees`(`name`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `trees_cwd_updated_at_idx` ON `trees` (`cwd`,"updated_at" DESC);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,644 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "46aede74-e940-46f0-a10e-109e7a270dd9",
+  "prevId": "92716ac2-9f17-4c38-a0c1-bf5c303a65c4",
+  "tables": {
+    "input_history": {
+      "name": "input_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "compaction_failed_items": {
+      "name": "compaction_failed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "docker_launches": {
+      "name": "docker_launches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "container_target": {
+          "name": "container_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "docker_run_args_json": {
+          "name": "docker_run_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unchained": {
+          "name": "unchained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "docker_launches_kind_args_check": {
+          "name": "docker_launches_kind_args_check",
+          "value": "(\"docker_launches\".\"kind\" = 'connect' AND \"docker_launches\".\"container_target\" IS NOT NULL AND \"docker_launches\".\"docker_run_args_json\" IS NULL)\n        OR (\"docker_launches\".\"kind\" = 'run' AND \"docker_launches\".\"container_target\" IS NULL AND \"docker_launches\".\"docker_run_args_json\" IS NOT NULL)"
+        }
+      }
+    },
+    "history_items": {
+      "name": "history_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_failed_id": {
+          "name": "request_failed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction_failed_id": {
+          "name": "compaction_failed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "llm_ir_id": {
+          "name": "llm_ir_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "history_items_requestFailedId_unique": {
+          "name": "history_items_requestFailedId_unique",
+          "columns": ["request_failed_id"],
+          "isUnique": true
+        },
+        "history_items_compactionFailedId_unique": {
+          "name": "history_items_compactionFailedId_unique",
+          "columns": ["compaction_failed_id"],
+          "isUnique": true
+        },
+        "history_items_notificationId_unique": {
+          "name": "history_items_notificationId_unique",
+          "columns": ["notification_id"],
+          "isUnique": true
+        },
+        "history_items_llmIrId_unique": {
+          "name": "history_items_llmIrId_unique",
+          "columns": ["llm_ir_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "history_items_request_failed_id_request_failed_items_id_fk": {
+          "name": "history_items_request_failed_id_request_failed_items_id_fk",
+          "tableFrom": "history_items",
+          "tableTo": "request_failed_items",
+          "columnsFrom": ["request_failed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "history_items_compaction_failed_id_compaction_failed_items_id_fk": {
+          "name": "history_items_compaction_failed_id_compaction_failed_items_id_fk",
+          "tableFrom": "history_items",
+          "tableTo": "compaction_failed_items",
+          "columnsFrom": ["compaction_failed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "history_items_notification_id_notifications_id_fk": {
+          "name": "history_items_notification_id_notifications_id_fk",
+          "tableFrom": "history_items",
+          "tableTo": "notifications",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "history_items_llm_ir_id_llm_irs_id_fk": {
+          "name": "history_items_llm_ir_id_llm_irs_id_fk",
+          "tableFrom": "history_items",
+          "tableTo": "llm_irs",
+          "columnsFrom": ["llm_ir_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "history_items_exactly_one_payload_check": {
+          "name": "history_items_exactly_one_payload_check",
+          "value": "(\"history_items\".\"request_failed_id\" IS NOT NULL)\n        + (\"history_items\".\"compaction_failed_id\" IS NOT NULL)\n        + (\"history_items\".\"notification_id\" IS NOT NULL)\n        + (\"history_items\".\"llm_ir_id\" IS NOT NULL) = 1"
+        }
+      }
+    },
+    "launches": {
+      "name": "launches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "docker_launch_id": {
+          "name": "docker_launch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_launch_id": {
+          "name": "local_launch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "launches_dockerLaunchId_unique": {
+          "name": "launches_dockerLaunchId_unique",
+          "columns": ["docker_launch_id"],
+          "isUnique": true
+        },
+        "launches_localLaunchId_unique": {
+          "name": "launches_localLaunchId_unique",
+          "columns": ["local_launch_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "launches_docker_launch_id_docker_launches_id_fk": {
+          "name": "launches_docker_launch_id_docker_launches_id_fk",
+          "tableFrom": "launches",
+          "tableTo": "docker_launches",
+          "columnsFrom": ["docker_launch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "launches_local_launch_id_local_launches_id_fk": {
+          "name": "launches_local_launch_id_local_launches_id_fk",
+          "tableFrom": "launches",
+          "tableTo": "local_launches",
+          "columnsFrom": ["local_launch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "launches_exactly_one_kind_check": {
+          "name": "launches_exactly_one_kind_check",
+          "value": "(\"launches\".\"docker_launch_id\" IS NOT NULL) <> (\"launches\".\"local_launch_id\" IS NOT NULL)"
+        }
+      }
+    },
+    "llm_irs": {
+      "name": "llm_irs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "json": {
+          "name": "json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_launches": {
+      "name": "local_launches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unchained": {
+          "name": "unchained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "previews": {
+      "name": "previews",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_type": {
+          "name": "preview_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "previews_session_id_trees_name_fk": {
+          "name": "previews_session_id_trees_name_fk",
+          "tableFrom": "previews",
+          "tableTo": "trees",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "request_failed_items": {
+      "name": "request_failed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tree_nodes": {
+      "name": "tree_nodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "history_item_id": {
+          "name": "history_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tree_id": {
+          "name": "tree_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_leaf": {
+          "name": "is_leaf",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "launch_id": {
+          "name": "launch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tree_nodes_tree_id_idx": {
+          "name": "tree_nodes_tree_id_idx",
+          "columns": ["tree_id"],
+          "isUnique": false
+        },
+        "tree_nodes_one_root_unique": {
+          "name": "tree_nodes_one_root_unique",
+          "columns": ["tree_id"],
+          "isUnique": true,
+          "where": "\"tree_nodes\".\"parent_id\" IS NULL"
+        },
+        "tree_nodes_historyItemId_unique": {
+          "name": "tree_nodes_historyItemId_unique",
+          "columns": ["history_item_id"],
+          "isUnique": true
+        },
+        "tree_nodes_id_treeId_unique": {
+          "name": "tree_nodes_id_treeId_unique",
+          "columns": ["id", "tree_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tree_nodes_history_item_id_history_items_id_fk": {
+          "name": "tree_nodes_history_item_id_history_items_id_fk",
+          "tableFrom": "tree_nodes",
+          "tableTo": "history_items",
+          "columnsFrom": ["history_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tree_nodes_tree_id_trees_id_fk": {
+          "name": "tree_nodes_tree_id_trees_id_fk",
+          "tableFrom": "tree_nodes",
+          "tableTo": "trees",
+          "columnsFrom": ["tree_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tree_nodes_launch_id_launches_id_fk": {
+          "name": "tree_nodes_launch_id_launches_id_fk",
+          "tableFrom": "tree_nodes",
+          "tableTo": "launches",
+          "columnsFrom": ["launch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tree_nodes_parent_same_tree_fk": {
+          "name": "tree_nodes_parent_same_tree_fk",
+          "tableFrom": "tree_nodes",
+          "tableTo": "tree_nodes",
+          "columnsFrom": ["parent_id", "tree_id"],
+          "columnsTo": ["id", "tree_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "tree_nodes_not_own_parent_check": {
+          "name": "tree_nodes_not_own_parent_check",
+          "value": "\"tree_nodes\".\"parent_id\" IS NULL OR \"tree_nodes\".\"parent_id\" <> \"tree_nodes\".\"id\""
+        }
+      }
+    },
+    "trees": {
+      "name": "trees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "trees_name_unique": {
+          "name": "trees_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "trees_cwd_updated_at_idx": {
+          "name": "trees_cwd_updated_at_idx",
+          "columns": ["cwd", "\"updated_at\" DESC"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shown_update_notifs": {
+      "name": "shown_update_notifs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "update": {
+          "name": "update",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "update_idx": {
+          "name": "update_idx",
+          "columns": ["update"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "trees_cwd_updated_at_idx": {
+        "columns": {
+          "\"updated_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1783462300500,
       "tag": "0004_tree_nodes_tree_id_index",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1784836672681,
+      "tag": "0005_clean_red_shift",
+      "breakpoints": true
     }
   ]
 }

--- a/source/cli/cli.tsx
+++ b/source/cli/cli.tsx
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { setupDb } from "../db/setup.ts";
 setupDb();
+
 import React from "react";
 import path from "path";
 import os from "os";
@@ -28,26 +29,32 @@ import { timeout } from "../signals.ts";
 import { shutdownLspClients } from "../lsp/client.ts";
 import { replaceDockerRunArgs, replaceOctoFlags, withOctoFlags } from "./cli-args.ts";
 import type { ParsedCliArgs } from "./cli-args.ts";
-import { loadSession } from "../session-history/index.ts";
+import { listSessions, loadSession } from "../session-history/index.ts";
 import type { LoadedSession, Session } from "../session-history/index.ts";
 import { useAppStore } from "../state.ts";
 import { FOREGROUND_COLOR, THEME_COLOR } from "../theme.ts";
+import { formatTimeAgo } from "../time.ts";
 import { KeyboardProvider } from "../hooks/use-keyboard.ts";
 import { render, type CreateRootOptions } from "paintcannon-react";
+
 const __dirname = import.meta.dirname;
+
 const INTERACTIVE_RENDER_OPTIONS = {
   alternateScreen: true,
   captureMouse: true,
   captureCtrlC: true,
 } satisfies CreateRootOptions;
+
 function renderInteractive(element: React.ReactNode) {
   const root = render(<KeyboardProvider>{element}</KeyboardProvider>, INTERACTIVE_RENDER_OPTIONS);
   root.container.style.position = "relative";
   root.container.style.color = FOREGROUND_COLOR;
   return root;
 }
+
 const CONFIG_STANDARD_DIR = path.join(os.homedir(), ".config/octofriend/");
 const CONFIG_JSON5_FILE = path.join(CONFIG_STANDARD_DIR, "octofriend.json5");
+
 const cli = withOctoFlags(
   new Command().description("If run with no subcommands, runs Octo interactively."),
 )
@@ -79,6 +86,7 @@ const cli = withOctoFlags(
         },
       };
     }
+
     try {
       // Set terminal title for tmux
       process.title = "\\_o_O.//";
@@ -89,6 +97,7 @@ const cli = withOctoFlags(
       await runConfig.transport.close();
     }
   });
+
 const docker = cli.command("docker").description("Sandbox Octo inside Docker");
 withOctoFlags(docker.command("connect"))
   .description("Sandbox Octo inside an already-running container")
@@ -113,6 +122,7 @@ withOctoFlags(docker.command("connect"))
       await transport.close();
     }
   });
+
 withOctoFlags(docker.command("run"))
   .description(
     "Run a Docker image and sandbox Octo inside it, shutting it down when Octo shuts down",
@@ -123,6 +133,7 @@ withOctoFlags(docker.command("run"))
       type: "image",
       image: await manageContainer(args),
     });
+
     try {
       await runMain({
         transport,
@@ -138,6 +149,7 @@ withOctoFlags(docker.command("run"))
       await transport.close();
     }
   });
+
 async function buildConfigForResuming(
   resumeSessionId: string,
   overrides: {
@@ -155,6 +167,7 @@ async function buildConfigForResuming(
     console.error(`No session found with ID ${resumeSessionId}.`);
     process.exit(1);
   }
+
   const storedCliArgs = loadedSession.session.metadata.cliArgs;
   let effectiveCliArgs = replaceOctoFlags(storedCliArgs, overrides);
   if (overrides.dockerRunArgs != null) {
@@ -167,10 +180,12 @@ async function buildConfigForResuming(
       effectiveCliArgs = replaceDockerRunArgs(effectiveCliArgs, overrides.dockerRunArgs);
     }
   }
+
   const shared = {
     parsedCliArgs: effectiveCliArgs,
     loadedSession,
   };
+
   switch (effectiveCliArgs.kind) {
     case "local":
       return {
@@ -195,6 +210,7 @@ async function buildConfigForResuming(
       };
   }
 }
+
 async function runMain(opts: {
   parsedCliArgs: ParsedCliArgs;
   transport: Transport;
@@ -213,6 +229,7 @@ async function runMain(opts: {
   } else {
     session = useAppStore.getState().startNewSession(opts.transport.cwd, opts.parsedCliArgs);
   }
+
   try {
     let { config, configPath } = await loadConfig(opts.parsedCliArgs.config);
 
@@ -238,8 +255,10 @@ async function runMain(opts: {
       }
       console.log("MCP server initialization complete.");
     }
+
     const skills = await discoverSkills(opts.transport, timeout(5000), config);
     const cwd = opts.transport.cwd;
+
     const { waitUntilExit } = renderInteractive(
       <App
         bootSkills={skills.map(s => s.name)}
@@ -257,12 +276,14 @@ async function runMain(opts: {
         inputHistory={await loadInputHistory()}
       />,
     );
+
     await waitUntilExit();
     const { history } = useAppStore.getState();
     if (history.some(item => item.type === "llm-ir")) {
       const resumeCommand = chalk.hex(THEME_COLOR)(`octo --resume ${session.metadata.sessionId}`);
       console.log(`\nResume this session with ${resumeCommand}`);
     }
+
     console.log("\nApprox. tokens used:");
     if (Object.keys(tokenCounts()).length === 0) {
       console.log("0");
@@ -278,18 +299,21 @@ async function runMain(opts: {
     await shutdownMcpClients();
   }
 }
+
 cli
   .command("version")
   .description("Prints the current version")
   .action(async () => {
     console.log(APP_METADATA.version);
   });
+
 cli
   .command("init")
   .description("Create a fresh config file for Octo")
   .action(() => {
     renderInteractive(<FirstTimeSetup configPath={CONFIG_JSON5_FILE} />);
   });
+
 cli
   .command("changelog")
   .description("List the changelog")
@@ -297,6 +321,7 @@ cli
     const changelog = await fs.readFile(path.join(__dirname, "../../../CHANGELOG.md"), "utf8");
     console.log(changelog);
   });
+
 cli
   .command("list")
   .description("List all models you've configured with Octo")
@@ -304,6 +329,37 @@ cli
     const { config } = await loadConfigWithoutReauth();
     console.log(config.models.map(m => m.nickname).join("\n"));
   });
+
+const sessionCommand = cli.command("session").description("Manage Octo sessions");
+sessionCommand
+  .command("list")
+  .description("List sessions for the current working directory")
+  .action(() => {
+    const sessions = listSessions(process.cwd());
+    if (sessions.length === 0) return;
+
+    const sessionIdWidth = Math.max("SESSION ID".length, ...sessions.map(s => s.sessionId.length));
+    const now = new Date();
+    const octoTheme = chalk.hex(THEME_COLOR);
+    const rows = sessions.map(session => ({
+      ...session,
+      updatedAtText: formatTimeAgo(new Date(session.updatedAt), now),
+    }));
+    const previewWidth = Math.max("PREVIEW".length, ...rows.map(row => (row.preview ?? "").length));
+    console.log(`Resume a session with: ${octoTheme("octo --resume <session-id>")}\n`);
+    console.log(
+      `${"SESSION ID".padEnd(sessionIdWidth)}  ${"PREVIEW".padEnd(previewWidth)}  LAST UPDATED`,
+    );
+    console.log(
+      `${"─".repeat(sessionIdWidth)}  ${"─".repeat(previewWidth)}  ${"─".repeat("LAST UPDATED".length)}`,
+    );
+    for (const row of rows) {
+      console.log(
+        `${octoTheme(row.sessionId.padEnd(sessionIdWidth))}  ${chalk.dim((row.preview ?? "").padEnd(previewWidth))}  ${chalk.white(row.updatedAtText)}`,
+      );
+    }
+  });
+
 const bench = cli.command("bench");
 bench
   .command("tps")
@@ -323,12 +379,14 @@ bench
     const model = opts.model
       ? config.models.find(m => m.nickname === opts.model)
       : config.models[0];
+
     if (model == null) {
       console.error(`No model with the nickname ${opts.model} found. Did you add it to Octo?`);
       console.error("The available models are:");
       console.error("- " + config.models.map(m => m.nickname).join("\n- "));
       process.exit(1);
     }
+
     const concurrency = Math.max(1, parseInt(opts.concurrency ?? "1", 10));
     let modelData: ModelData;
     if (model.type === "codex") {
@@ -355,6 +413,7 @@ bench
       };
     }
     const autofixJson = makeAutofixJson(config);
+
     console.log(
       `Benchmarking ${model.nickname} with ${concurrency} concurrent request${concurrency > 1 ? "s" : ""}`,
     );
@@ -362,6 +421,7 @@ bench
     const timer = setInterval(() => {
       console.log("Still working...");
     }, 5000);
+
     type SuccessfulBenchmark = {
       tokens: number;
       ttft: number;
@@ -369,15 +429,19 @@ bench
       interTokenLatencies: number[];
       success: true;
     };
+
     type FailedBenchmark = {
       success: false;
       error: string;
     };
+
     type BenchmarkResult = SuccessfulBenchmark | FailedBenchmark;
+
     async function runSingleBenchmark(): Promise<BenchmarkResult> {
       const start = new Date();
       let firstToken: Date | null = null;
       const tokenTimestamps: Date[] = [];
+
       const result = await run({
         modelData,
         autofixJson,
@@ -405,6 +469,7 @@ bench
         abortSignal: abortController.signal,
         transport,
       });
+
       if (!result.success) {
         return {
           success: false,
@@ -412,21 +477,27 @@ bench
             result.error.type === "auth-error" ? result.error.authError : result.error.requestError,
         };
       }
+
       const end = new Date();
+
       if (firstToken == null) {
         return {
           success: false,
           error: "No tokens received",
         };
       }
+
       const ttft = (firstToken as Date).getTime() - start.getTime();
       const tokenElapsed = end.getTime() - (firstToken as Date).getTime();
+
       const tokens = result.data.usage.output;
+
       const interTokenLatencies: number[] = [];
       for (let i = 1; i < tokenTimestamps.length; i++) {
         const latency = tokenTimestamps[i].getTime() - tokenTimestamps[i - 1].getTime();
         interTokenLatencies.push(latency);
       }
+
       return {
         tokens,
         ttft,
@@ -435,6 +506,7 @@ bench
         success: true,
       };
     }
+
     const benchmarkStart = new Date();
     const results = await Promise.all(
       Array.from(
@@ -445,7 +517,9 @@ bench
       ),
     );
     const benchmarkEnd = new Date();
+
     clearInterval(timer);
+
     const failures = results.filter((r): r is FailedBenchmark => !r.success);
     if (failures.length > 0) {
       console.error(`\n${failures.length} request(s) failed:`);
@@ -456,19 +530,25 @@ bench
         process.exit(1);
       }
     }
+
     const successes = results.filter((r): r is SuccessfulBenchmark => r.success);
+
     if (successes.length === 0) {
       console.log("No successful requests");
       process.exit(1);
     }
+
     const totalTokens = successes.reduce((sum, r) => sum + r.tokens, 0);
     const avgTokens = totalTokens / successes.length;
     const avgTtft = successes.reduce((sum, r) => sum + r.ttft, 0) / successes.length;
+
     const allInterTokenLatencies = successes.flatMap(r => r.interTokenLatencies);
     const avgTokenElapsed =
       successes.reduce((sum, r) => sum + r.tokenElapsed, 0) / successes.length;
+
     const totalTime = (benchmarkEnd.getTime() - benchmarkStart.getTime()) / 1000;
     const tps = totalTokens / totalTime;
+
     console.log(`\n
 Successful requests: ${successes.length}/${concurrency}
 Total tokens: ${totalTokens}
@@ -476,6 +556,7 @@ Avg tokens per request: ${avgTokens.toFixed(2)}
 Total time: ${totalTime.toFixed(2)}s
 Avg time to first token: ${(avgTtft / 1000).toFixed(3)}s
 `);
+
     if (allInterTokenLatencies.length > 0) {
       let minLatency = allInterTokenLatencies[0];
       let maxLatency = allInterTokenLatencies[0];
@@ -486,6 +567,7 @@ Avg time to first token: ${(avgTtft / 1000).toFixed(3)}s
         total += latency;
       }
       const avgLatency = total / allInterTokenLatencies.length;
+
       console.log(`Inter-token latencies (${allInterTokenLatencies.length} total):
   Min: ${minLatency}ms
   Max: ${maxLatency}ms
@@ -493,10 +575,12 @@ Avg time to first token: ${(avgTtft / 1000).toFixed(3)}s
   Avg stream time per request: ${(avgTokenElapsed / 1000).toFixed(3)}s
 `);
     }
+
     console.log(`Tok/sec output (overall): ${tps.toFixed(2)}
 Tok/sec output (per-request avg): ${successes.map(r => r.tokens / (r.tokenElapsed / 1000)).reduce((a, b) => a + b, 0) / successes.length}
 `);
   });
+
 cli
   .command("prompt")
   .description("Sends a prompt to a model")
@@ -512,18 +596,21 @@ cli
     const model = opts.model
       ? config.models.find(m => m.nickname === opts.model)
       : config.models[0];
+
     if (model == null) {
       console.error(`No model with the nickname ${opts.model} found. Did you add it to Octo?`);
       console.error("The available models are:");
       console.error("- " + config.models.map(m => m.nickname).join("\n- "));
       process.exit(1);
     }
+
     let modelData: ModelData;
     if (model.type === "codex") {
       const authResult = await readAuthForModel(model, config);
       if (!authResult.ok) {
         console.error(`${model.nickname} doesn't have auth set up.`);
         const error = authResult.error;
+
         if (error.type === "missing") {
           console.error(`${error.message}`);
         } else if (error.type === "command_failed") {
@@ -537,6 +624,7 @@ cli
         } else if (error.type === "invalid") {
           console.error(`Invalid auth configuration: ${error.message}`);
         }
+
         process.exit(1);
       }
       modelData = {
@@ -549,6 +637,7 @@ cli
       if (!authResult.ok) {
         console.error(`${model.nickname} doesn't have auth set up.`);
         const error = authResult.error;
+
         if (error.type === "missing") {
           console.error(`${error.message}`);
           if (model.auth?.type === "env") {
@@ -565,6 +654,7 @@ cli
         } else if (error.type === "invalid") {
           console.error(`Invalid auth configuration: ${error.message}`);
         }
+
         process.exit(1);
       }
       modelData = {
@@ -584,13 +674,16 @@ cli
         ],
       },
     ];
+
     let systemPrompt: undefined | (() => Promise<string>) = undefined;
     if (opts.system) {
       const sys = opts.system;
       systemPrompt = async () => sys;
     }
+
     const autofixJson = makeAutofixJson(config);
     const abortController = new AbortController();
+
     let seenReasoning = false;
     let seenContent = false;
     const result = await run({
@@ -601,10 +694,12 @@ cli
       handlers: {
         onTokens: (chunk, type) => {
           if (type === "reasoning") seenReasoning = true;
+
           if (seenReasoning && type === "content" && !seenContent) {
             seenContent = true;
             process.stderr.write("\n\n");
           }
+
           if (type === "reasoning") process.stderr.write(chunk);
           else process.stdout.write(chunk);
         },
@@ -622,8 +717,10 @@ cli
       }
       process.exit(1);
     }
+
     process.stdout.write("\n");
   });
+
 async function loadConfig(path?: string) {
   let { config, configPath } = await loadConfigWithoutReauth(path);
   let defaultModel = config.models[0];
@@ -643,6 +740,7 @@ async function loadConfig(path?: string) {
     defaultModel = config.models[0];
     if (!(await readAuthForModel(defaultModel, config)).ok) process.exit(1);
   }
+
   for (const key of AUTOFIX_KEYS) {
     let autofixModel = config[key];
     if (autofixModel) {
@@ -664,17 +762,20 @@ async function loadConfig(path?: string) {
       }
     }
   }
+
   return {
     config,
     configPath,
   };
 }
+
 async function loadConfigWithoutReauth(configPath?: string) {
   if (configPath)
     return {
       configPath,
       config: await readConfig(configPath),
     };
+
   if (await fileExists(CONFIG_JSON5_FILE)) {
     return {
       configPath: CONFIG_JSON5_FILE,
@@ -686,14 +787,17 @@ async function loadConfigWithoutReauth(configPath?: string) {
   await markUpdatesSeen();
   const { waitUntilExit } = renderInteractive(<FirstTimeSetup configPath={CONFIG_JSON5_FILE} />);
   await waitUntilExit();
+
   if (await fileExists(CONFIG_JSON5_FILE)) {
     return {
       configPath: CONFIG_JSON5_FILE,
       config: await readConfig(CONFIG_JSON5_FILE),
     };
   }
+
   process.exit(1);
 }
+
 migrate().then(() => {
   cli.parse();
 });

--- a/source/session-history/index.ts
+++ b/source/session-history/index.ts
@@ -1,5 +1,5 @@
 import { ParsedCliArgs } from "../cli/cli-args.ts";
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { db, DbTransaction, schema } from "../db/db.ts";
 import { OctoIR } from "../ir/octo-ir.ts";
 import {
@@ -8,13 +8,17 @@ import {
   launches,
   llmIrs,
   notifications,
+  previews,
   requestFailedItems,
   treeNodes,
   trees,
 } from "./schema/session-history-schema.ts";
 import { deserializeLlmIr, serializeLlmIr } from "./llm-ir-json.ts";
+import { excerpt } from "./preview.ts";
 
 export type TransportKind = "local" | "docker-connect" | "docker-run";
+
+export type SessionPreviewType = "latest-user-message";
 
 export type HistoryItem =
   | { type: "request-failed" }
@@ -41,12 +45,32 @@ export type LoadedSession = {
   history: readonly HistoryNode[];
 };
 
+export type SessionSummary = {
+  sessionId: string;
+  updatedAt: number;
+  preview: string | null;
+};
+
 export function createSession(cwd: string, cliArgs: ParsedCliArgs): Session {
   return {
     metadata: { sessionId: null, cwd, cliArgs },
     treeId: null,
     launchId: null,
   };
+}
+
+export function listSessions(cwd: string): SessionSummary[] {
+  return db()
+    .select({
+      sessionId: trees.name,
+      updatedAt: trees.updatedAt,
+      preview: previews.preview,
+    })
+    .from(trees)
+    .leftJoin(previews, eq(previews.sessionId, trees.name))
+    .where(eq(trees.cwd, cwd))
+    .orderBy(desc(trees.updatedAt))
+    .all();
 }
 
 export function loadSession(sessionId: string): LoadedSession | null {
@@ -171,6 +195,42 @@ function cliArgsFromRow(node: SessionTreeNode): ParsedCliArgs {
   };
 }
 
+function updateSessionPreview(
+  tx: DbTransaction,
+  sessionId: string,
+  previewStr: string,
+  previewType: SessionPreviewType,
+) {
+  tx.insert(previews)
+    .values({
+      preview: previewStr,
+      sessionId,
+      previewType,
+    })
+    .onConflictDoUpdate({
+      target: previews.sessionId,
+      set: {
+        preview: previewStr,
+        previewType,
+      },
+    })
+    .run();
+}
+
+// If the historyItem is a user message with some non-empty text update the session's preview to be an excerpt of that.
+function maybeUpdateSessionPreview(tx: DbTransaction, sessionId: string, historyItem: HistoryItem) {
+  if (historyItem.type === "llm-ir") {
+    if (historyItem.ir.role === "user") {
+      const userMessageContent = historyItem.ir.content.find(
+        content => content.type == "text",
+      )?.content;
+      if (userMessageContent) {
+        updateSessionPreview(tx, sessionId, excerpt(userMessageContent), "latest-user-message");
+      }
+    }
+  }
+}
+
 export function insertHistoryItems(
   session: Session,
   parentNodeId: number | null,
@@ -179,8 +239,9 @@ export function insertHistoryItems(
   if (itemsToInsert.length === 0) return [];
 
   // sessionId is null until the first durable history item is persisted; generate it lazily.
+  const sessionId = session.metadata.sessionId ?? crypto.randomUUID();
   if (session.metadata.sessionId == null) {
-    session.metadata = { ...session.metadata, sessionId: crypto.randomUUID() };
+    session.metadata = { ...session.metadata, sessionId };
   }
 
   const result = db().transaction(tx => {
@@ -192,6 +253,7 @@ export function insertHistoryItems(
     let currParentId = parentNodeId;
     for (const historyItem of itemsToInsert) {
       const insertedHistoryItemId = insertHistoryItem(tx, historyItem);
+      maybeUpdateSessionPreview(tx, sessionId, historyItem);
       const insertedTreeNode = tx
         .insert(treeNodes)
         .values({
@@ -206,6 +268,7 @@ export function insertHistoryItems(
       insertedNodes.push({ ...historyItem, nodeId: insertedTreeNode.id });
       currParentId = insertedTreeNode.id;
     }
+    tx.update(trees).set({ updatedAt: Date.now() }).where(eq(trees.id, treeId)).run();
     return { treeId, launchId, insertedNodes };
   });
 

--- a/source/session-history/preview.test.ts
+++ b/source/session-history/preview.test.ts
@@ -6,11 +6,12 @@ describe("excerpt", () => {
     expect(excerpt("Fix the migration first.")).toBe("Fix the migration first.…");
   });
 
-  it("prefers a nearby sentence boundary", () => {
+  it("prefers a nearby word boundary", () => {
     const sentence = "Fix the migration, then add previews.";
     const text = `${sentence} Generate an LLM summary later after there is more context.`;
 
-    expect(excerpt(text)).toBe(`${sentence}…`);
+    expect(excerpt(text)).toBe("Fix the migration, then add previews. Generate an…");
+    expect(excerpt(text)).toHaveLength(MAX_PREVIEW_CHARACTERS);
   });
 
   it("falls back to the character limit at a word boundary", () => {

--- a/source/session-history/preview.test.ts
+++ b/source/session-history/preview.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { excerpt, MAX_PREVIEW_CHARACTERS } from "./preview.ts";
+
+describe("excerpt", () => {
+  it("adds an ellipsis to short text", () => {
+    expect(excerpt("Fix the migration first.")).toBe("Fix the migration first.…");
+  });
+
+  it("prefers a nearby sentence boundary", () => {
+    const sentence = "Fix the migration, then add previews.";
+    const text = `${sentence} Generate an LLM summary later after there is more context.`;
+
+    expect(excerpt(text)).toBe(`${sentence}…`);
+  });
+
+  it("falls back to the character limit at a word boundary", () => {
+    const text = "word ".repeat(30).trim();
+    const expected = `${"word ".repeat(10).trim()}…`;
+
+    expect(excerpt(text)).toBe(expected);
+    expect(excerpt(text)).toHaveLength(MAX_PREVIEW_CHARACTERS);
+  });
+});

--- a/source/session-history/preview.ts
+++ b/source/session-history/preview.ts
@@ -1,20 +1,15 @@
 export const MAX_PREVIEW_CHARACTERS = 50;
-const MINIMUM_SENTENCE_FILL_RATIO = 0.6;
 const ELLIPSIS = "…";
 
 const wordSegmenter = new Intl.Segmenter(undefined, {
   granularity: "word",
 });
 
-const sentenceSegmenter = new Intl.Segmenter(undefined, {
-  granularity: "sentence",
-});
-
 const graphemeSegmenter = new Intl.Segmenter(undefined, {
   granularity: "grapheme",
 });
 
-// Shortens text at a natural (as possible) boundary within the MAX_PREVEW_CHARACTERS limit.
+// Shortens text within the MAX_PREVEW_CHARACTERS limit at a natural word boundary.
 export function excerpt(text: string): string {
   const clean = text.trim().replace(/\s+/g, " ");
   if (clean === "") return "";
@@ -22,22 +17,12 @@ export function excerpt(text: string): string {
   const contentLimit = MAX_PREVIEW_CHARACTERS - ELLIPSIS.length;
   if (clean.length <= contentLimit) return `${clean}${ELLIPSIS}`;
 
-  const minimumEnd = Math.ceil(MAX_PREVIEW_CHARACTERS * MINIMUM_SENTENCE_FILL_RATIO);
-
-  let sentenceEnd: number | undefined;
-  for (const sentence of sentenceSegmenter.segment(clean)) {
-    const end = sentence.index + sentence.segment.trimEnd().length;
-    if (end > contentLimit) break;
-    if (end >= minimumEnd) sentenceEnd = end;
-  }
-
   let wordEnd: number | undefined;
   for (const word of wordSegmenter.segment(clean)) {
     const end = word.index + word.segment.length;
     if (end > contentLimit) break;
     if (word.isWordLike || wordEnd != null) wordEnd = end;
   }
-  if (wordEnd != null && wordEnd < minimumEnd) wordEnd = undefined;
 
   let hardEnd = 0;
   for (const grapheme of graphemeSegmenter.segment(clean)) {
@@ -46,7 +31,7 @@ export function excerpt(text: string): string {
     hardEnd = end;
   }
 
-  const end = sentenceEnd ?? wordEnd ?? hardEnd;
+  const end = wordEnd ?? hardEnd;
   const result = clean.slice(0, end).trimEnd();
   return `${result}${ELLIPSIS}`;
 }

--- a/source/session-history/preview.ts
+++ b/source/session-history/preview.ts
@@ -1,0 +1,52 @@
+export const MAX_PREVIEW_CHARACTERS = 50;
+const MINIMUM_SENTENCE_FILL_RATIO = 0.6;
+const ELLIPSIS = "…";
+
+const wordSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "word",
+});
+
+const sentenceSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "sentence",
+});
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+// Shortens text at a natural (as possible) boundary within the MAX_PREVEW_CHARACTERS limit.
+export function excerpt(text: string): string {
+  const clean = text.trim().replace(/\s+/g, " ");
+  if (clean === "") return "";
+
+  const contentLimit = MAX_PREVIEW_CHARACTERS - ELLIPSIS.length;
+  if (clean.length <= contentLimit) return `${clean}${ELLIPSIS}`;
+
+  const minimumEnd = Math.ceil(MAX_PREVIEW_CHARACTERS * MINIMUM_SENTENCE_FILL_RATIO);
+
+  let sentenceEnd: number | undefined;
+  for (const sentence of sentenceSegmenter.segment(clean)) {
+    const end = sentence.index + sentence.segment.trimEnd().length;
+    if (end > contentLimit) break;
+    if (end >= minimumEnd) sentenceEnd = end;
+  }
+
+  let wordEnd: number | undefined;
+  for (const word of wordSegmenter.segment(clean)) {
+    const end = word.index + word.segment.length;
+    if (end > contentLimit) break;
+    if (word.isWordLike || wordEnd != null) wordEnd = end;
+  }
+  if (wordEnd != null && wordEnd < minimumEnd) wordEnd = undefined;
+
+  let hardEnd = 0;
+  for (const grapheme of graphemeSegmenter.segment(clean)) {
+    const end = grapheme.index + grapheme.segment.length;
+    if (end > contentLimit) break;
+    hardEnd = end;
+  }
+
+  const end = sentenceEnd ?? wordEnd ?? hardEnd;
+  const result = clean.slice(0, end).trimEnd();
+  return `${result}${ELLIPSIS}`;
+}

--- a/source/session-history/schema/session-history-schema.ts
+++ b/source/session-history/schema/session-history-schema.ts
@@ -10,10 +10,26 @@ import {
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
-export const trees = sqliteTable("trees", {
-  id: integer().primaryKey({ autoIncrement: true }),
-  name: text().notNull().unique(),
-  cwd: text().notNull(),
+export const trees = sqliteTable(
+  "trees",
+  {
+    id: integer().primaryKey({ autoIncrement: true }),
+    name: text().notNull().unique(),
+    cwd: text().notNull(),
+    updatedAt: integer()
+      .notNull()
+      .$onUpdate(() => Date.now()),
+  },
+  table => [index("trees_cwd_updated_at_idx").on(table.cwd, sql`${table.updatedAt} DESC`)],
+);
+
+export const previews = sqliteTable("previews", {
+  sessionId: text()
+    .notNull()
+    .primaryKey()
+    .references(() => trees.name, { onDelete: "cascade" }),
+  preview: text(),
+  previewType: text({ enum: ["latest-user-message"] }).notNull(),
   updatedAt: integer()
     .notNull()
     .$onUpdate(() => Date.now()),
@@ -143,8 +159,16 @@ export const treeNodes = sqliteTable(
   ],
 );
 
-export const treesRelations = relations(trees, ({ many }) => ({
+export const treesRelations = relations(trees, ({ many, one }) => ({
   nodes: many(treeNodes),
+  preview: one(previews),
+}));
+
+export const previewsRelations = relations(previews, ({ one }) => ({
+  tree: one(trees, {
+    fields: [previews.sessionId],
+    references: [trees.name],
+  }),
 }));
 
 export const treeNodesRelations = relations(treeNodes, ({ one }) => ({

--- a/source/time.test.ts
+++ b/source/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatTimeUntil } from "./time.ts";
+import { formatTimeAgo, formatTimeUntil } from "./time.ts";
 
 describe("formatTimeUntil", () => {
   const now = new Date("2026-03-02T12:00:00Z");
@@ -107,5 +107,29 @@ describe("formatTimeUntil", () => {
   it("should handle negative days as 0 minutes", () => {
     const expiresAt = new Date("2026-02-28T12:00:00Z");
     expect(formatTimeUntil(expiresAt, now)).toBe("in 0 minutes");
+  });
+});
+
+describe("formatTimeAgo", () => {
+  const now = new Date("2026-03-02T12:00:00Z");
+
+  it.each([
+    ["less than a minute", 30 * 1000, "just now"],
+    ["one minute", 60 * 1000, "1 minute ago"],
+    ["multiple minutes", 10 * 60 * 1000, "10 minutes ago"],
+    ["one hour", 60 * 60 * 1000, "1 hour ago"],
+    ["multiple hours", 10 * 60 * 60 * 1000, "10 hours ago"],
+    ["one day", 24 * 60 * 60 * 1000, "1 day ago"],
+    ["multiple days", 10 * 24 * 60 * 60 * 1000, "10 days ago"],
+    ["one month", 30 * 24 * 60 * 60 * 1000, "1 month ago"],
+    ["multiple months", 90 * 24 * 60 * 60 * 1000, "3 months ago"],
+    ["one year", 365 * 24 * 60 * 60 * 1000, "1 year ago"],
+    ["multiple years", 2 * 365 * 24 * 60 * 60 * 1000, "2 years ago"],
+  ])("formats %s", (_description, elapsedMs, expected) => {
+    expect(formatTimeAgo(new Date(now.getTime() - elapsedMs), now)).toBe(expected);
+  });
+
+  it("treats future timestamps as just now", () => {
+    expect(formatTimeAgo(new Date(now.getTime() + 60 * 1000), now)).toBe("just now");
   });
 });

--- a/source/time.ts
+++ b/source/time.ts
@@ -29,3 +29,29 @@ export function formatTimeUntil(expiresAt: Date, now: Date = new Date()): string
   }
   return `in ${diffDays} day${diffDays !== 1 ? "s" : ""}`;
 }
+
+export function formatTimeAgo(occurredAt: Date, now: Date = new Date()): string {
+  const elapsedMs = Math.max(0, now.getTime() - occurredAt.getTime());
+  const elapsedMinutes = Math.floor(elapsedMs / (1000 * 60));
+
+  if (elapsedMinutes < 1) return "just now";
+  if (elapsedMinutes < 60) return `${elapsedMinutes} ${pluralize("minute", elapsedMinutes)} ago`;
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) return `${elapsedHours} ${pluralize("hour", elapsedHours)} ago`;
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  if (elapsedDays < 30) return `${elapsedDays} ${pluralize("day", elapsedDays)} ago`;
+
+  if (elapsedDays < 365) {
+    const elapsedMonths = Math.floor(elapsedDays / 30);
+    return `${elapsedMonths} ${pluralize("month", elapsedMonths)} ago`;
+  }
+
+  const elapsedYears = Math.floor(elapsedDays / 365);
+  return `${elapsedYears} ${pluralize("year", elapsedYears)} ago`;
+}
+
+function pluralize(unit: string, count: number): string {
+  return count === 1 ? unit : `${unit}s`;
+}


### PR DESCRIPTION
 Adds the `octo session list` command to show a list of session id's sorted by most recently updated as well as an "preview" (excerpt of the most recent user message).
 
<img width="753" height="170" alt="Screenshot 2026-07-23 at 12 29 53 PM" src="https://github.com/user-attachments/assets/87096587-929b-4b73-8bd0-f450d6f7e4ba" />

  The `preview` table references by the session's UUID (trees.name). We add an index on tree's `cwd` and `updatedAt` so that it can be more efficiently looked up.
  ```mermaid
  erDiagram
      TREES ||--o| PREVIEWS : "has"

      TREES {
          integer id PK
          text name UK "session UUID"
      }

      PREVIEWS {
          text session_id PK, FK
          text preview
          text preview_type
          integer updated_at
      }
  ```