### PR TITLE
Cool rounded border for octo

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -26,6 +26,7 @@ import {
 import Loading from "./components/loading.tsx";
 import { Header } from "./header.tsx";
 import {
+  BACKGROUND_COLOR,
   SCROLLBAR_COLOR,
   SUBTLE_SCROLLBAR_COLOR,
   UnchainedContext,
@@ -73,7 +74,6 @@ import { MultimediaInput } from "./components/multimedia-input.tsx";
 import { ImageInfo } from "./utils/image-utils.ts";
 import { Markdown } from "./markdown/index.tsx";
 import { LINE_SPLIT_REGEX } from "./str.ts";
-import { countLines } from "./str.ts";
 import { VimModeIndicator } from "./components/vim-mode.tsx";
 import type { ToolCall } from "./libocto/tool-def.ts";
 import type toolMap from "./tools/tool-defs/index.ts";
@@ -84,7 +84,7 @@ import {
   usePriorityInput,
   UNCHAINED_PRIORITY,
 } from "./hooks/use-priority-input.tsx";
-import { readFileSync, writeFileSync } from "fs";
+import { writeFileSync } from "fs";
 import os from "os";
 import path from "path";
 import { CwdContext, useCwd } from "./hooks/use-cwd.tsx";
@@ -259,7 +259,7 @@ export default function App({
         query: state.query,
       })),
     );
