### PR TITLE
In-app load previous session menu

### DIFF
--- a/source/cli/cli.tsx
+++ b/source/cli/cli.tsx
@@ -33,7 +33,12 @@ import { deleteSession, listSessions, loadSession } from "../session-history/ind
 import type { LoadedSession, Session } from "../session-history/index.ts";
 import { useAppStore } from "../state.ts";
 import { FOREGROUND_COLOR, THEME_COLOR } from "../theme.ts";
-import { formatTimeAgo } from "../time.ts";
+import {
+  SESSION_ID_HEADER,
+  SESSION_PREVIEW_HEADER,
+  SESSION_UPDATED_HEADER,
+  sessionListTable,
+} from "../session-history/session-list.ts";
 import { KeyboardProvider } from "../hooks/use-keyboard.ts";
 import { render, type CreateRootOptions } from "paintcannon-react";
 import { ToastProvider } from "../components/toast.tsx";
@@ -345,20 +350,14 @@ sessionCommand
     const sessions = listSessions(process.cwd());
     if (sessions.length === 0) return;
 
-    const sessionIdWidth = Math.max("SESSION ID".length, ...sessions.map(s => s.sessionId.length));
-    const now = new Date();
+    const { rows, sessionIdWidth, previewWidth } = sessionListTable(sessions);
     const octoTheme = chalk.hex(THEME_COLOR);
