### PR TITLE
Fix dangling tool calls

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -612,7 +612,7 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
         setVimMode("NORMAL");
         return;
       }
-      abortResponse();
+      abortResponse(session);
       if (modeData.mode === "menu") closeMenu();
     }
     if (event.ctrlKey && event.key === "p") {

--- a/source/compilers/lower-octo.test.ts
+++ b/source/compilers/lower-octo.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { lowerOcto } from "./lower-octo.ts";
+import type { LoweredIR } from "../libocto/llm-ir.ts";
+import { compilerUsage } from "../libocto/compilers/compiler-interface.ts";
+import type { ToolCall } from "../libocto/tool-def.ts";
+import type toolMap from "../tools/tool-defs/index.ts";
+import type { OctoIR } from "../ir/octo-ir.ts";
+import type { ImageInfo } from "../utils/image-utils.ts";
+import type { MultimodalConfig } from "../providers.ts";
+
+/*
+ * Regression tests for BUGS.md #3: reading an image with a vision model must not leave a
+ * dangling tool call in the lowered history.
+ *
+ * Every tool call in an assistant message must be answered by a tool-output-shaped IR before the
+ * history is sent to a compiler. Anthropic hard-400s on unanswered `tool_use` blocks, and while
+ * the chat-completions spec tolerates missing outputs, a call with no result is confusing and
+ * out-of-distribution for models.
+ */
+
+type ReadToolCall = Extract<ToolCall<typeof toolMap>, { name: "read" }>;
+
+function readCall(id: string, filePath: string): ReadToolCall {
+  return {
+    type: "tool-call",
+    name: "read",
+    toolCallId: id,
+    original: { filePath },
+    parsed: { filePath },
+  };
+}
+
+function imageInfo(): ImageInfo {
+  return {
+    mimeType: "image/png",
+    base64Data: "aGVsbG8=",
+    dataUrl: "data:image/png;base64,aGVsbG8=",
+    filePath: "/tmp/screenshot.png",
+    sizeBytes: 5,
+  };
+}
+
+const VISION: MultimodalConfig = {
+  image: {
+    enabled: true,
+    maxSizeMB: 10,
+    acceptedMimeTypes: ["image/png"],
+  },
+};
+
+function unansweredToolCallIds(messages: Array<LoweredIR<typeof toolMap>>): string[] {
+  const requested: string[] = [];
+  const answered = new Set<string>();
+  for (const ir of messages) {
+    if (ir.role === "assistant") {
+      for (const call of ir.toolCalls ?? []) {
+        requested.push(call.toolCallId);
+      }
+      continue;
+    }
+    if (
+      ir.role === "tool-output" ||
+      ir.role === "tool-skip-output" ||
+      ir.role === "tool-runtime-error" ||
+      ir.role === "tool-validation-error"
+    ) {
+      answered.add(ir.toolCall.toolCallId);
+      continue;
+    }
+    if (ir.role === "tool-parse-error") {
+      answered.add(ir.malformedRequest.toolCallId);
+    }
+  }
+  return requested.filter(id => !answered.has(id));
+}
+
+function imageReadHistory(): OctoIR[] {
+  const call = readCall("call_image", "/tmp/screenshot.png");
+  return [
+    {
+      role: "user",
+      content: [{ type: "text", content: "What does /tmp/screenshot.png show?" }],
+    },
+    {
+      role: "assistant",
+      content: "Let me look at that image.",
+      usage: compilerUsage(0, 0),
+      toolCalls: [call],
+    },
+    {
+      role: "file-read",
+      path: "/tmp/screenshot.png",
+      content: "Image file: /tmp/screenshot.png",
+      image: imageInfo(),
+      toolCall: call,
+    },
+  ];
+}
+
+describe("lowerOcto tool-call answering", () => {
+  it("answers the tool call for an image read when the model has vision", () => {
+    const lowered = lowerOcto(imageReadHistory(), VISION);
+    expect(unansweredToolCallIds(lowered)).toEqual([]);
+  });
+
+  it("answers the tool call for an image read when the model lacks vision", () => {
+    const lowered = lowerOcto(imageReadHistory(), undefined);
+    expect(unansweredToolCallIds(lowered)).toEqual([]);
+  });
+
+  it("answers the tool call for a plain text read", () => {
+    const call = readCall("call_text", "/tmp/notes.txt");
+    const lowered = lowerOcto(
+      [
+        {
+          role: "user",
+          content: [{ type: "text", content: "Read /tmp/notes.txt" }],
+        },
+        {
+          role: "assistant",
+          content: "Reading it.",
+          usage: compilerUsage(0, 0),
+          toolCalls: [call],
+        },
+        {
+          role: "file-read",
+          path: "/tmp/notes.txt",
+          content: "1: hello",
+          toolCall: call,
+        },
+      ],
+      VISION,
+    );
+    expect(unansweredToolCallIds(lowered)).toEqual([]);
+  });
+});

--- a/source/compilers/optimize-files.test.ts
+++ b/source/compilers/optimize-files.test.ts
@@ -60,7 +60,7 @@ describe("optimizeFiles", () => {
     ]);
   });
 
