### PR TITLE
Add octo session delete

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -56,7 +56,8 @@ import { useShallow } from "zustand/react/shallow";
 import { KbShortcutPanel } from "./components/kb-select/kb-shortcut-panel.tsx";
 import { Item, ShortcutArray } from "./components/kb-select/kb-shortcut-select.tsx";
 import { useAppStore, RunArgs, useModel, InflightResponseType } from "./state.ts";
-import type { Session } from "./session-history/index.ts";
+import { SessionNotFoundError } from "./session-history/index.ts";
+import type { HistoryNode, Session } from "./session-history/index.ts";
 import { Octo } from "./components/octo.tsx";
 import { Menu } from "./menu.tsx";
 import SelectInput from "./components/selection/select-input.tsx";
@@ -93,11 +94,11 @@ import path from "path";
 import { CwdContext, useCwd } from "./hooks/use-cwd.tsx";
 import { LspToolRenderer } from "./components/lsp-tool-renderer.tsx";
 import { CustomAuthFlow } from "./components/add-model-flow.tsx";
-import { HistoryNode } from "./session-history/index.ts";
 import { Span, useAnimation, useApp } from "paintcannon-react";
 import { useKeyboard } from "./hooks/use-keyboard.ts";
 import { TerminalFlex } from "./components/terminal-flex.tsx";
 import { ToolCallRow } from "./components/tool-call-row.tsx";