-  useKeyboard(event => {
+  useKeyboard(() => {
     cancelNotifyReadyForInput();
   });
   useEffect(() => {
@@ -349,17 +349,10 @@ export default function App({
                             flexDirection: "column",
                             width: "100%",
                             height: "100%",
+                            padding: 1,
                           }}
                         >
                           <TerminalFlex
-                            ref={transcriptRef}
-                            onScroll={event => {
-                              followTranscriptRef.current = isScrolledToBottom(
-                                event.scrollTop,
-                                event.scrollHeight,
-                                transcriptRef.current?.clientHeight ?? 1,
-                              );
-                            }}
                             style={{
                               flexDirection: "column",
                               flexGrow: 1,
@@ -367,75 +360,97 @@ export default function App({
                               flexBasis: 0,
                               minWidth: 0,
                               minHeight: 0,
-                              overflowY: "scroll",
-                              scrollbarGutter: "stable",
-                              scrollbarColor: SCROLLBAR_COLOR,
+                              border: "chunky-rounded",
+                              borderColor: BACKGROUND_COLOR,
+                              backgroundColor: BACKGROUND_COLOR,
                             }}
                           >
                             <TerminalFlex
+                              ref={transcriptRef}
+                              onScroll={event => {
+                                followTranscriptRef.current = isScrolledToBottom(
+                                  event.scrollTop,
+                                  event.scrollHeight,
+                                  transcriptRef.current?.clientHeight ?? 1,
+                                );
+                              }}
                               style={{
                                 flexDirection: "column",
-                                minHeight: "100%",
-                                flexShrink: 0,
-                                overflowWrap: "anywhere",
+                                flexGrow: 1,
+                                flexShrink: 1,
+                                flexBasis: 0,
+                                minWidth: 0,
+                                minHeight: 0,
+                                overflowY: "scroll",
+                                scrollbarGutter: "stable",
+                                scrollbarColor: SCROLLBAR_COLOR,
                               }}
                             >
                               <TerminalFlex
                                 style={{
                                   flexDirection: "column",
-                                  alignItems: "center",
-                                  justifyContent: "center",
-                                  width: "100%",
-                                  flexGrow: 1,
-                                  flexShrink: 1,
-                                  marginTop: 1,
-                                  marginBottom: 1,
+                                  minHeight: "100%",
+                                  flexShrink: 0,
+                                  overflowWrap: "anywhere",
                                 }}
                               >
-                                {bootItems.map((item, index) => (
-                                  <TranscriptItemRenderer item={item} key={`boot-${index}`} />
-                                ))}
-                              </TerminalFlex>
-                              <TranscriptItemRenderer item={{ type: "slogan" }} />
-                              <TerminalFlex
-                                key={clearNonce}
-                                style={{
-                                  flexDirection: "column",
-                                }}
-                              >
-                                {history.map((item, index) => (
-                                  <TranscriptItemRenderer
-                                    item={{
-                                      type: "history-item",
-                                      item,
-                                    }}
-                                    key={`history-${index}`}
-                                  />
-                                ))}
-                                {(modeData.mode === "responding" ||
-                                  modeData.mode === "compacting") &&
-                                  (modeData.inflightResponse.reasoningContent ||
-                                    modeData.inflightResponse.content) && (
-                                    <MessageDisplay item={modeData.inflightResponse} />
+                                <TerminalFlex
+                                  style={{
+                                    flexDirection: "column",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    width: "100%",
+                                    flexGrow: 1,
+                                    flexShrink: 1,
+                                    marginTop: 1,
+                                    marginBottom: 1,
+                                  }}
+                                >
+                                  {bootItems.map((item, index) => (
+                                    <TranscriptItemRenderer item={item} key={`boot-${index}`} />
+                                  ))}
+                                </TerminalFlex>
+                                <TranscriptItemRenderer item={{ type: "slogan" }} />
+                                <TerminalFlex
+                                  key={clearNonce}
+                                  style={{
+                                    flexDirection: "column",
+                                  }}
+                                >
+                                  {history.map((item, index) => (
+                                    <TranscriptItemRenderer
+                                      item={{
+                                        type: "history-item",
+                                        item,
+                                      }}
+                                      key={`history-${index}`}
+                                    />
+                                  ))}
+                                  {(modeData.mode === "responding" ||
+                                    modeData.mode === "compacting") &&
+                                    (modeData.inflightResponse.reasoningContent ||
+                                      modeData.inflightResponse.content) && (
+                                      <MessageDisplay item={modeData.inflightResponse} />
+                                    )}
+                                  {modeData.mode === "tool-call" && (
+                                    <ToolRequestsRenderer
+                                      toolReqs={modeData.toolReqs}
+                                      config={currConfig}
+                                      transport={transport}
+                                      session={session}
+                                      onContentLayout={scrollTranscriptToBottom}
+                                    />
                                   )}
-                                {modeData.mode === "tool-call" && (
-                                  <ToolRequestsRenderer
-                                    toolReqs={modeData.toolReqs}
-                                    config={currConfig}
-                                    transport={transport}
-                                    session={session}
-                                    onContentLayout={scrollTranscriptToBottom}
-                                  />
-                                )}
+                                </TerminalFlex>
                               </TerminalFlex>
                             </TerminalFlex>
+                            <BottomBar
+                              inputHistory={inputHistory}
+                              metadata={metadata}
+                              tempNotification={tempNotification}
+                              onSessionChange={handleSessionChange}
+                            />
                           </TerminalFlex>
-                          <BottomBar
-                            inputHistory={inputHistory}
-                            metadata={metadata}
-                            tempNotification={tempNotification}
-                            onSessionChange={handleSessionChange}
-                          />
                         </TerminalFlex>
                       </ExitOnDoubleCtrlC>
                     </CwdContext.Provider>
@@ -546,6 +561,7 @@ function BottomBar({
         <Span
           style={{
             color: themeColor,
+            visibility: versionCheck === "" ? "hidden" : "visible",
           }}
         >
           {versionCheck}

--- a/source/cli/cli.tsx
+++ b/source/cli/cli.tsx
@@ -31,7 +31,7 @@ import type { ParsedCliArgs } from "./cli-args.ts";
 import { loadSession } from "../session-history/index.ts";
 import type { LoadedSession, Session } from "../session-history/index.ts";
 import { useAppStore } from "../state.ts";
-import { BACKGROUND_COLOR, FOREGROUND_COLOR, THEME_COLOR } from "../theme.ts";
+import { FOREGROUND_COLOR, THEME_COLOR } from "../theme.ts";
 import { KeyboardProvider } from "../hooks/use-keyboard.ts";
 import { AppFocusOverlay } from "../components/app-focus-overlay.tsx";
 import { render, type CreateRootOptions } from "paintcannon-react";
@@ -49,7 +49,6 @@ function renderInteractive(element: React.ReactNode) {
     INTERACTIVE_RENDER_OPTIONS,
   );
   root.container.style.position = "relative";
-  root.container.style.backgroundColor = BACKGROUND_COLOR;
   root.container.style.color = FOREGROUND_COLOR;
   return root;
 }


### PR DESCRIPTION
As proposed by @fireph, this looks sick:

<img width="3838" height="2096" alt="image" src="https://github.com/user-attachments/assets/f2c95099-8d17-43b7-8a77-9031bdd34123" />

It adds a 1-cell transparent padding around the edge of Octo, allowing your original terminal color to show (which can look nice with e.g. tabbed terminals), and uses the Paintcannon `chunky-borders` for a sweet rounded corner floating effect.