-    const rows = sessions.map(session => ({
-      ...session,
-      updatedAtText: formatTimeAgo(new Date(session.updatedAt), now),
-    }));
-    const previewWidth = Math.max("PREVIEW".length, ...rows.map(row => (row.preview ?? "").length));
     console.log(`Resume a session with: ${octoTheme("octo --resume <session-id>")}\n`);
     console.log(
-      `${"SESSION ID".padEnd(sessionIdWidth)}  ${"PREVIEW".padEnd(previewWidth)}  LAST UPDATED`,
+      `${SESSION_ID_HEADER.padEnd(sessionIdWidth)}  ${SESSION_PREVIEW_HEADER.padEnd(previewWidth)}  ${SESSION_UPDATED_HEADER}`,
     );
     console.log(
-      `${"─".repeat(sessionIdWidth)}  ${"─".repeat(previewWidth)}  ${"─".repeat("LAST UPDATED".length)}`,
+      `${"─".repeat(sessionIdWidth)}  ${"─".repeat(previewWidth)}  ${"─".repeat(SESSION_UPDATED_HEADER.length)}`,
     );
     for (const row of rows) {
       console.log(

--- a/source/components/kb-select/kb-shortcut-table.tsx
+++ b/source/components/kb-select/kb-shortcut-table.tsx
@@ -1,0 +1,218 @@
+import React, { useEffect, useState } from "react";
+import { Span } from "paintcannon-react";
+import { useKeyboard } from "../../hooks/use-keyboard.ts";
+import { TABLE_SELECTED_ROW_BACKGROUND_COLOR } from "../../theme.ts";
+import { IndicatorComponent } from "../select.tsx";
+import { TerminalFlex } from "../terminal-flex.tsx";
+
+export type KbShortcutTableCellProps<Row> = {
+  row: Row;
+  isSelected: boolean;
+};
+
+export type KbShortcutTableColumn<Row> = {
+  heading: string;
+  Cell: React.ComponentType<KbShortcutTableCellProps<Row>>;
+};
+
+export type KbShortcutTableAction = {
+  shortcut: string;
+  label: React.ReactNode;
+  onSelect: () => void;
+};
+
+type Props<Row> = {
+  rows: Row[];
+  columns: Array<KbShortcutTableColumn<Row>>;
+  getRowKey: (row: Row) => React.Key;
+  onSelect: (row: Row) => void;
+  actions?: KbShortcutTableAction[];
+};
+
+const PAGE_SIZE = 10;
+
+export function KbShortcutTable<Row>({
+  rows,
+  columns,
+  getRowKey,
+  onSelect,
+  actions = [],
+}: Props<Row>) {
+  const [page, setPage] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const pageCount = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
+  const pageStart = page * PAGE_SIZE;
+  const visibleRows = rows.slice(pageStart, pageStart + PAGE_SIZE);
+
+  useEffect(() => {
+    setPage(current => Math.min(current, pageCount - 1));
+    setSelectedIndex(0);
+  }, [pageCount, rows.length]);
+
+  useKeyboard(event => {
+    if (event.ctrlKey) return;
+
+    const action = actions.find(candidate => candidate.shortcut === event.key);
+    if (action) {
+      event.preventDefault();
+      action.onSelect();
+      return;
+    }
+
+    if (event.key === "h" && page > 0) {
+      event.preventDefault();
+      setPage(current => current - 1);
+      setSelectedIndex(0);
+      return;
+    }
+    if (event.key === "l" && page < pageCount - 1) {
+      event.preventDefault();
+      setPage(current => current + 1);
+      setSelectedIndex(0);
+      return;
+    }
+    if (event.key === "k" || event.key === "ArrowUp") {
+      event.preventDefault();
+      setSelectedIndex(current => Math.max(0, current - 1));
+      return;
+    }
+    if (event.key === "j" || event.key === "ArrowDown") {
+      event.preventDefault();
+      setSelectedIndex(current => Math.min(visibleRows.length - 1, current + 1));
+      return;
+    }
+    if (/^[0-9]$/.test(event.key)) {
+      const row = visibleRows[Number.parseInt(event.key, 10)];
+      if (row !== undefined) {
+        event.preventDefault();
+        onSelect(row);
+      }
+      return;
+    }
+    if (event.key === "Enter") {
+      const row = visibleRows[selectedIndex];
+      if (row !== undefined) {
+        event.preventDefault();
+        onSelect(row);
+      }
+    }
+  });
+
+  const actionRowStart = visibleRows.length + (rows.length > 0 ? 2 : 1);
+  return (
+    <TerminalFlex
+      style={{
+        display: "grid",
+        gridTemplateColumns: ["max-content", ...columns.map(() => "max-content")].join(" "),
+        gridAutoRows: "max-content",
+        columnGap: 2,
+      }}
+    >
+      {rows.length > 0 && (
+        <>
+          {columns.map((column, columnIndex) => (
+            <TerminalFlex
+              key={columnIndex}
+              style={{
+                gridColumn: columnIndex === 0 ? "1 / span 2" : columnIndex + 2,
+                gridRow: 1,
+              }}
+            >
+              <TerminalFlex
+                style={{
+                  flexGrow: 1,
+                  minWidth: 0,
+                  marginLeft: columnIndex === 0 ? 2 : 0,
+                  borderBottom: "solid",
+                  borderColor: "gray",
+                }}
+              >
+                <Span style={{ color: "gray" }}>{column.heading}</Span>
+              </TerminalFlex>
+            </TerminalFlex>
+          ))}
+        </>
+      )}
+      {visibleRows.map((row, rowIndex) => {
+        const isSelected = rowIndex === selectedIndex;
+        const gridRow = rowIndex + 2;
+        const backgroundColor = isSelected ? TABLE_SELECTED_ROW_BACKGROUND_COLOR : undefined;
+        return (
+          <React.Fragment key={getRowKey(row)}>
+            {backgroundColor && (
+              <TerminalFlex
+                style={{
+                  gridColumn: "1 / -1",
+                  gridRow,
+                  backgroundColor,
+                }}
+              />
+            )}
+            <TerminalFlex
+              style={{
+                gridColumn: 1,
+                gridRow,
+                flexWrap: "nowrap",
+                backgroundColor,
+              }}
+            >
+              <IndicatorComponent isSelected={isSelected} />
+              <Span style={{ color: "gray" }}>{rowIndex}:</Span>
+            </TerminalFlex>
+            {columns.map((column, columnIndex) => (
+              <TerminalFlex
+                key={columnIndex}
+                style={{
+                  gridColumn: columnIndex + 2,
+                  gridRow,
+                  minWidth: 0,
+                  backgroundColor,
+                }}
+              >
+                <column.Cell row={row} isSelected={isSelected} />
+              </TerminalFlex>
+            ))}
+          </React.Fragment>
+        );
+      })}
+      {page > 0 && <TableAction gridRow={actionRowStart} label="Previous page" shortcut="h" />}
+      {page < pageCount - 1 && (
+        <TableAction gridRow={actionRowStart + (page > 0 ? 1 : 0)} label="Next page" shortcut="l" />
+      )}
+      {actions.map((action, actionIndex) => (
+        <TableAction
+          key={action.shortcut}
+          gridRow={
+            actionRowStart + (page > 0 ? 1 : 0) + (page < pageCount - 1 ? 1 : 0) + actionIndex
+          }
+          label={action.label}
+          shortcut={action.shortcut}
+        />
+      ))}
+    </TerminalFlex>
+  );
+}
+
+function TableAction({
+  gridRow,
+  label,
+  shortcut,
+}: {
+  gridRow: number;
+  label: React.ReactNode;
+  shortcut: string;
+}) {
+  return (
+    <TerminalFlex
+      style={{
+        gridColumn: "1 / -1",
+        gridRow,
+      }}
+    >
+      <TerminalFlex style={{ width: 5, flexShrink: 0 }} />
+      <Span>{label}</Span>
+      <Span> </Span>
+      <Span style={{ color: "gray" }}>({shortcut})</Span>
+    </TerminalFlex>
+  );
+}

--- a/source/menu.tsx
+++ b/source/menu.tsx
@@ -3,7 +3,7 @@ import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 import { useAppStore, useModel } from "./state.ts";
 import { useSession } from "./session-context.ts";
-import type { Session } from "./session-history/index.ts";
+import { listPreviousSessions, type Session } from "./session-history/index.ts";
 import { Auth, mergeEnvVar, useConfig, useSetConfig, Config } from "./config.ts";
 import { ModelSetup } from "./components/auto-detect-models.tsx";
 import { AutofixModelMenu } from "./components/autofix-model-menu.tsx";
@@ -16,8 +16,10 @@ import { MenuQuotaIndicator } from "./components/menu-quota-indicator.tsx";
 import { CustomAuthFlow } from "./components/add-model-flow.tsx";
 import { Span, useApp } from "paintcannon-react";
 import { useKeyboard } from "./hooks/use-keyboard.ts";
+import { LoadSessionMenu } from "./session-history/load-session-menu.tsx";
 type MenuMode =
   | "main-menu"
+  | "load-session"
   | "settings-menu"
   | "model-select"
   | "add-model"
@@ -41,12 +43,18 @@ const useMenuState = create<MenuState>((set, _) => ({
   },
 }));
 export function Menu({ onSessionChange }: { onSessionChange: (session: Session) => void }) {
-  const { menuMode } = useMenuState(
+  const { menuMode, setMenuMode } = useMenuState(
     useShallow(state => ({
       menuMode: state.menuMode,
+      setMenuMode: state.setMenuMode,
     })),
   );
   if (menuMode === "main-menu") return <MainMenu />;
+  if (menuMode === "load-session") {
+    return (
+      <LoadSessionMenu onBack={() => setMenuMode("main-menu")} onSessionChange={onSessionChange} />
+    );
+  }
   if (menuMode === "settings-menu") return <SettingsMenu />;
   if (menuMode === "model-select") return <SwitchModelMenu />;
   if (menuMode === "set-default-model") return <SetDefaultModelMenu />;
@@ -360,6 +368,8 @@ function MainMenu() {
     })),
   );
   const session = useSession();
