### PR TITLE
Apply flex attributes to make spacing consistent

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -1594,6 +1594,8 @@ const TranscriptItemRenderer = ({ item }: { item: TranscriptItem }) => {
         <TerminalFlex
           style={{
             marginTop: 1,
+            alignSelf: "stretch",
+            minWidth: 0,
           }}
         >
           <Markdown markdown={item.updates} />
@@ -1911,6 +1913,7 @@ function renderLlmIR(item: OctoIR, isCompacting: boolean) {
         <TerminalFlex
           style={{
             marginRight: 1,
+            flexShrink: 0,
           }}
         >
           <Span

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -94,6 +94,7 @@ import { HistoryNode } from "./session-history/index.ts";
 import { Span, useAnimation, useApp } from "paintcannon-react";
 import { useKeyboard } from "./hooks/use-keyboard.ts";
 import { TerminalFlex } from "./components/terminal-flex.tsx";
+import { ToolCallRow } from "./components/tool-call-row.tsx";
 import {
   ScrollTranscriptToBottomContext,
   useScrollTranscriptToBottom,
@@ -2129,50 +2130,16 @@ function SkillToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof skill> 
   );
 }
 function FetchToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof fetchTool> }) {
-  const themeColor = useColor();
-  return (
-    <TerminalFlex>
-      <Span
-        style={{
-          color: "gray",
-        }}
-      >
-        {item.name}:{" "}
-      </Span>
-      <Span
-        style={{
-          color: themeColor,
-        }}
-      >
-        {item.arguments.url}
-      </Span>
-    </TerminalFlex>
-  );
+  return <ToolCallRow name={item.name}>{item.arguments.url}</ToolCallRow>;
 }
 function ShellToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof shell> }) {
-  const themeColor = useColor();
   return (
     <TerminalFlex
       style={{
         flexDirection: "column",
       }}
     >
-      <TerminalFlex>
-        <Span
-          style={{
-            color: "gray",
-          }}
-        >
-          {item.name}:{" "}
-        </Span>
-        <Span
-          style={{
-            color: themeColor,
-          }}
-        >
-          {item.arguments.cmd}
-        </Span>
-      </TerminalFlex>
+      <ToolCallRow name={item.name}>{item.arguments.cmd}</ToolCallRow>
       <Span
         style={{
           color: "gray",
@@ -2184,46 +2151,10 @@ function ShellToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof shell> 
   );
 }
 function ReadToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof read> }) {
-  const themeColor = useColor();
-  return (
-    <TerminalFlex>
-      <Span
-        style={{
-          color: "gray",
-        }}
-      >
-        {item.name}:{" "}
-      </Span>
-      <Span
-        style={{
-          color: themeColor,
-        }}
-      >
-        {item.arguments.filePath}
-      </Span>
-    </TerminalFlex>
-  );
+  return <ToolCallRow name={item.name}>{item.arguments.filePath}</ToolCallRow>;
 }
 function ListToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof list> }) {
-  const themeColor = useColor();
-  return (
-    <TerminalFlex>
-      <Span
-        style={{
-          color: "gray",
-        }}
-      >
-        {item.name}:{" "}
-      </Span>
-      <Span
-        style={{
-          color: themeColor,
-        }}
-      >
-        {item?.arguments?.dirPath || process.cwd()}
-      </Span>
-    </TerminalFlex>
-  );
+  return <ToolCallRow name={item.name}>{item?.arguments?.dirPath || process.cwd()}</ToolCallRow>;
 }
 function EditToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof edit> }) {
   const themeColor = useColor();
@@ -2316,29 +2247,15 @@ function CreateToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof create
   );
 }
 function McpToolRenderer({ item }: { item: ParsedToolSchemaFrom<typeof mcp> }) {
-  const themeColor = useColor();
   return (
     <TerminalFlex
       style={{
         flexDirection: "column",
       }}
     >
-      <TerminalFlex>
-        <Span
-          style={{
-            color: "gray",
-          }}
-        >
-          {item.name}:{" "}
-        </Span>
-        <Span
-          style={{
-            color: themeColor,
-          }}
-        >
-          Server: {item.arguments.server}, Tool: {item.arguments.tool}
-        </Span>
-      </TerminalFlex>
+      <ToolCallRow name={item.name}>
+        Server: {item.arguments.server}, Tool: {item.arguments.tool}
+      </ToolCallRow>
       <Span
         style={{
           color: "gray",

--- a/source/components/octo.tsx
+++ b/source/components/octo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
 import { Span } from "paintcannon-react";
 export const Octo = () => {
-  return <Span>🐙</Span>;
+  return <Span style={{ flexShrink: 0 }}>🐙</Span>;
 };

--- a/source/components/select.tsx
+++ b/source/components/select.tsx
@@ -9,6 +9,7 @@ export const IndicatorComponent = ({ isSelected = false }: { isSelected?: boolea
     <TerminalFlex
       style={{
         marginRight: 1,
+        flexShrink: 0,
       }}
     >
       {isSelected ? (

--- a/source/components/selection/select-indicator.tsx
+++ b/source/components/selection/select-indicator.tsx
@@ -10,6 +10,7 @@ function Indicator({ isSelected = false }: Props) {
     <TerminalFlex
       style={{
         marginRight: 1,
+        flexShrink: 0,
       }}
     >
       {isSelected ? (

--- a/source/components/tool-call-row.tsx
+++ b/source/components/tool-call-row.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Span } from "paintcannon-react";
+import { useColor } from "../theme.ts";
+import { TerminalFlex } from "./terminal-flex.tsx";
+
+export function ToolCallRow({ name, children }: { name: string; children: React.ReactNode }) {
+  const themeColor = useColor();
+
+  return (
+    <TerminalFlex>
+      <Span
+        style={{
+          color: "gray",
+          flexShrink: 0,
+        }}
+      >
+        {name}:{" "}
+      </Span>
+      <Span
+        style={{
+          color: themeColor,
+          minWidth: 0,
+          overflowWrap: "anywhere",
+        }}
+      >
+        {children}
+      </Span>
+    </TerminalFlex>
+  );
+}

--- a/source/markdown/index.tsx
+++ b/source/markdown/index.tsx
@@ -36,6 +36,9 @@ export function Markdown({ markdown }: { markdown: string }) {
     <TerminalFlex
       style={{
         flexDirection: "column",
+        minWidth: 0,
+        maxWidth: "100%",
+        overflowWrap: "anywhere",
       }}
     >
       {tokens.map((token, index) => (
@@ -104,6 +107,7 @@ function BlockquoteRenderer({ token }: { token: Tokens.Blockquote }) {
       <Span
         style={{
           color: MARKDOWN_BLOCKQUOTE_BORDER_COLOR,
+          flexShrink: 0,
         }}
       >
         │{" "}
@@ -334,6 +338,7 @@ function ListItemRenderer({ token }: { token: Tokens.ListItem }) {
           <Span
             style={{
               color: token.checked ? MARKDOWN_CHECKED_TASK_COLOR : MARKDOWN_UNCHECKED_TASK_COLOR,
+              flexShrink: 0,
             }}
           >
             {token.checked ? "[✓]" : "[ ]"}{" "}


### PR DESCRIPTION
Similar to https://github.com/synthetic-lab/octofriend/pull/237 but applied `flexShrink: 0` & other css styling to preserve the layout of Octo's messages from before.

Created a `ToolCallRow` component with the appropriate styling to DRY it up.

| `ToolCallRow`s Before ("`shell`" wrapped mid-word)  | After |
| --- | --- |
| <img width="410"  alt="Screenshot 2026-07-24 at 8 56 45 AM" src="https://github.com/user-attachments/assets/b2ffc264-6982-4d49-9eda-8a295c39f84e" /> | <img width="410" alt="image" src="https://github.com/user-attachments/assets/c2ee7b97-6a6a-4af5-a5be-12d45367338a" /> |

| Before (other examples)  | After |
| --- | --- |
| <img width="824" height="387" alt="image" src="https://github.com/user-attachments/assets/c50873ca-0936-4631-8e1d-63a99003de89" /> | <img width="770" height="451" alt="image" src="https://github.com/user-attachments/assets/b8ae0d1f-29e0-42eb-9452-2f554a3e588d" /> |