+import { useToast } from "./components/toast.tsx";
 import {
   ScrollTranscriptToBottomContext,
   useScrollTranscriptToBottom,
@@ -631,6 +632,7 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
   const model = useModel();
   const transport = useContext(TransportContext);
   const session = useSession();
+  const showToast = useToast();
   const vimEnabled = !!config.vimEmulation?.enabled;
   const {
     modeData,
@@ -680,15 +682,27 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
     async (submittedQuery?: string, images?: ImageInfo[]) => {
       const finalQuery = submittedQuery ?? query;
       setQuery("");
-      await input({
-        query: finalQuery,
-        config,
-        transport,
-        session,
-        images,
-      });
+      try {
+        await input({
+          query: finalQuery,
+          config,
+          transport,
+          session,
+          images,
+        });
+      } catch (error) {
+        if (error instanceof SessionNotFoundError) {
+          showToast(
+            <Span style={{ color: "red" }}>
+              Could not send message. Session {error.sessionId} does not exist.
+            </Span>,
+          );
+          return;
+        }
+        throw error;
+      }
     },
-    [query, config, transport, session, setQuery],
+    [query, config, transport, session, setQuery, showToast],
   );
   if (modeData.mode === "responding" || modeData.mode === "compacting") {
     return (

--- a/source/cli/cli.tsx
+++ b/source/cli/cli.tsx
@@ -29,7 +29,7 @@ import { timeout } from "../signals.ts";
 import { shutdownLspClients } from "../lsp/client.ts";
 import { replaceDockerRunArgs, replaceOctoFlags, withOctoFlags } from "./cli-args.ts";
 import type { ParsedCliArgs } from "./cli-args.ts";
-import { listSessions, loadSession } from "../session-history/index.ts";
+import { deleteSession, listSessions, loadSession } from "../session-history/index.ts";
 import type { LoadedSession, Session } from "../session-history/index.ts";
 import { useAppStore } from "../state.ts";
 import { FOREGROUND_COLOR, THEME_COLOR } from "../theme.ts";
@@ -49,9 +49,7 @@ const INTERACTIVE_RENDER_OPTIONS = {
 function renderInteractive(element: React.ReactNode) {
   const root = render(
     <ToastProvider>
-      <KeyboardProvider>
-        {element}
-      </KeyboardProvider>
+      <KeyboardProvider>{element}</KeyboardProvider>
     </ToastProvider>,
     INTERACTIVE_RENDER_OPTIONS,
   );
@@ -367,6 +365,18 @@ sessionCommand
         `${octoTheme(row.sessionId.padEnd(sessionIdWidth))}  ${chalk.dim((row.preview ?? "").padEnd(previewWidth))}  ${chalk.white(row.updatedAtText)}`,
       );
     }
+  });
+sessionCommand
+  .command("delete")
+  .description("Delete a session")
+  .argument("<session-id>", "The session ID to delete")
+  .action(sessionId => {
+    if (!deleteSession(sessionId)) {
+      console.error(`No session found with ID ${sessionId}.`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`Deleted session ${sessionId}.`);
   });
 
 const bench = cli.command("bench");

--- a/source/session-history/index.test.ts
+++ b/source/session-history/index.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSession,
+  deleteSession,
+  insertHistoryItems,
+  loadSession,
+  SessionNotFoundError,
+  type HistoryItem,
+} from "./index.ts";
+
+const LOCAL_CLI_ARGS = { kind: "local" } as const;
+
+function userMessage(content: string): HistoryItem {
+  return {
+    type: "llm-ir",
+    ir: {
+      role: "user",
+      content: [{ type: "text", content }],
+    },
+  };
+}
+
+describe("deleteSession", () => {
+  it("deletes an existing session", () => {
+    const session = createSession("/test/delete-session", LOCAL_CLI_ARGS);
+    insertHistoryItems(session, null, [userMessage("Delete me")]);
+    const sessionId = session.metadata.sessionId;
+    expect(sessionId).not.toBeNull();
+
+    expect(deleteSession(sessionId!)).toBe(true);
+    expect(loadSession(sessionId!)).toBeNull();
+    expect(deleteSession(sessionId!)).toBe(false);
+  });
+
+  it("reports a deleted session before inserting more history", () => {
+    const session = createSession("/test/stale-session", LOCAL_CLI_ARGS);
+    const history = insertHistoryItems(session, null, [userMessage("Initial message")]);
+    const sessionId = session.metadata.sessionId;
+    expect(sessionId).not.toBeNull();
+    expect(deleteSession(sessionId!)).toBe(true);
+
+    let thrown: unknown;
+    try {
+      insertHistoryItems(session, history.at(-1)!.nodeId, [userMessage("Late message")]);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SessionNotFoundError);
+    expect(thrown).toMatchObject({
+      sessionId,
+      message: `Session ${sessionId} does not exist.`,
+    });
+  });
+});

--- a/source/session-history/index.ts
+++ b/source/session-history/index.ts
@@ -1,12 +1,14 @@
 import { ParsedCliArgs } from "../cli/cli-args.ts";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, inArray } from "drizzle-orm";
 import { db, DbTransaction, schema } from "../db/db.ts";
 import { OctoIR } from "../ir/octo-ir.ts";
 import {
   compactionFailedItems,
+  dockerLaunches,
   historyItems,
   launches,
   llmIrs,
+  localLaunches,
   notifications,
   previews,
   requestFailedItems,
@@ -51,6 +53,13 @@ export type SessionSummary = {
   preview: string | null;
 };
 
+export class SessionNotFoundError extends Error {
+  constructor(readonly sessionId: string) {
+    super(`Session ${sessionId} does not exist.`);
+    this.name = "SessionNotFoundError";
+  }
+}
+
 export function createSession(cwd: string, cliArgs: ParsedCliArgs): Session {
   return {
     metadata: { sessionId: null, cwd, cliArgs },
@@ -71,6 +80,51 @@ export function listSessions(cwd: string): SessionSummary[] {
     .where(eq(trees.cwd, cwd))
     .orderBy(desc(trees.updatedAt))
     .all();
+}
+
+export function deleteSession(sessionId: string): boolean {
+  return db().transaction(tx => {
+    const sessionLaunches = tx
+      .selectDistinct({ id: treeNodes.launchId })
+      .from(trees)
+      .innerJoin(treeNodes, eq(treeNodes.treeId, trees.id))
+      .where(eq(trees.name, sessionId))
+      .all();
+
+    const deletedTree = tx.delete(trees).where(eq(trees.name, sessionId)).run();
+    if (deletedTree.changes === 0) return false;
+    if (sessionLaunches.length === 0) return true;
+
+    const deletedLaunches = tx
+      .delete(launches)
+      .where(
+        inArray(
+          launches.id,
+          sessionLaunches.map(launch => launch.id),
+        ),
+      )
+      .returning({
+        dockerLaunchId: launches.dockerLaunchId,
+        localLaunchId: launches.localLaunchId,
+      })
+      .all();
+
+    const dockerLaunchIds = deletedLaunches.flatMap(launch =>
+      launch.dockerLaunchId == null ? [] : [launch.dockerLaunchId],
+    );
+    if (dockerLaunchIds.length > 0) {
+      tx.delete(dockerLaunches).where(inArray(dockerLaunches.id, dockerLaunchIds)).run();
+    }
+
+    const localLaunchIds = deletedLaunches.flatMap(launch =>
+      launch.localLaunchId == null ? [] : [launch.localLaunchId],
+    );
+    if (localLaunchIds.length > 0) {
+      tx.delete(localLaunches).where(inArray(localLaunches.id, localLaunchIds)).run();
+    }
+
+    return true;
+  });
 }
 
 export function loadSession(sessionId: string): LoadedSession | null {
@@ -246,7 +300,7 @@ export function insertHistoryItems(
 
   const result = db().transaction(tx => {
     // we don't create a session tree or uuid until at least one history item is available
-    const treeId = session.treeId ?? createTree(tx, session.metadata);
+    const treeId = treeIdForHistoryInsert(tx, session, sessionId);
     const launchId = session.launchId ?? createLaunch(tx, session.metadata.cliArgs);
 
     const insertedNodes: HistoryNode[] = [];
@@ -275,6 +329,15 @@ export function insertHistoryItems(
   session.treeId = result.treeId;
   session.launchId = result.launchId;
   return result.insertedNodes;
+}
+
+function treeIdForHistoryInsert(tx: DbTransaction, session: Session, sessionId: string): number {
+  const treeId = session.treeId;
+  if (treeId == null) return createTree(tx, session.metadata);
+
+  const tree = tx.select({ name: trees.name }).from(trees).where(eq(trees.id, treeId)).get();
+  if (tree?.name !== sessionId) throw new SessionNotFoundError(sessionId);
+  return treeId;
 }
 
 function createTree(tx: DbTransaction, metadata: SessionMetadata): number {


### PR DESCRIPTION
With `octo session delete <session-id>` you now have the power to erase that session!
**After deletion**
<img width="862" height="206" alt="Screenshot 2026-07-24 at 6 51 49 PM" src="https://github.com/user-attachments/assets/59cdb068-b9ba-46b8-9ca6-723011fde5ae" />

**Behavior if you add a message to a session that had been deleted in another tab.**
<img width="1490" height="684" alt="Screenshot 2026-07-24 at 6 51 58 PM" src="https://github.com/user-attachments/assets/c46471fd-68e6-4c82-9d6d-ce6ef10e7088" />