-  it("turns displayable image reads into user messages with images", () => {
+  it("answers displayable image reads with a tool output containing the image", () => {
     const image: ImageInfo = {
       mimeType: "image/png",
       base64Data: "abc",
@@ -90,9 +90,10 @@ describe("optimizeFiles", () => {
       ),
     ).toEqual([
       {
-        role: "user",
+        role: "tool-output",
+        toolCall: toolCall("image-read"),
         content: [
-          { type: "text", content: "[Tool result for call image-read]: image contents" },
+          { type: "text", content: "image contents" },
           { type: "image", image },
         ],
       },

--- a/source/compilers/optimize-files.ts
+++ b/source/compilers/optimize-files.ts
@@ -36,13 +36,17 @@ function optimizeFileIR(
 
     const imageCheck = ir.image ? canDisplayImage(modalities, ir.image) : null;
     if (ir.image && imageCheck?.ok) {
+      /*
+       * The read tool call must still be answered by a tool-output-shaped IR: converting it
+       * into a user message would leave the assistant's tool call dangling, which Anthropic
+       * hard-400s on (and is out-of-distribution for chat-completions models). Vision models
+       * support images in tool outputs, so attach the image to the tool output directly.
+       */
       return {
-        role: "user",
+        role: "tool-output",
+        toolCall: ir.toolCall,
         content: [
-          {
-            type: "text",
-            content: `[Tool result for call ${ir.toolCall.toolCallId}]: ${ir.content}`,
-          },
+          { type: "text", content: irPrompts.fileRead(ir.content, seenPath, imageCheck) },
           { type: "image", image: ir.image },
         ],
       };

--- a/source/components/exit-on-double-ctrl-c.tsx
+++ b/source/components/exit-on-double-ctrl-c.tsx
@@ -2,6 +2,7 @@ import React, { useState, createContext, useContext } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "../state.ts";
 import { useConfig } from "../config.ts";
+import { useSession } from "../session-context.ts";
 import { useApp } from "paintcannon-react";
 import { useKeyboard } from "../hooks/use-keyboard.ts";
 export function useCtrlC(callback: () => void) {
@@ -19,6 +20,7 @@ export function ExitOnDoubleCtrlC({ children }: { children: React.ReactNode }) {
   const [ctrlCPressed, setCtrlCPressed] = useState(false);
   const { exit } = useApp();
   const config = useConfig();
+  const session = useSession();
   const vimEnabled = !!config.vimEmulation?.enabled;
   const { modeData } = useAppStore(
     useShallow(state => ({
@@ -28,6 +30,14 @@ export function ExitOnDoubleCtrlC({ children }: { children: React.ReactNode }) {
   const isInsertMode = vimEnabled && modeData.mode === "input" && modeData.vimMode === "INSERT";
   useCtrlC(() => {
     if (ctrlCPressed) {
+      /*
+       * Record skip markers for any un-run tool calls before exiting, so the session history
+       * stays well-formed (Anthropic rejects sessions with unanswered tool calls on resume).
+       * If the menu is open, close it first: the in-flight state is stashed in preMenuModeData.
+       */
+      const state = useAppStore.getState();
+      if (state.modeData.mode === "menu") state.closeMenu();
+      state.abortResponse(session, { exiting: true });
       exit();
     } else {
       if (!isInsertMode) {

--- a/source/libocto/compilers/ir-prompts.ts
+++ b/source/libocto/compilers/ir-prompts.ts
@@ -9,6 +9,10 @@ export function imageAttachmentPlaceholderText() {
   return "[An image was attached here. Since images are not supported by your model, the source to the image is omitted. There might be future context that allows you to make a guess about what the image was, so keep that in mind as you process the rest of the messages.]";
 }
 
+export function toolImageOutputPreamble() {
+  return "The tool call above returned the following image:";
+}
+
 export function openTag(tag: string, attrs?: Record<string, string>) {
   if (!attrs || Object.keys(attrs).length === 0) return "<" + tag + ">";
 

--- a/source/libocto/compilers/responses.ts
+++ b/source/libocto/compilers/responses.ts
@@ -99,26 +99,51 @@ function responseContentParts(
 }
 
 function responseToolOutput(
+  toolCallId: string,
   content: IRContent["content"],
   modalities?: CompilerModalities,
-): string {
-  const visibleParts = content.map(part => {
-    if (part.type === "text") return { type: "text" as const, text: part.content };
-    if (!modalities?.includes("vision")) {
-      return { type: "text" as const, text: imagePlaceholderContent() };
+): ResponseInput {
+  /*
+   * The Responses API only allows plain-string function call outputs, unlike chat completions
+   * and Anthropic which support image content in tool outputs. Text parts go into the output
+   * string; images for vision models are delivered in a user message immediately after the
+   * function call output, keeping the call/output adjacency intact without inlining base64
+   * into the output string.
+   */
+  const textParts: string[] = [];
+  const imageParts: ResponseInputContent[] = [];
+  for (const part of content) {
+    if (part.type === "text") {
+      textParts.push(part.content);
+      continue;
     }
-    return {
-      type: "image" as const,
-      mimeType: part.image.mimeType,
-      dataUrl: part.image.dataUrl,
-    };
-  });
-
-  if (visibleParts.every(part => part.type === "text")) {
-    return visibleParts.map(part => part.text).join("\n");
+    if (modalities?.includes("vision")) {
+      imageParts.push({
+        type: "input_image",
+        detail: "auto",
+        image_url: part.image.dataUrl,
+      });
+    } else {
+      textParts.push(imagePlaceholderContent());
+    }
   }
 
-  return JSON.stringify(visibleParts);
+  const output: ResponseInput = [
+    {
+      type: "function_call_output",
+      call_id: toolCallId,
+      output: textParts.join("\n"),
+    },
+  ];
+
+  if (imageParts.length > 0) {
+    output.push({
+      role: "user",
+      content: [{ type: "input_text", text: irPrompts.toolImageOutputPreamble() }, ...imageParts],
+    });
+  }
+
+  return output;
 }
 
 async function toResponseInput<A extends Agent<any, any, any>>(
@@ -192,13 +217,7 @@ function responseInputFromIr<A extends Agent<any, any, any>>(
   }
 
   if (ir.role === "tool-output") {
-    return [
-      {
-        type: "function_call_output",
-        call_id: ir.toolCall.toolCallId,
-        output: responseToolOutput(ir.content, modalities),
-      },
-    ];
+    return responseToolOutput(ir.toolCall.toolCallId, ir.content, modalities);
   }
 
   if (ir.role === "tool-skip-output") {

--- a/source/menu.tsx
+++ b/source/menu.tsx
@@ -650,11 +650,22 @@ function QuitConfirm() {
     })),
   );
   const app = useApp();
+  const session = useSession();
   return (
     <ConfirmDialog
       confirmLabel="Yes, quit"
       rejectLabel="Never mind, take me back"
-      onConfirm={() => app.exit()}
+      onConfirm={() => {
+        /*
+         * Restore the stashed pre-menu state (which may be an in-flight tool batch), then
+         * record skip markers for any un-run tool calls so the session history stays
+         * well-formed after exit.
+         */
+        const state = useAppStore.getState();
+        state.closeMenu();
+        state.abortResponse(session, { exiting: true });
+        app.exit();
+      }}
       onReject={() => setMenuMode("main-menu")}
       rejectFirst={true}
     />

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -176,4 +176,28 @@ describe("aborting a tool batch", () => {
     expect(unansweredToolCallIds(useAppStore.getState().history)).toEqual([]);
     expect(useAppStore.getState().modeData.mode).toBe("input");
   }, 30_000);
+
+  it("marks even the running tool call as answered when exiting", async () => {
+    const transport = new LocalTransport();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "octo-state-test-"));
+    tempDirs.push(dir);
+    const marker = path.join(dir, "started");
+
+    const callA = shellCall("call_a", `touch ${marker} && sleep 30`);
+    const callB = shellCall("call_b", "echo b");
+    const { session } = setupToolBatch(callA, callB);
+
+    const running = useAppStore.getState().runTool({ config, transport, session, toolReq: callA });
+    await waitFor(() => existsSync(marker));
+
+    /*
+     * On exit (double Ctrl+C, menu quit) the process can't wait for the running tool to
+     * settle, so the store must synchronously mark every unanswered call as skipped —
+     * including the running one. Assert before `running` resolves.
+     */
+    useAppStore.getState().abortResponse(session, { exiting: true });
+    expect(unansweredToolCallIds(useAppStore.getState().history)).toEqual([]);
+
+    await running;
+  }, 30_000);
 });

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -1,0 +1,179 @@
+import { existsSync } from "fs";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAppStore } from "./state.ts";
+import type { Config } from "./config.ts";
+import type { HistoryNode } from "./session-history/index.ts";
+import { createSession, insertHistoryItems } from "./session-history/index.ts";
+import { compilerUsage } from "./libocto/compilers/compiler-interface.ts";
+import type { ToolCall } from "./libocto/tool-def.ts";
+import type toolMap from "./tools/tool-defs/index.ts";
+import { LocalTransport } from "./transports/local.ts";
+
+/*
+ * Regression tests for BUGS.md #2: aborting a multi-tool batch must not leave dangling tool
+ * calls in history.
+ *
+ * Every tool call in an assistant message must be answered by a tool-output-shaped IR. Anthropic
+ * hard-400s on unanswered `tool_use` blocks, and while the chat-completions spec tolerates
+ * missing outputs, a call with no result is confusing and out-of-distribution for models.
+ * Today, ESC during a tool batch silently drops every request after the currently-running one.
+ */
+
+type ShellToolCall = Extract<ToolCall<typeof toolMap>, { name: "shell" }>;
+
+const config: Config = {
+  yourName: "Test",
+  models: [
+    {
+      nickname: "test-model",
+      model: "test-model",
+      context: 128_000,
+      baseUrl: "http://localhost",
+    },
+  ],
+};
+
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  useAppStore.setState({
+    history: [],
+    preMenuModeData: null,
+    lastUserPromptIndex: null,
+    modeData: { mode: "input", vimMode: "INSERT" },
+  });
+});
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()!;
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+function shellCall(id: string, cmd: string): ShellToolCall {
+  return {
+    type: "tool-call",
+    name: "shell",
+    toolCallId: id,
+    original: { cmd, timeout: 60_000 },
+    parsed: { cmd, timeout: 60_000 },
+  };
+}
+
+function unansweredToolCallIds(history: readonly HistoryNode[]): string[] {
+  const requested: string[] = [];
+  const answered = new Set<string>();
+  for (const item of history) {
+    if (item.type !== "llm-ir") continue;
+    const ir = item.ir;
+    if (ir.role === "assistant") {
+      for (const call of ir.toolCalls ?? []) {
+        requested.push(call.toolCallId);
+      }
+      continue;
+    }
+    if (
+      ir.role === "tool-output" ||
+      ir.role === "tool-skip-output" ||
+      ir.role === "tool-runtime-error" ||
+      ir.role === "tool-validation-error" ||
+      ir.role === "tool-reject"
+    ) {
+      answered.add(ir.toolCall.toolCallId);
+      continue;
+    }
+    if (ir.role === "tool-parse-error") {
+      answered.add(ir.malformedRequest.toolCallId);
+      continue;
+    }
+    if (ir.role === "file-read" || ir.role === "file-mutate") {
+      answered.add(ir.toolCall.toolCallId);
+    }
+  }
+  return requested.filter(id => !answered.has(id));
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 10_000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("Timed out waiting for condition");
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+}
+
+function setupToolBatch(callA: ShellToolCall, callB: ShellToolCall) {
+  const session = createSession(process.cwd(), { kind: "local" });
+  const nodes = insertHistoryItems(session, null, [
+    {
+      type: "llm-ir",
+      ir: {
+        role: "user",
+        content: [{ type: "text", content: "Run these two commands" }],
+      },
+    },
+    {
+      type: "llm-ir",
+      ir: {
+        role: "assistant",
+        content: "On it.",
+        usage: compilerUsage(0, 0),
+        toolCalls: [callA, callB],
+      },
+    },
+  ]);
+  useAppStore.getState().hydrateSession(nodes);
+  const abortController = new AbortController();
+  useAppStore.setState({
+    modeData: {
+      mode: "tool-call",
+      toolReqs: [callA, callB],
+      runningToolCallId: null,
+      abortController,
+    },
+  });
+  return { session, abortController };
+}
+
+describe("aborting a tool batch", () => {
+  it("marks pending tool calls as answered when aborting between tool calls", async () => {
+    const transport = new LocalTransport();
+    const callA = shellCall("call_a", "echo a");
+    const callB = shellCall("call_b", "echo b");
+    const { session } = setupToolBatch(callA, callB);
+
+    await useAppStore.getState().runTool({ config, transport, session, toolReq: callA });
+
+    // The user presses ESC while call_b is still pending. The UI drops the remaining requests
+    // (ToolRequestsRenderer unmounts), so the store must record that call_b never ran —
+    // otherwise the next request sends an assistant message with an unanswered tool call.
+    useAppStore.getState().abortResponse(session);
+
+    expect(unansweredToolCallIds(useAppStore.getState().history)).toEqual([]);
+    expect(useAppStore.getState().modeData.mode).toBe("input");
+  });
+
+  it("marks pending tool calls as answered when aborting a running tool", async () => {
+    const transport = new LocalTransport();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "octo-state-test-"));
+    tempDirs.push(dir);
+    const marker = path.join(dir, "started");
+
+    const callA = shellCall("call_a", `touch ${marker} && sleep 30`);
+    const callB = shellCall("call_b", "echo b");
+    const { session } = setupToolBatch(callA, callB);
+
+    const running = useAppStore.getState().runTool({ config, transport, session, toolReq: callA });
+
+    // Wait for the shell command to actually start, then ESC mid-run.
+    await waitFor(() => existsSync(marker));
+    useAppStore.getState().abortResponse(session);
+    await running;
+
+    expect(unansweredToolCallIds(useAppStore.getState().history)).toEqual([]);
+    expect(useAppStore.getState().modeData.mode).toBe("input");
+  }, 30_000);
+});

--- a/source/state.ts
+++ b/source/state.ts
@@ -122,7 +122,7 @@ export type UiState = {
   input: (args: RunArgs & { query: string; images?: ImageInfo[] }) => Promise<void>;
   runTool: (args: RunArgs & { toolReq: ToolCallRequest }) => Promise<void>;
   rejectTool: (toolCall: ToolCallRequest, session: Session) => void;
-  abortResponse: () => void;
+  abortResponse: (session: Session) => void;
   toggleMenu: () => void;
   openMenu: () => void;
   closeMenu: () => void;
@@ -335,9 +335,66 @@ export const useAppStore = create<UiState>((set, get) => ({
     });
   },
 
-  abortResponse: () => {
+  abortResponse: (session: Session) => {
     const { modeData } = get();
     if ("abortController" in modeData) modeData.abortController.abort();
+    if (modeData.mode !== "tool-call") return;
+
+    /*
+     * Aborting a tool batch mid-flight leaves every request that never ran unanswered in
+     * history; Anthropic hard-400s on unanswered tool calls, and chat-completions models find
+     * them out-of-distribution. Mark any unanswered requests as skipped so the next request is
+     * well-formed. The currently-running tool is excluded: it appends its own output when it
+     * settles.
+     */
+    const answered = new Set<string>();
+    for (const item of get().history) {
+      if (item.type !== "llm-ir") continue;
+      const ir = item.ir;
+      if (
+        ir.role === "tool-output" ||
+        ir.role === "tool-skip-output" ||
+        ir.role === "tool-runtime-error" ||
+        ir.role === "tool-validation-error" ||
+        ir.role === "tool-reject" ||
+        ir.role === "file-read" ||
+        ir.role === "file-mutate"
+      ) {
+        answered.add(ir.toolCall.toolCallId);
+      }
+    }
+
+    const skipped: HistoryItem[] = [];
+    for (const req of modeData.toolReqs) {
+      if (req.type !== "tool-call") continue;
+      if (req.toolCallId === modeData.runningToolCallId) continue;
+      if (answered.has(req.toolCallId)) continue;
+      skipped.push({
+        type: "llm-ir",
+        ir: {
+          role: "tool-skip-output",
+          toolCall: req,
+          reason: "The user aborted the response, so this tool was skipped",
+        },
+      });
+    }
+
+    if (skipped.length > 0) {
+      set({ history: appendAndPersistHistory(session, get().history, skipped) });
+    }
+
+    /*
+     * If no tool is currently running, nothing else will flip the mode back to input, so do it
+     * here. If a tool is running, runTool's _maybeHandleAbort flips it once the tool settles.
+     */
+    if (modeData.runningToolCallId == null) {
+      set({
+        modeData: {
+          mode: "input",
+          vimMode: "INSERT",
+        },
+      });
+    }
   },
 
   _maybeHandleAbort: (signal: AbortSignal): boolean => {

--- a/source/state.ts
+++ b/source/state.ts
@@ -122,7 +122,7 @@ export type UiState = {
   input: (args: RunArgs & { query: string; images?: ImageInfo[] }) => Promise<void>;
   runTool: (args: RunArgs & { toolReq: ToolCallRequest }) => Promise<void>;
   rejectTool: (toolCall: ToolCallRequest, session: Session) => void;
-  abortResponse: (session: Session) => void;
+  abortResponse: (session: Session, opts?: { exiting?: boolean }) => void;
   toggleMenu: () => void;
   openMenu: () => void;
   closeMenu: () => void;
@@ -335,7 +335,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     });
   },
 
-  abortResponse: (session: Session) => {
+  abortResponse: (session: Session, opts?: { exiting?: boolean }) => {
     const { modeData } = get();
     if ("abortController" in modeData) modeData.abortController.abort();
     if (modeData.mode !== "tool-call") return;
@@ -344,8 +344,9 @@ export const useAppStore = create<UiState>((set, get) => ({
      * Aborting a tool batch mid-flight leaves every request that never ran unanswered in
      * history; Anthropic hard-400s on unanswered tool calls, and chat-completions models find
      * them out-of-distribution. Mark any unanswered requests as skipped so the next request is
-     * well-formed. The currently-running tool is excluded: it appends its own output when it
-     * settles.
+     * well-formed. Normally the currently-running tool is excluded, since it appends its own
+     * output when it settles — but when the process is exiting it will never settle, so mark
+     * it as skipped too.
      */
     const answered = new Set<string>();
     for (const item of get().history) {
@@ -367,14 +368,17 @@ export const useAppStore = create<UiState>((set, get) => ({
     const skipped: HistoryItem[] = [];
     for (const req of modeData.toolReqs) {
       if (req.type !== "tool-call") continue;
-      if (req.toolCallId === modeData.runningToolCallId) continue;
       if (answered.has(req.toolCallId)) continue;
+      const isRunning = req.toolCallId === modeData.runningToolCallId;
+      if (isRunning && !opts?.exiting) continue;
       skipped.push({
         type: "llm-ir",
         ir: {
           role: "tool-skip-output",
           toolCall: req,
-          reason: "The user aborted the response, so this tool was skipped",
+          reason: isRunning
+            ? "The user exited while this tool was running, so its output was not recorded"
+            : "The user aborted the response, so this tool was skipped",
         },
       });
     }


### PR DESCRIPTION
Now that we have Kimi K3 on Synthetic, I pointed Kimi-in-Octo at Octo and told it to find bugs. Two of the more-critical bugs it found were:

1. When aborting a tool call, we left it dangling without a corresponding tool call output IR. The Responses compiler auto-fixes all of these, but the standard and Anthropic compilers don't. The standard chat completions API doesn't *break* if you leave dangling tool calls without outputs, but it is *weird* and probably out-of-domain for models. K3 claimed that Anthropic breaks, although I didn't check; regardless it's still a weird state for an LLM to end up in where we just ignore its tool calls.
2. Image-reading tool calls also left dangling tool calls. Rather than turning image reads into tool output IRs, we turned them into faked user message IRs.

This PR fixes both sources of dangling, unanswered tool calls.