+  const hasPreviousSessions =
+    listPreviousSessions(session.metadata.cwd, session.metadata.sessionId).length > 0;
   const { setMenuMode } = useMenuState(
     useShallow(state => ({
       setMenuMode: state.setMenuMode,
@@ -376,6 +386,7 @@ function MainMenu() {
   type Value =
     | "model-select"
     | "add-model"
+    | "load-session"
     | "vim-toggle"
     | "return"
     | "quit"
@@ -398,6 +409,15 @@ function MainMenu() {
       value: "clear-confirm" as const,
     },
   };
+  if (hasPreviousSessions) {
+    items = {
+      ...items,
+      s: {
+        label: "⥻ Load previous session",
+        value: "load-session" as const,
+      },
+    };
+  }
   if (config.vimEmulation?.enabled) {
     items = {
       ...items,

--- a/source/session-history/index.ts
+++ b/source/session-history/index.ts
@@ -127,6 +127,13 @@ export function deleteSession(sessionId: string): boolean {
   });
 }
 
+export function listPreviousSessions(
+  cwd: string,
+  currentSessionId: string | null,
+): SessionSummary[] {
+  return listSessions(cwd).filter(session => session.sessionId !== currentSessionId);
+}
+
 export function loadSession(sessionId: string): LoadedSession | null {
   const tree = loadSessionTree(sessionId);
   if (tree == null) return null;

--- a/source/session-history/load-session-menu.tsx
+++ b/source/session-history/load-session-menu.tsx
@@ -1,0 +1,135 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { Span } from "paintcannon-react";
+import { useShallow } from "zustand/react/shallow";
+import { MenuHeader } from "../components/kb-select/kb-shortcut-panel.tsx";
+import {
+  KbShortcutTable,
+  type KbShortcutTableCellProps,
+  type KbShortcutTableColumn,
+} from "../components/kb-select/kb-shortcut-table.tsx";
+import { TerminalFlex } from "../components/terminal-flex.tsx";
+import { useCwd } from "../hooks/use-cwd.tsx";
+import { useKeyboard } from "../hooks/use-keyboard.ts";
+import { useSession } from "../session-context.ts";
+import { useAppStore } from "../state.ts";
+import { useColor } from "../theme.ts";
+import { listPreviousSessions, loadSession, type Session } from "./index.ts";
+import {
+  SESSION_PREVIEW_HEADER,
+  SESSION_UPDATED_HEADER,
+  sessionListTable,
+  type SessionListRow,
+} from "./session-list.ts";
+
+type Props = {
+  onBack: () => void;
+  onSessionChange: (session: Session) => void;
+};
+
+const SESSION_COLUMNS: Array<KbShortcutTableColumn<SessionListRow>> = [
+  {
+    heading: SESSION_PREVIEW_HEADER,
+    Cell: SessionPreviewCell,
+  },
+  {
+    heading: SESSION_UPDATED_HEADER,
+    Cell: SessionUpdatedCell,
+  },
+];
+
+export function LoadSessionMenu({ onBack, onSessionChange }: Props) {
+  const cwd = useCwd();
+  const currentSession = useSession();
+  const [error, setError] = useState<string | null>(null);
+  const { closeMenu, hydrateSession, setQuery } = useAppStore(
+    useShallow(state => ({
+      closeMenu: state.closeMenu,
+      hydrateSession: state.hydrateSession,
+      setQuery: state.setQuery,
+    })),
+  );
+  const rows = useMemo(
+    () => sessionListTable(listPreviousSessions(cwd, currentSession.metadata.sessionId)).rows,
+    [currentSession.metadata.sessionId, cwd],
+  );
+
+  useKeyboard(event => {
+    if (event.key === "Escape") onBack();
+  });
+
+  const load = useCallback(
+    (row: SessionListRow) => {
+      const loaded = loadSession(row.sessionId);
+      if (loaded == null) {
+        setError(`Session ${row.sessionId} no longer exists.`);
+        return;
+      }
+
+      const nextSession: Session = {
+        ...loaded.session,
+        metadata: {
+          ...loaded.session.metadata,
+          cliArgs: currentSession.metadata.cliArgs,
+        },
+      };
+      setQuery("");
+      hydrateSession(loaded.history);
+      onSessionChange(nextSession);
+      onBack();
+      closeMenu();
+    },
+    [closeMenu, currentSession.metadata.cliArgs, hydrateSession, onBack, onSessionChange, setQuery],
+  );
+
+  return (
+    <TerminalFlex
+      style={{
+        flexDirection: "column",
+      }}
+    >
+      <MenuHeader title="Load previous session" />
+      <TerminalFlex
+        style={{
+          justifyContent: "center",
+        }}
+      >
+        <TerminalFlex
+          style={{
+            flexDirection: "column",
+          }}
+        >
+          {rows.length === 0 && (
+            <Span style={{ color: "gray" }}>No saved sessions found for this directory.</Span>
+          )}
+          <KbShortcutTable
+            rows={rows}
+            columns={SESSION_COLUMNS}
+            getRowKey={row => row.sessionId}
+            onSelect={load}
+            actions={[
+              {
+                shortcut: "b",
+                label: "Back to main menu",
+                onSelect: onBack,
+              },
+            ]}
+          />
+          {error && <Span style={{ color: "red" }}>{error}</Span>}
+        </TerminalFlex>
+      </TerminalFlex>
+    </TerminalFlex>
+  );
+}
+
+function SessionPreviewCell({ row, isSelected }: KbShortcutTableCellProps<SessionListRow>) {
+  const themeColor = useColor();
+  return (
+    <TerminalFlex style={{ minWidth: 40 }}>
+      <Span style={isSelected ? { color: themeColor } : undefined}>{row.preview ?? ""}</Span>
+    </TerminalFlex>
+  );
+}
+
+function SessionUpdatedCell({ row, isSelected }: KbShortcutTableCellProps<SessionListRow>) {
+  return <Span style={isSelected ? undefined : { color: "gray" }}>{row.updatedAtText}</Span>;
+}

--- a/source/session-history/session-list.ts
+++ b/source/session-history/session-list.ts
@@ -1,0 +1,34 @@
+import type { SessionSummary } from "./index.ts";
+import { formatTimeAgo } from "../time.ts";
+
+export const SESSION_ID_HEADER = "SESSION ID";
+export const SESSION_PREVIEW_HEADER = "PREVIEW";
+export const SESSION_UPDATED_HEADER = "LAST UPDATED";
+
+export type SessionListRow = SessionSummary & {
+  updatedAtText: string;
+};
+
+export type SessionListTable = {
+  rows: SessionListRow[];
+  sessionIdWidth: number;
+  previewWidth: number;
+};
+
+export function sessionListTable(
+  sessions: SessionSummary[],
+  now: Date = new Date(),
+): SessionListTable {
+  const rows = sessions.map(session => ({
+    ...session,
+    updatedAtText: formatTimeAgo(new Date(session.updatedAt), now),
+  }));
+  return {
+    rows,
+    sessionIdWidth: Math.max(SESSION_ID_HEADER.length, ...rows.map(row => row.sessionId.length)),
+    previewWidth: Math.max(
+      SESSION_PREVIEW_HEADER.length,
+      ...rows.map(row => (row.preview ?? "").length),
+    ),
+  };
+}

--- a/source/theme.ts
+++ b/source/theme.ts
@@ -11,6 +11,7 @@ export const BACKGROUND_COLOR = "#0f172a";
 export const DIMMED_BACKGROUND_COLOR = "#020617";
 export const FOREGROUND_COLOR = "#bababa";
 export const THOUGHTBOX_COLOR = "#6b6b6b";
+export const TABLE_SELECTED_ROW_BACKGROUND_COLOR = "#1e293b";
 export const SCROLLBAR_COLOR = "#64748b #1e293b";
 export const DIMMED_SCROLLBAR_COLOR = "#475569 #0f172a";
 export const SUBTLE_SCROLLBAR_COLOR = "#475569 #1e293b";


### PR DESCRIPTION
Ignore the sessions with no preview text; this will not happen to any non-canary users.
<img width="2876" height="1072" alt="image" src="https://github.com/user-attachments/assets/d3e68f6d-43a6-4a1f-ab8d-e51c22526f84" />
