### PR TITLE
Preserve model used during session when resumed

### DIFF
--- a/drizzle/0006_history_item_model_json.sql
+++ b/drizzle/0006_history_item_model_json.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `history_items` ADD `model_json` text;

--- a/drizzle/0006_history_item_model_json.sql
+++ b/drizzle/0006_history_item_model_json.sql
@@ -1,1 +1,7 @@
 ALTER TABLE `history_items` ADD `model_json` text;
+--> statement-breakpoint
+UPDATE `history_items`
+SET `model_json` = 'octo-no-model-recorded'
+WHERE `model_json` IS NULL;
+--> statement-breakpoint
+ALTER TABLE `history_items` ALTER `model_json` SET NOT NULL;

--- a/drizzle/0006_history_item_model_nickname.sql
+++ b/drizzle/0006_history_item_model_nickname.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `history_items` ADD `model_nickname` text;

--- a/drizzle/0006_history_item_model_nickname.sql
+++ b/drizzle/0006_history_item_model_nickname.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `history_items` ADD `model_nickname` text;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,651 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4af3ada5-ab90-4436-9ce8-f6323fcbc18e",
+  "prevId": "46aede74-e940-46f0-a10e-109e7a270dd9",
+  "tables": {
+    "input_history": {
+      "name": "input_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "compaction_failed_items": {
+      "name": "compaction_failed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "docker_launches": {
+      "name": "docker_launches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "container_target": {
+          "name": "container_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "docker_run_args_json": {
+          "name": "docker_run_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unchained": {
+          "name": "unchained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "docker_launches_kind_args_check": {
+          "name": "docker_launches_kind_args_check",
+          "value": "(\"docker_launches\".\"kind\" = 'connect' AND \"docker_launches\".\"container_target\" IS NOT NULL AND \"docker_launches\".\"docker_run_args_json\" IS NULL)\n        OR (\"docker_launches\".\"kind\" = 'run' AND \"docker_launches\".\"container_target\" IS NULL AND \"docker_launches\".\"docker_run_args_json\" IS NOT NULL)"
+        }
+      }
+    },
+    "history_items": {
+      "name": "history_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "model_nickname": {
+          "name": "model_nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_failed_id": {
+          "name": "request_failed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction_failed_id": {
+          "name": "compaction_failed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "llm_ir_id": {
+          "name": "llm_ir_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "history_items_requestFailedId_unique": {
+          "name": "history_items_requestFailedId_unique",
+          "columns": ["request_failed_id"],
+          "isUnique": true
+        },
+        "history_items_compactionFailedId_unique": {
+          "name": "history_items_compactionFailedId_unique",
+          "columns": ["compaction_failed_id"],
+          "isUnique": true
+        },
+        "history_items_notificationId_unique": {
+          "name": "history_items_notificationId_unique",
+          "columns": ["notification_id"],
+          "isUnique": true
+        },
+        "history_items_llmIrId_unique": {
+          "name": "history_items_llmIrId_unique",
+          "columns": ["llm_ir_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "history_items_request_failed_id_request_failed_items_id_fk": {
+          "name": "history_items_request_failed_id_request_failed_items_id_fk",
+          "tableFrom": "history_items",
+          "tableTo": "request_failed_items",
+          "columnsFrom": ["request_failed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "history_items_compaction_failed_id_compaction_failed_items_id_fk": {
+          "name": "history_items_compaction_failed_id_compaction_failed_items_id_fk",
+          "tableFrom": "history_items",
+          "tableTo": "compaction_failed_items",
+          "columnsFrom": ["compaction_failed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "history_items_notification_id_notifications_id_fk": {
+          "name": "history_items_notification_id_notifications_id_fk",
+          "tableFrom": "history_items",
+          "tableTo": "notifications",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "history_items_llm_ir_id_llm_irs_id_fk": {
+          "name": "history_items_llm_ir_id_llm_irs_id_fk",
+          "tableFrom": "history_items",
+          "tableTo": "llm_irs",
+          "columnsFrom": ["llm_ir_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "history_items_exactly_one_payload_check": {
+          "name": "history_items_exactly_one_payload_check",
+          "value": "(\"history_items\".\"request_failed_id\" IS NOT NULL)\n        + (\"history_items\".\"compaction_failed_id\" IS NOT NULL)\n        + (\"history_items\".\"notification_id\" IS NOT NULL)\n        + (\"history_items\".\"llm_ir_id\" IS NOT NULL) = 1"
+        }
+      }
+    },
+    "launches": {
+      "name": "launches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "docker_launch_id": {
+          "name": "docker_launch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_launch_id": {
+          "name": "local_launch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "launches_dockerLaunchId_unique": {
+          "name": "launches_dockerLaunchId_unique",
+          "columns": ["docker_launch_id"],
+          "isUnique": true
+        },
+        "launches_localLaunchId_unique": {
+          "name": "launches_localLaunchId_unique",
+          "columns": ["local_launch_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "launches_docker_launch_id_docker_launches_id_fk": {
+          "name": "launches_docker_launch_id_docker_launches_id_fk",
+          "tableFrom": "launches",
+          "tableTo": "docker_launches",
+          "columnsFrom": ["docker_launch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "launches_local_launch_id_local_launches_id_fk": {
+          "name": "launches_local_launch_id_local_launches_id_fk",
+          "tableFrom": "launches",
+          "tableTo": "local_launches",
+          "columnsFrom": ["local_launch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "launches_exactly_one_kind_check": {
+          "name": "launches_exactly_one_kind_check",
+          "value": "(\"launches\".\"docker_launch_id\" IS NOT NULL) <> (\"launches\".\"local_launch_id\" IS NOT NULL)"
+        }
+      }
+    },
+    "llm_irs": {
+      "name": "llm_irs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "json": {
+          "name": "json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_launches": {
+      "name": "local_launches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unchained": {
+          "name": "unchained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "previews": {
+      "name": "previews",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_type": {
+          "name": "preview_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "previews_session_id_trees_name_fk": {
+          "name": "previews_session_id_trees_name_fk",
+          "tableFrom": "previews",
+          "tableTo": "trees",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "request_failed_items": {
+      "name": "request_failed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tree_nodes": {
+      "name": "tree_nodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "history_item_id": {
+          "name": "history_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tree_id": {
+          "name": "tree_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_leaf": {
+          "name": "is_leaf",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "launch_id": {
+          "name": "launch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tree_nodes_tree_id_idx": {
+          "name": "tree_nodes_tree_id_idx",
+          "columns": ["tree_id"],
+          "isUnique": false
+        },
+        "tree_nodes_one_root_unique": {
+          "name": "tree_nodes_one_root_unique",
+          "columns": ["tree_id"],
+          "isUnique": true,
+          "where": "\"tree_nodes\".\"parent_id\" IS NULL"
+        },
+        "tree_nodes_historyItemId_unique": {
+          "name": "tree_nodes_historyItemId_unique",
+          "columns": ["history_item_id"],
+          "isUnique": true
+        },
+        "tree_nodes_id_treeId_unique": {
+          "name": "tree_nodes_id_treeId_unique",
+          "columns": ["id", "tree_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tree_nodes_history_item_id_history_items_id_fk": {
+          "name": "tree_nodes_history_item_id_history_items_id_fk",
+          "tableFrom": "tree_nodes",
+          "tableTo": "history_items",
+          "columnsFrom": ["history_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tree_nodes_tree_id_trees_id_fk": {
+          "name": "tree_nodes_tree_id_trees_id_fk",
+          "tableFrom": "tree_nodes",
+          "tableTo": "trees",
+          "columnsFrom": ["tree_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tree_nodes_launch_id_launches_id_fk": {
+          "name": "tree_nodes_launch_id_launches_id_fk",
+          "tableFrom": "tree_nodes",
+          "tableTo": "launches",
+          "columnsFrom": ["launch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tree_nodes_parent_same_tree_fk": {
+          "name": "tree_nodes_parent_same_tree_fk",
+          "tableFrom": "tree_nodes",
+          "tableTo": "tree_nodes",
+          "columnsFrom": ["parent_id", "tree_id"],
+          "columnsTo": ["id", "tree_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "tree_nodes_not_own_parent_check": {
+          "name": "tree_nodes_not_own_parent_check",
+          "value": "\"tree_nodes\".\"parent_id\" IS NULL OR \"tree_nodes\".\"parent_id\" <> \"tree_nodes\".\"id\""
+        }
+      }
+    },
+    "trees": {
+      "name": "trees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "trees_name_unique": {
+          "name": "trees_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "trees_cwd_updated_at_idx": {
+          "name": "trees_cwd_updated_at_idx",
+          "columns": ["cwd", "\"updated_at\" DESC"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shown_update_notifs": {
+      "name": "shown_update_notifs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "update": {
+          "name": "update",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "update_idx": {
+          "name": "update_idx",
+          "columns": ["update"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "trees_cwd_updated_at_idx": {
+        "columns": {
+          "\"updated_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -112,8 +112,8 @@
           "notNull": true,
           "autoincrement": true
         },
-        "model_nickname": {
-          "name": "model_nickname",
+        "model_json": {
+          "name": "model_json",
           "type": "text",
           "primaryKey": false,
           "notNull": false,

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -116,7 +116,7 @@
           "name": "model_json",
           "type": "text",
           "primaryKey": false,
-          "notNull": false,
+          "notNull": true,
           "autoincrement": false
         },
         "request_failed_id": {

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1784836672681,
       "tag": "0005_clean_red_shift",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1785201616377,
+      "tag": "0006_history_item_model_nickname",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -48,7 +48,7 @@
       "idx": 6,
       "version": "6",
       "when": 1785201616377,
-      "tag": "0006_history_item_model_nickname",
+      "tag": "0006_history_item_model_json",
       "breakpoints": true
     }
   ]

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -18,7 +18,7 @@ import {
   ConfigContext,
   ConfigPathContext,
   SetConfigContext,
-  getModelFromConfig,
+  matchModelFromConfig,
   mergeEnvVar,
   readAuthForModel,
   useConfig,
@@ -58,6 +58,7 @@ import { Item, ShortcutArray } from "./components/kb-select/kb-shortcut-select.t
 import { useAppStore, RunArgs, useModel, InflightResponseType, nextToolAction } from "./state.ts";
 import { SessionNotFoundError } from "./session-history/index.ts";
 import type { HistoryNode, Session } from "./session-history/index.ts";
+import { tryDeserializeModelJson } from "./session-history/model-json.ts";
 import { Octo } from "./components/octo.tsx";
 import { Menu } from "./menu.tsx";
 import SelectInput from "./components/selection/select-input.tsx";
@@ -301,18 +302,21 @@ export default function App({
     if (currConfig.vimEmulation?.enabled) setVimMode("INSERT");
   }, []);
   const showToast = useToast();
-  const currentModel = getModelFromConfig(currConfig, modelOverride);
-  const currentModelRef = useRef(currentModel);
-  currentModelRef.current = currentModel;
+  const matchedModel =
+    modelOverride == null ? null : matchModelFromConfig(currConfig, modelOverride);
+  const matchedModelRef = useRef(matchedModel);
+  matchedModelRef.current = matchedModel;
   useEffect(() => {
     if (modelOverride == null) return;
-    if (currentModelRef.current.nickname === modelOverride) return;
+    if (matchedModelRef.current != null) return;
+    const sessionModel = tryDeserializeModelJson(modelOverride);
+    const modelDescription = sessionModel ? `"${sessionModel.nickname},"` : "a model";
     showToast(
       <Span style={{ color: "red" }}>
-        {`This session used the model "${modelOverride}", which is no longer in your config. Falling back to the default model.`}
+        {`This session used ${modelDescription} which is no longer in your config. Falling back to the default model.`}
       </Span>,
     );
-  }, [currentModelRef, sessionHydrationNonce, showToast]);
+  }, [matchedModelRef, sessionHydrationNonce, showToast]);
   const skillNotifs: string[] = [];
   if (bootSkills.length > 0) {
     skillNotifs.push(" ");

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -18,6 +18,7 @@ import {
   ConfigContext,
   ConfigPathContext,
   SetConfigContext,
+  getModelFromConfig,
   mergeEnvVar,
   readAuthForModel,
   useConfig,
@@ -300,15 +301,18 @@ export default function App({
     if (currConfig.vimEmulation?.enabled) setVimMode("INSERT");
   }, []);
   const showToast = useToast();
+  const currentModel = getModelFromConfig(currConfig, modelOverride);
+  const currentModelRef = useRef(currentModel);
+  currentModelRef.current = currentModel;
   useEffect(() => {
     if (modelOverride == null) return;
-    if (currConfig.models.some(model => model.nickname === modelOverride)) return;
+    if (currentModelRef.current.nickname === modelOverride) return;
     showToast(
       <Span style={{ color: "red" }}>
         {`This session used the model "${modelOverride}", which is no longer in your config. Falling back to the default model.`}
       </Span>,
     );
-  }, [currConfig.models, modelOverride, sessionHydrationNonce, showToast]);
+  }, [currentModelRef, sessionHydrationNonce, showToast]);
   const skillNotifs: string[] = [];
   if (bootSkills.length > 0) {
     skillNotifs.push(" ");

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -301,7 +301,6 @@ export default function App({
     if (updates != null) markUpdatesSeen();
     if (currConfig.vimEmulation?.enabled) setVimMode("INSERT");
   }, []);
-  const showToast = useToast();
   const matchedModel =
     modelOverride == null ? null : matchModelFromConfig(currConfig, modelOverride);
   const matchedModelRef = useRef(matchedModel);

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -271,17 +271,27 @@ export default function App({
   const [tempNotification, setTempNotification] = useState<string | null>(
     isUnchained ? UNCHAINED_NOTIF : CHAINED_NOTIF,
   );
-  const { history, modeData, setVimMode, clearNonce, cancelNotifyReadyForInput, query } =
-    useAppStore(
-      useShallow(state => ({
-        history: state.history,
-        modeData: state.modeData,
-        setVimMode: state.setVimMode,
-        clearNonce: state.clearNonce,
-        cancelNotifyReadyForInput: state.cancelNotifyReadyForInput,
-        query: state.query,
-      })),
-    );
+  const {
+    history,
+    modeData,
+    setVimMode,
+    clearNonce,
+    sessionHydrationNonce,
+    modelOverride,
+    cancelNotifyReadyForInput,
+    query,
+  } = useAppStore(
+    useShallow(state => ({
+      history: state.history,
+      modeData: state.modeData,
+      setVimMode: state.setVimMode,
+      clearNonce: state.clearNonce,
+      sessionHydrationNonce: state.sessionHydrationNonce,
+      modelOverride: state.modelOverride,
+      cancelNotifyReadyForInput: state.cancelNotifyReadyForInput,
+      query: state.query,
+    })),
+  );
   useKeyboard(() => {
     cancelNotifyReadyForInput();
   });
@@ -289,6 +299,16 @@ export default function App({
     if (updates != null) markUpdatesSeen();
     if (currConfig.vimEmulation?.enabled) setVimMode("INSERT");
   }, []);
+  const showToast = useToast();
+  useEffect(() => {
+    if (modelOverride == null) return;
+    if (currConfig.models.some(model => model.nickname === modelOverride)) return;
+    showToast(
+      <Span style={{ color: "red" }}>
+        {`This session used the model "${modelOverride}", which is no longer in your config. Falling back to the default model.`}
+      </Span>,
+    );
+  }, [currConfig.models, modelOverride, sessionHydrationNonce, showToast]);
   const skillNotifs: string[] = [];
   if (bootSkills.length > 0) {
     skillNotifs.push(" ");
@@ -617,7 +637,7 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
         setVimMode("NORMAL");
         return;
       }
-      abortResponse(session);
+      abortResponse(session, config);
       if (modeData.mode === "menu") closeMenu();
     }
     if (event.ctrlKey && event.key === "p") {
@@ -1447,7 +1467,7 @@ function ToolRequestRenderer({
   const onSelect = useCallback(
     async (item: (typeof items)[number]) => {
       if (item.value === "no") {
-        rejectTool(toolReq, session);
+        rejectTool(toolReq, session, config);
       } else if (item.value === "yes-whitelist") {
         await addToWhitelist(whitelistKey);
         await runTool({

--- a/source/components/add-model-flow.tsx
+++ b/source/components/add-model-flow.tsx
@@ -683,16 +683,7 @@ const nickname = fullFlow
           prompt="Nickname:"
           defaultValue={defaultNickname}
           parse={val => val}
-          validate={nickname => {
-            const taken = props.config?.models.some(model => model.nickname === nickname) ?? false;
-            if (taken) {
-              return {
-                valid: false,
-                error: `You already have a model named "${nickname}".`,
-              };
-            }
-            return { valid: true };
-          }}
+          validate={() => ({ valid: true })}
           onSubmit={nickname =>
             router.context({
               ...props,

--- a/source/components/add-model-flow.tsx
+++ b/source/components/add-model-flow.tsx
@@ -683,9 +683,16 @@ const nickname = fullFlow
           prompt="Nickname:"
           defaultValue={defaultNickname}
           parse={val => val}
-          validate={() => ({
-            valid: true,
-          })}
+          validate={nickname => {
+            const taken = props.config?.models.some(model => model.nickname === nickname) ?? false;
+            if (taken) {
+              return {
+                valid: false,
+                error: `You already have a model named "${nickname}".`,
+              };
+            }
+            return { valid: true };
+          }}
           onSubmit={nickname =>
             router.context({
               ...props,

--- a/source/components/exit-on-double-ctrl-c.tsx
+++ b/source/components/exit-on-double-ctrl-c.tsx
@@ -37,7 +37,7 @@ export function ExitOnDoubleCtrlC({ children }: { children: React.ReactNode }) {
        */
       const state = useAppStore.getState();
       if (state.modeData.mode === "menu") state.closeMenu();
-      state.abortResponse(session, { exiting: true });
+      state.abortResponse(session, config, { exiting: true });
       exit();
     } else {
       if (!isInsertMode) {

--- a/source/config.test.ts
+++ b/source/config.test.ts
@@ -5,11 +5,15 @@ import os from "os";
 import path from "path";
 import {
   configDeps,
+  getModelFromConfig,
   hasExistingAuthForBaseUrl,
+  matchModelFromConfig,
   readAuthForModel,
   readConfig,
   type Config,
+  type ModelConfig,
 } from "./config.ts";
+import { serializeModelJson } from "./session-history/model-json.ts";
 
 const ENV_NAME = "OCTO_TEST_AUTH";
 const MISSING_ENV_NAME = "OCTO_TEST_MISSING_AUTH";
@@ -154,3 +158,89 @@ async function writeConfigFixture(config: unknown): Promise<string> {
   await fs.writeFile(configPath, JSON.stringify(config));
   return configPath;
 }
+
+describe("matchModelFromConfig", () => {
+  const smartModel: ModelConfig = {
+    nickname: "smart-model",
+    baseUrl: "https://example.test/v1",
+    model: "smart",
+    context: 128_000,
+    auth: { type: "env", name: ENV_NAME },
+  };
+  const fastModel: ModelConfig = {
+    nickname: "fast-model",
+    baseUrl: "https://example.test/v1",
+    model: "fast",
+    context: 32_000,
+  };
+  const config: Config = {
+    yourName: "test",
+    models: [smartModel, fastModel],
+  };
+
+  it("returns the default model when there is no override", () => {
+    expect(getModelFromConfig(config, null)).toBe(smartModel);
+  });
+
+  it("exactly matches an unchanged serialized model", () => {
+    expect(matchModelFromConfig(config, serializeModelJson(fastModel))).toBe(fastModel);
+  });
+
+  it("fuzzy-matches on baseUrl, model, and auth when other fields changed", () => {
+    const renamed: ModelConfig = {
+      ...smartModel,
+      nickname: "renamed-smart-model",
+      context: 64_000,
+      reasoning: "high",
+    };
+    expect(matchModelFromConfig(config, serializeModelJson(renamed))).toBe(smartModel);
+  });
+
+  it("treats legacy apiEnvVar as equivalent to env auth", () => {
+    const legacy: ModelConfig = {
+      nickname: "smart-model",
+      baseUrl: "https://example.test/v1",
+      model: "smart",
+      context: 128_000,
+      apiEnvVar: ENV_NAME,
+    };
+    expect(matchModelFromConfig(config, serializeModelJson(legacy))).toBe(smartModel);
+  });
+
+  it("loosely matches on baseUrl and model when auth fields differ", () => {
+    const reauthed: ModelConfig = {
+      ...smartModel,
+      auth: { type: "env", name: MISSING_ENV_NAME },
+    };
+    expect(matchModelFromConfig(config, serializeModelJson(reauthed))).toBe(smartModel);
+  });
+
+  it("does not match when the base URL differs", () => {
+    const moved: ModelConfig = {
+      ...smartModel,
+      baseUrl: "https://elsewhere.test/v1",
+    };
+    expect(matchModelFromConfig(config, serializeModelJson(moved))).toBeNull();
+  });
+
+  it("does not match when the model string differs", () => {
+    const swapped: ModelConfig = {
+      ...smartModel,
+      model: "some-other-model",
+    };
+    expect(matchModelFromConfig(config, serializeModelJson(swapped))).toBeNull();
+  });
+
+  it("falls back to the default model when nothing matches", () => {
+    const moved: ModelConfig = {
+      ...smartModel,
+      baseUrl: "https://elsewhere.test/v1",
+    };
+    expect(getModelFromConfig(config, serializeModelJson(moved))).toBe(smartModel);
+  });
+
+  it("returns null for an unparseable override", () => {
+    expect(matchModelFromConfig(config, "not json")).toBeNull();
+    expect(getModelFromConfig(config, "not json")).toBe(smartModel);
+  });
+});

--- a/source/config.ts
+++ b/source/config.ts
@@ -9,6 +9,8 @@ import { execFile, spawn } from "child_process";
 import { fileExists } from "./fs-utils.ts";
 import { providerForBaseUrl, keyFromName, ProviderConfig } from "./providers.ts";
 import { getCodexOAuthTokens } from "./codex-oauth.ts";
+import { serializeModelJson, tryDeserializeModelJson } from "./session-history/model-json.ts";
+import { isDeepStrictEqual } from "node:util";
 import { registry } from "antipattern";
 
 const __dir = path.dirname(fileURLToPath(import.meta.url));
@@ -796,9 +798,41 @@ function readKeys() {
 
 export function getModelFromConfig(config: Config, modelOverride: string | null) {
   if (modelOverride == null) return config.models[0];
-  const matching = config.models.find(m => m.nickname === modelOverride);
-  if (matching) return matching;
-  return config.models[0];
+  return matchModelFromConfig(config, modelOverride) ?? config.models[0];
+}
+
+/*
+ * Resolves a persisted versioned model JSON blob (see session-history/model-json.ts) back to a
+ * model in the current config, trying progressively looser matches:
+ *   1. exact serialized match;
+ *   2. fuzzy match on baseUrl, model, and auth fields (e.g. the model was renamed);
+ *   3. loose match on just baseUrl and model (e.g. the model was re-authenticated).
+ * Returns null if no tier matches.
+ */
+export function matchModelFromConfig(config: Config, modelJson: string): ModelConfig | null {
+  const exact = config.models.find(model => serializeModelJson(model) === modelJson);
+  if (exact) return exact;
+
+  const persisted = tryDeserializeModelJson(modelJson);
+  if (persisted == null) return null;
+  const fuzzy = config.models.find(candidate => fuzzyMatchModel(candidate, persisted));
+  if (fuzzy) return fuzzy;
+  return config.models.find(candidate => looseMatchModel(candidate, persisted)) ?? null;
+}
+
+function fuzzyMatchModel(candidate: ModelConfig, persisted: ModelConfig): boolean {
+  if (!looseMatchModel(candidate, persisted)) return false;
+  return isDeepStrictEqual(getAuthForModel(candidate), getAuthForModel(persisted));
+}
+
+function looseMatchModel(candidate: ModelConfig, persisted: ModelConfig): boolean {
+  if (candidate.model !== persisted.model) return false;
+  return modelBaseUrl(candidate) === modelBaseUrl(persisted);
+}
+
+function modelBaseUrl(model: ModelConfig): string | null {
+  if (model.type === "codex") return null;
+  return model.baseUrl;
 }
 
 export async function readConfig(filePath: string): Promise<Config> {

--- a/source/menu.tsx
+++ b/source/menu.tsx
@@ -224,7 +224,7 @@ function SwitchModelMenu() {
         setPendingModel(model);
         return;
       }
-      setModelOverride(target, session);
+      setModelOverride(model, session);
       setMenuMode("main-menu");
       toggleMenu();
     },
@@ -273,7 +273,7 @@ function SwitchModelMenu() {
               });
             }
           }
-          setModelOverride(pendingModel.nickname, session);
+          setModelOverride(pendingModel, session);
           setPendingModel(null);
           setMenuMode("main-menu");
           toggleMenu();
@@ -762,7 +762,7 @@ function SetDefaultModelMenu() {
         ...config,
         models: [model, ...rest],
       });
-      setModelOverride(target, session);
+      setModelOverride(model, session);
       setMenuMode("main-menu");
       toggleMenu();
     },
@@ -828,7 +828,7 @@ function RemoveModelMenu() {
         models: [...rest],
       });
       const current = rest[0];
-      setModelOverride(current.nickname, session);
+      setModelOverride(current, session);
       setMenuMode("main-menu");
       toggleMenu();
     },

--- a/source/menu.tsx
+++ b/source/menu.tsx
@@ -113,7 +113,7 @@ function AutofixToggle({
           await setConfig(newconf);
           setMenuMode("main-menu");
           toggleMenu();
-          notify(disableNotification, session);
+          notify(disableNotification, session, config);
         }}
         onConfirm={() => {
           setMenuMode("main-menu");
@@ -142,7 +142,7 @@ function AutofixToggle({
         });
         setMenuMode("main-menu");
         toggleMenu();
-        notify(enableNotification, session);
+        notify(enableNotification, session, config);
       }}
       onCancel={() => {
         setMenuMode("main-menu");
@@ -504,7 +504,7 @@ function MainMenu() {
         }
 
         // Notify user
-        notify(`Switched to ${wasEnabled ? "Emacs" : "Vim"} mode`, session);
+        notify(`Switched to ${wasEnabled ? "Emacs" : "Vim"} mode`, session, config);
         return;
       } else if (item.value === "clear-confirm") setMenuMode("clear-confirm");
       else setMenuMode(item.value);
@@ -651,6 +651,7 @@ function QuitConfirm() {
   );
   const app = useApp();
   const session = useSession();
+  const config = useConfig();
   return (
     <ConfirmDialog
       confirmLabel="Yes, quit"
@@ -663,7 +664,7 @@ function QuitConfirm() {
          */
         const state = useAppStore.getState();
         state.closeMenu();
-        state.abortResponse(session, { exiting: true });
+        state.abortResponse(session, config, { exiting: true });
         app.exit();
       }}
       onReject={() => setMenuMode("main-menu")}
@@ -688,6 +689,7 @@ function ClearConversationConfirm({
     })),
   );
   const session = useSession();
+  const config = useConfig();
   return (
     <ConfirmDialog
       confirmLabel="Yes, start new conversation"
@@ -702,7 +704,7 @@ function ClearConversationConfirm({
           oldSessionId != null
             ? ` To resume the previous session, run \`octo --resume ${oldSessionId}\``
             : "";
-        notify(`New conversation started.${resumeHint}`, newSession);
+        notify(`New conversation started.${resumeHint}`, newSession, config);
       }}
       onReject={() => setMenuMode("main-menu")}
     />

--- a/source/session-history/index.test.ts
+++ b/source/session-history/index.test.ts
@@ -5,13 +5,24 @@ import {
   createSession,
   deleteSession,
   insertHistoryItems,
-  latestModelNickname,
+  latestModelJson,
   loadSession,
   SessionNotFoundError,
   type HistoryItem,
 } from "./index.ts";
+import { serializeModelJson } from "./model-json.ts";
+import type { ModelConfig } from "../config.ts";
 
 const LOCAL_CLI_ARGS = { kind: "local" } as const;
+
+function testModel(nickname: string): ModelConfig {
+  return {
+    nickname,
+    model: nickname,
+    context: 128_000,
+    baseUrl: "http://localhost",
+  };
+}
 
 function userMessage(content: string): HistoryItem {
   return {
@@ -111,35 +122,38 @@ describe("deleteSession", () => {
   });
 });
 
-describe("model nicknames", () => {
-  it("persists the model nickname on history nodes", () => {
-    const session = createSession("/test/model-nickname", LOCAL_CLI_ARGS);
-    insertHistoryItems(session, null, [userMessage("Hello")], "smart-model");
+describe("model identifiers", () => {
+  it("persists the serialized model on history nodes", () => {
+    const session = createSession("/test/model-json", LOCAL_CLI_ARGS);
+    const smartModelJson = serializeModelJson(testModel("smart-model"));
+    insertHistoryItems(session, null, [userMessage("Hello")], smartModelJson);
     const sessionId = session.metadata.sessionId!;
 
     const loaded = loadSession(sessionId);
     expect(loaded).not.toBeNull();
-    expect(loaded!.history.map(node => node.modelNickname)).toEqual(["smart-model"]);
-    expect(latestModelNickname(loaded!.history)).toBe("smart-model");
+    expect(loaded!.history.map(node => node.modelJson)).toEqual([smartModelJson]);
+    expect(latestModelJson(loaded!.history)).toBe(smartModelJson);
   });
 
-  it("resumes with the most recently persisted nickname", () => {
+  it("resumes with the most recently persisted model", () => {
     const session = createSession("/test/model-switch", LOCAL_CLI_ARGS);
-    const first = insertHistoryItems(session, null, [userMessage("Hello")], "smart-model");
-    insertHistoryItems(session, first.at(-1)!.nodeId, [userMessage("Switch")], "fast-model");
+    const smartModelJson = serializeModelJson(testModel("smart-model"));
+    const fastModelJson = serializeModelJson(testModel("fast-model"));
+    const first = insertHistoryItems(session, null, [userMessage("Hello")], smartModelJson);
+    insertHistoryItems(session, first.at(-1)!.nodeId, [userMessage("Switch")], fastModelJson);
     const sessionId = session.metadata.sessionId!;
 
     const loaded = loadSession(sessionId)!;
-    expect(loaded.history.map(node => node.modelNickname)).toEqual(["smart-model", "fast-model"]);
-    expect(latestModelNickname(loaded.history)).toBe("fast-model");
+    expect(loaded.history.map(node => node.modelJson)).toEqual([smartModelJson, fastModelJson]);
+    expect(latestModelJson(loaded.history)).toBe(fastModelJson);
   });
 
-  it("returns null when no node has a nickname", () => {
+  it("returns null when no node has a model", () => {
     const session = createSession("/test/model-legacy", LOCAL_CLI_ARGS);
     insertHistoryItems(session, null, [userMessage("Hello")], null);
     const sessionId = session.metadata.sessionId!;
 
     const loaded = loadSession(sessionId)!;
-    expect(latestModelNickname(loaded.history)).toBeNull();
+    expect(latestModelJson(loaded.history)).toBeNull();
   });
 });

--- a/source/session-history/index.test.ts
+++ b/source/session-history/index.test.ts
@@ -10,7 +10,7 @@ import {
   SessionNotFoundError,
   type HistoryItem,
 } from "./index.ts";
-import { serializeModelJson } from "./model-json.ts";
+import { NO_MODEL_RECORDED, serializeModelJson } from "./model-json.ts";
 import type { ModelConfig } from "../config.ts";
 
 const LOCAL_CLI_ARGS = { kind: "local" } as const;
@@ -148,12 +148,13 @@ describe("model identifiers", () => {
     expect(latestModelJson(loaded.history)).toBe(fastModelJson);
   });
 
-  it("returns null when no node has a model", () => {
+  it("treats the legacy sentinel as no recorded model", () => {
     const session = createSession("/test/model-legacy", LOCAL_CLI_ARGS);
-    insertHistoryItems(session, null, [userMessage("Hello")], null);
+    insertHistoryItems(session, null, [userMessage("Hello")], NO_MODEL_RECORDED);
     const sessionId = session.metadata.sessionId!;
 
     const loaded = loadSession(sessionId)!;
+    expect(loaded.history.map(node => node.modelJson)).toEqual([null]);
     expect(latestModelJson(loaded.history)).toBeNull();
   });
 });

--- a/source/session-history/index.test.ts
+++ b/source/session-history/index.test.ts
@@ -24,6 +24,8 @@ function testModel(nickname: string): ModelConfig {
   };
 }
 
+const TEST_MODEL_JSON = serializeModelJson(testModel("test-model"));
+
 function userMessage(content: string): HistoryItem {
   return {
     type: "llm-ir",
@@ -45,7 +47,7 @@ function countRows() {
 describe("deleteSession", () => {
   it("deletes an existing session", () => {
     const session = createSession("/test/delete-session", LOCAL_CLI_ARGS);
-    insertHistoryItems(session, null, [userMessage("Delete me")], "test-model");
+    insertHistoryItems(session, null, [userMessage("Delete me")], TEST_MODEL_JSON);
     const sessionId = session.metadata.sessionId;
     expect(sessionId).not.toBeNull();
 
@@ -60,7 +62,7 @@ describe("deleteSession", () => {
       session,
       null,
       [userMessage("Initial message")],
-      "test-model",
+      TEST_MODEL_JSON,
     );
     const sessionId = session.metadata.sessionId;
     expect(sessionId).not.toBeNull();
@@ -72,7 +74,7 @@ describe("deleteSession", () => {
         session,
         history.at(-1)!.nodeId,
         [userMessage("Late message")],
-        "test-model",
+        TEST_MODEL_JSON,
       );
     } catch (error) {
       thrown = error;
@@ -89,10 +91,12 @@ describe("deleteSession", () => {
     const session = createSession("/test/delete-payloads", LOCAL_CLI_ARGS);
     const baseline = countRows();
 
-    insertHistoryItems(session, null, [
-      userMessage("Garbage collect me"),
-      { type: "notification", content: "and me" },
-    ]);
+    insertHistoryItems(
+      session,
+      null,
+      [userMessage("Garbage collect me"), { type: "notification", content: "and me" }],
+      TEST_MODEL_JSON,
+    );
     expect(countRows()).toEqual({
       historyItems: baseline.historyItems + 2,
       llmIrs: baseline.llmIrs + 1,
@@ -105,9 +109,9 @@ describe("deleteSession", () => {
 
   it("leaves other sessions' history rows intact", () => {
     const keep = createSession("/test/keep-session", LOCAL_CLI_ARGS);
-    insertHistoryItems(keep, null, [userMessage("Keep me")]);
+    insertHistoryItems(keep, null, [userMessage("Keep me")], TEST_MODEL_JSON);
     const drop = createSession("/test/drop-session", LOCAL_CLI_ARGS);
-    insertHistoryItems(drop, null, [userMessage("Drop me")]);
+    insertHistoryItems(drop, null, [userMessage("Drop me")], TEST_MODEL_JSON);
 
     expect(deleteSession(drop.metadata.sessionId!)).toBe(true);
 

--- a/source/session-history/index.test.ts
+++ b/source/session-history/index.test.ts
@@ -5,6 +5,7 @@ import {
   createSession,
   deleteSession,
   insertHistoryItems,
+  latestModelNickname,
   loadSession,
   SessionNotFoundError,
   type HistoryItem,
@@ -33,7 +34,7 @@ function countRows() {
 describe("deleteSession", () => {
   it("deletes an existing session", () => {
     const session = createSession("/test/delete-session", LOCAL_CLI_ARGS);
-    insertHistoryItems(session, null, [userMessage("Delete me")]);
+    insertHistoryItems(session, null, [userMessage("Delete me")], "test-model");
     const sessionId = session.metadata.sessionId;
     expect(sessionId).not.toBeNull();
 
@@ -44,14 +45,24 @@ describe("deleteSession", () => {
 
   it("reports a deleted session before inserting more history", () => {
     const session = createSession("/test/stale-session", LOCAL_CLI_ARGS);
-    const history = insertHistoryItems(session, null, [userMessage("Initial message")]);
+    const history = insertHistoryItems(
+      session,
+      null,
+      [userMessage("Initial message")],
+      "test-model",
+    );
     const sessionId = session.metadata.sessionId;
     expect(sessionId).not.toBeNull();
     expect(deleteSession(sessionId!)).toBe(true);
 
     let thrown: unknown;
     try {
-      insertHistoryItems(session, history.at(-1)!.nodeId, [userMessage("Late message")]);
+      insertHistoryItems(
+        session,
+        history.at(-1)!.nodeId,
+        [userMessage("Late message")],
+        "test-model",
+      );
     } catch (error) {
       thrown = error;
     }
@@ -97,5 +108,38 @@ describe("deleteSession", () => {
       .map(row => row.json);
     expect(remaining.some(json => json.includes("Keep me"))).toBe(true);
     expect(remaining.some(json => json.includes("Drop me"))).toBe(false);
+  });
+});
+
+describe("model nicknames", () => {
+  it("persists the model nickname on history nodes", () => {
+    const session = createSession("/test/model-nickname", LOCAL_CLI_ARGS);
+    insertHistoryItems(session, null, [userMessage("Hello")], "smart-model");
+    const sessionId = session.metadata.sessionId!;
+
+    const loaded = loadSession(sessionId);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.history.map(node => node.modelNickname)).toEqual(["smart-model"]);
+    expect(latestModelNickname(loaded!.history)).toBe("smart-model");
+  });
+
+  it("resumes with the most recently persisted nickname", () => {
+    const session = createSession("/test/model-switch", LOCAL_CLI_ARGS);
+    const first = insertHistoryItems(session, null, [userMessage("Hello")], "smart-model");
+    insertHistoryItems(session, first.at(-1)!.nodeId, [userMessage("Switch")], "fast-model");
+    const sessionId = session.metadata.sessionId!;
+
+    const loaded = loadSession(sessionId)!;
+    expect(loaded.history.map(node => node.modelNickname)).toEqual(["smart-model", "fast-model"]);
+    expect(latestModelNickname(loaded.history)).toBe("fast-model");
+  });
+
+  it("returns null when no node has a nickname", () => {
+    const session = createSession("/test/model-legacy", LOCAL_CLI_ARGS);
+    insertHistoryItems(session, null, [userMessage("Hello")], null);
+    const sessionId = session.metadata.sessionId!;
+
+    const loaded = loadSession(sessionId)!;
+    expect(latestModelNickname(loaded.history)).toBeNull();
   });
 });

--- a/source/session-history/index.ts
+++ b/source/session-history/index.ts
@@ -28,7 +28,10 @@ export type HistoryItem =
   | { type: "notification"; content: string }
   | { type: "llm-ir"; ir: OctoIR };
 
-export type HistoryNode = HistoryItem & { nodeId: number };
+export type HistoryNode = HistoryItem & {
+  nodeId: number;
+  modelNickname: string | null;
+};
 
 export type SessionMetadata = {
   sessionId: string | null;
@@ -58,6 +61,10 @@ export class SessionNotFoundError extends Error {
     super(`Session ${sessionId} does not exist.`);
     this.name = "SessionNotFoundError";
   }
+}
+
+export function latestModelNickname(history: readonly HistoryNode[]): string | null {
+  return history.at(-1)?.modelNickname ?? null;
 }
 
 export function createSession(cwd: string, cliArgs: ParsedCliArgs): Session {
@@ -213,14 +220,29 @@ type SessionTreeNode = SessionTree["nodes"][number];
 
 function historyNodeFromRow(node: SessionTreeNode): HistoryNode {
   const item = node.historyItem;
+  const modelNickname = item.modelNickname ?? null;
   if (item.llmIr != null) {
-    return { nodeId: node.id, type: "llm-ir", ir: deserializeLlmIr(item.llmIr.json) };
+    return {
+      nodeId: node.id,
+      modelNickname,
+      type: "llm-ir",
+      ir: deserializeLlmIr(item.llmIr.json),
+    };
   }
   if (item.notification != null) {
-    return { nodeId: node.id, type: "notification", content: item.notification.content };
+    return {
+      nodeId: node.id,
+      modelNickname,
+      type: "notification",
+      content: item.notification.content,
+    };
   }
-  if (item.requestFailedItem != null) return { nodeId: node.id, type: "request-failed" };
-  if (item.compactionFailedItem != null) return { nodeId: node.id, type: "compaction-failed" };
+  if (item.requestFailedItem != null) {
+    return { nodeId: node.id, modelNickname, type: "request-failed" };
+  }
+  if (item.compactionFailedItem != null) {
+    return { nodeId: node.id, modelNickname, type: "compaction-failed" };
+  }
   throw new Error(`History node ${node.id} has no payload.`);
 }
 
@@ -296,6 +318,7 @@ export function insertHistoryItems(
   session: Session,
   parentNodeId: number | null,
   itemsToInsert: HistoryItem[],
+  modelNickname: string | null,
 ): HistoryNode[] {
   if (itemsToInsert.length === 0) return [];
 
@@ -313,7 +336,7 @@ export function insertHistoryItems(
     const insertedNodes: HistoryNode[] = [];
     let currParentId = parentNodeId;
     for (const historyItem of itemsToInsert) {
-      const insertedHistoryItemId = insertHistoryItem(tx, historyItem);
+      const insertedHistoryItemId = insertHistoryItem(tx, historyItem, modelNickname);
       maybeUpdateSessionPreview(tx, sessionId, historyItem);
       const insertedTreeNode = tx
         .insert(treeNodes)
@@ -326,7 +349,7 @@ export function insertHistoryItems(
         })
         .returning({ id: treeNodes.id })
         .get();
-      insertedNodes.push({ ...historyItem, nodeId: insertedTreeNode.id });
+      insertedNodes.push({ ...historyItem, nodeId: insertedTreeNode.id, modelNickname });
       currParentId = insertedTreeNode.id;
     }
     tx.update(trees).set({ updatedAt: Date.now() }).where(eq(trees.id, treeId)).run();
@@ -396,7 +419,11 @@ function createLaunch(tx: DbTransaction, cliArgs: ParsedCliArgs): number {
     .get().id;
 }
 
-function insertHistoryItem(tx: DbTransaction, item: HistoryItem): number {
+function insertHistoryItem(
+  tx: DbTransaction,
+  item: HistoryItem,
+  modelNickname: string | null,
+): number {
   let requestFailedId: number | null = null;
   let compactionFailedId: number | null = null;
   let notificationId: number | null = null;
@@ -442,7 +469,7 @@ function insertHistoryItem(tx: DbTransaction, item: HistoryItem): number {
 
   const insertedHistoryItem = tx
     .insert(historyItems)
-    .values({ requestFailedId, compactionFailedId, notificationId, llmIrId })
+    .values({ modelNickname, requestFailedId, compactionFailedId, notificationId, llmIrId })
     .returning({ id: historyItems.id })
     .get();
   return insertedHistoryItem.id;

--- a/source/session-history/index.ts
+++ b/source/session-history/index.ts
@@ -30,7 +30,7 @@ export type HistoryItem =
 
 export type HistoryNode = HistoryItem & {
   nodeId: number;
-  modelNickname: string | null;
+  modelJson: string | null;
 };
 
 export type SessionMetadata = {
@@ -63,8 +63,8 @@ export class SessionNotFoundError extends Error {
   }
 }
 
-export function latestModelNickname(history: readonly HistoryNode[]): string | null {
-  return history.at(-1)?.modelNickname ?? null;
+export function latestModelJson(history: readonly HistoryNode[]): string | null {
+  return history.at(-1)?.modelJson ?? null;
 }
 
 export function createSession(cwd: string, cliArgs: ParsedCliArgs): Session {
@@ -220,11 +220,11 @@ type SessionTreeNode = SessionTree["nodes"][number];
 
 function historyNodeFromRow(node: SessionTreeNode): HistoryNode {
   const item = node.historyItem;
-  const modelNickname = item.modelNickname ?? null;
+  const modelJson = item.modelJson ?? null;
   if (item.llmIr != null) {
     return {
       nodeId: node.id,
-      modelNickname,
+      modelJson,
       type: "llm-ir",
       ir: deserializeLlmIr(item.llmIr.json),
     };
@@ -232,16 +232,16 @@ function historyNodeFromRow(node: SessionTreeNode): HistoryNode {
   if (item.notification != null) {
     return {
       nodeId: node.id,
-      modelNickname,
+      modelJson,
       type: "notification",
       content: item.notification.content,
     };
   }
   if (item.requestFailedItem != null) {
-    return { nodeId: node.id, modelNickname, type: "request-failed" };
+    return { nodeId: node.id, modelJson, type: "request-failed" };
   }
   if (item.compactionFailedItem != null) {
-    return { nodeId: node.id, modelNickname, type: "compaction-failed" };
+    return { nodeId: node.id, modelJson, type: "compaction-failed" };
   }
   throw new Error(`History node ${node.id} has no payload.`);
 }
@@ -318,7 +318,7 @@ export function insertHistoryItems(
   session: Session,
   parentNodeId: number | null,
   itemsToInsert: HistoryItem[],
-  modelNickname: string | null,
+  modelJson: string | null,
 ): HistoryNode[] {
   if (itemsToInsert.length === 0) return [];
 
@@ -336,7 +336,7 @@ export function insertHistoryItems(
     const insertedNodes: HistoryNode[] = [];
     let currParentId = parentNodeId;
     for (const historyItem of itemsToInsert) {
-      const insertedHistoryItemId = insertHistoryItem(tx, historyItem, modelNickname);
+      const insertedHistoryItemId = insertHistoryItem(tx, historyItem, modelJson);
       maybeUpdateSessionPreview(tx, sessionId, historyItem);
       const insertedTreeNode = tx
         .insert(treeNodes)
@@ -349,7 +349,7 @@ export function insertHistoryItems(
         })
         .returning({ id: treeNodes.id })
         .get();
-      insertedNodes.push({ ...historyItem, nodeId: insertedTreeNode.id, modelNickname });
+      insertedNodes.push({ ...historyItem, nodeId: insertedTreeNode.id, modelJson });
       currParentId = insertedTreeNode.id;
     }
     tx.update(trees).set({ updatedAt: Date.now() }).where(eq(trees.id, treeId)).run();
@@ -419,11 +419,7 @@ function createLaunch(tx: DbTransaction, cliArgs: ParsedCliArgs): number {
     .get().id;
 }
 
-function insertHistoryItem(
-  tx: DbTransaction,
-  item: HistoryItem,
-  modelNickname: string | null,
-): number {
+function insertHistoryItem(tx: DbTransaction, item: HistoryItem, modelJson: string | null): number {
   let requestFailedId: number | null = null;
   let compactionFailedId: number | null = null;
   let notificationId: number | null = null;
@@ -469,7 +465,7 @@ function insertHistoryItem(
 
   const insertedHistoryItem = tx
     .insert(historyItems)
-    .values({ modelNickname, requestFailedId, compactionFailedId, notificationId, llmIrId })
+    .values({ modelJson, requestFailedId, compactionFailedId, notificationId, llmIrId })
     .returning({ id: historyItems.id })
     .get();
   return insertedHistoryItem.id;

--- a/source/session-history/index.ts
+++ b/source/session-history/index.ts
@@ -16,6 +16,7 @@ import {
   trees,
 } from "./schema/session-history-schema.ts";
 import { deserializeLlmIr, serializeLlmIr } from "./llm-ir-json.ts";
+import { NO_MODEL_RECORDED } from "./model-json.ts";
 import { excerpt } from "./preview.ts";
 
 export type TransportKind = "local" | "docker-connect" | "docker-run";
@@ -220,7 +221,7 @@ type SessionTreeNode = SessionTree["nodes"][number];
 
 function historyNodeFromRow(node: SessionTreeNode): HistoryNode {
   const item = node.historyItem;
-  const modelJson = item.modelJson ?? null;
+  const modelJson = item.modelJson === NO_MODEL_RECORDED ? null : item.modelJson;
   if (item.llmIr != null) {
     return {
       nodeId: node.id,
@@ -318,7 +319,7 @@ export function insertHistoryItems(
   session: Session,
   parentNodeId: number | null,
   itemsToInsert: HistoryItem[],
-  modelJson: string | null,
+  modelJson: string,
 ): HistoryNode[] {
   if (itemsToInsert.length === 0) return [];
 
@@ -419,7 +420,7 @@ function createLaunch(tx: DbTransaction, cliArgs: ParsedCliArgs): number {
     .get().id;
 }
 
-function insertHistoryItem(tx: DbTransaction, item: HistoryItem, modelJson: string | null): number {
+function insertHistoryItem(tx: DbTransaction, item: HistoryItem, modelJson: string): number {
   let requestFailedId: number | null = null;
   let compactionFailedId: number | null = null;
   let notificationId: number | null = null;

--- a/source/session-history/model-json.test.ts
+++ b/source/session-history/model-json.test.ts
@@ -1,6 +1,13 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ApiKeyModelConfig, CodexModelConfig, ModelConfig } from "../config.ts";
-import { serializeModelJson } from "./model-json.ts";
+import { NO_MODEL_RECORDED, serializeModelJson, tryDeserializeModelJson } from "./model-json.ts";
+
+const MODEL_JSON_MIGRATION = path.join(
+  import.meta.dirname,
+  "../../drizzle/0006_history_item_model_json.sql",
+);
 
 /*
  * Fails to compile if ModelConfigSchema gains a new variant beyond the API-key and Codex ones:
@@ -68,5 +75,19 @@ describe("model JSON versioning", () => {
       version: "octo-model/v1",
       model: FULL_CODEX_MODEL,
     });
+  });
+
+  it("never confuses the no-model-recorded sentinel for a real model JSON", () => {
+    // The migration uses this sentinel to backfill rows written before models were recorded; it
+    // must never be valid model JSON.
+    expect(() => JSON.parse(NO_MODEL_RECORDED)).toThrow();
+    expect(tryDeserializeModelJson(NO_MODEL_RECORDED)).toBeNull();
+  });
+
+  it("uses the same sentinel in the backfill migration", () => {
+    // The migration is a static SQL file, so the sentinel is duplicated there; this keeps the two
+    // copies from drifting.
+    const sql = readFileSync(MODEL_JSON_MIGRATION, "utf8");
+    expect(sql).toContain(`'${NO_MODEL_RECORDED}'`);
   });
 });

--- a/source/session-history/model-json.test.ts
+++ b/source/session-history/model-json.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { ApiKeyModelConfig, CodexModelConfig, ModelConfig } from "../config.ts";
+import { serializeModelJson } from "./model-json.ts";
+
+/*
+ * Fails to compile if ModelConfigSchema gains a new variant beyond the API-key and Codex ones:
+ * add an AllRequired fixture and serialization assertion for the new variant below, and bump
+ * CURRENT_MODEL_JSON_VERSION in model-json.ts with a migration in migrateModelJson.
+ */
+export const modelConfigVariantCoverage: ModelConfig extends ApiKeyModelConfig | CodexModelConfig
+  ? true
+  : never = true;
+
+/*
+ * These fixtures are typed with AllRequired, which strips optionality from every field. If the
+ * ModelConfig shape changes, this file fails to typecheck and the assertions below go stale.
+ * When that happens, bump CURRENT_MODEL_JSON_VERSION in model-json.ts and add a migration to
+ * migrateModelJson so models persisted by older sessions still resolve.
+ */
+type AllRequired<T> = { [K in keyof T]-?: T[K] };
+
+const FULL_API_KEY_MODEL: AllRequired<ApiKeyModelConfig> = {
+  type: "standard",
+  nickname: "full-api-key-model",
+  model: "full-model",
+  context: 128_000,
+  reasoning: "high",
+  modalities: {
+    image: {
+      enabled: true,
+      maxSizeMB: 5,
+      acceptedMimeTypes: ["image/png"],
+    },
+  },
+  baseUrl: "https://example.test/v1",
+  apiEnvVar: "EXAMPLE_API_KEY",
+  auth: { type: "env", name: "EXAMPLE_API_KEY" },
+};
+
+const FULL_CODEX_MODEL: AllRequired<CodexModelConfig> = {
+  type: "codex",
+  nickname: "full-codex-model",
+  model: "gpt-5.5",
+  context: 200_000,
+  reasoning: "medium",
+  modalities: {
+    image: {
+      enabled: true,
+      maxSizeMB: 5,
+      acceptedMimeTypes: ["image/png"],
+    },
+  },
+  auth: { type: "codex" },
+};
+
+describe("model JSON versioning", () => {
+  it("serializes the full API-key model shape under the current version", () => {
+    // The version is intentionally hard-coded: bumping CURRENT_MODEL_JSON_VERSION without
+    // updating the serialized shape (or vice versa) fails this test.
+    expect(JSON.parse(serializeModelJson(FULL_API_KEY_MODEL))).toEqual({
+      version: "octo-model/v1",
+      model: FULL_API_KEY_MODEL,
+    });
+  });
+
+  it("serializes the full Codex model shape under the current version", () => {
+    expect(JSON.parse(serializeModelJson(FULL_CODEX_MODEL))).toEqual({
+      version: "octo-model/v1",
+      model: FULL_CODEX_MODEL,
+    });
+  });
+});

--- a/source/session-history/model-json.ts
+++ b/source/session-history/model-json.ts
@@ -1,0 +1,40 @@
+import type { ModelConfig } from "../config.ts";
+
+export const CURRENT_MODEL_JSON_VERSION = "octo-model/v1" as const;
+
+type VersionedModelJson = {
+  version: typeof CURRENT_MODEL_JSON_VERSION;
+  model: ModelConfig;
+};
+
+export function serializeModelJson(model: ModelConfig): string {
+  return JSON.stringify({
+    version: CURRENT_MODEL_JSON_VERSION,
+    model,
+  } satisfies VersionedModelJson);
+}
+
+export function deserializeModelJson(json: string): ModelConfig {
+  const parsed = JSON.parse(json) as unknown;
+  return migrateModelJson(parsed);
+}
+
+export function tryDeserializeModelJson(json: string): ModelConfig | null {
+  try {
+    return deserializeModelJson(json);
+  } catch {
+    return null;
+  }
+}
+
+function migrateModelJson(value: unknown): ModelConfig {
+  if (isObject(value) && value["version"] === CURRENT_MODEL_JSON_VERSION) {
+    return value["model"] as ModelConfig;
+  }
+
+  throw new Error("Unsupported model JSON version");
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/source/session-history/model-json.ts
+++ b/source/session-history/model-json.ts
@@ -2,6 +2,9 @@ import type { ModelConfig } from "../config.ts";
 
 export const CURRENT_MODEL_JSON_VERSION = "octo-model/v1" as const;
 
+// Stored in place of a model JSON for history items written before we started recording models.
+export const NO_MODEL_RECORDED = "octo-no-model-recorded" as const;
+
 type VersionedModelJson = {
   version: typeof CURRENT_MODEL_JSON_VERSION;
   model: ModelConfig;

--- a/source/session-history/schema/session-history-schema.ts
+++ b/source/session-history/schema/session-history-schema.ts
@@ -107,7 +107,7 @@ export const historyItems = sqliteTable(
   "history_items",
   {
     id: integer().primaryKey({ autoIncrement: true }),
-    modelNickname: text(),
+    modelJson: text(),
     requestFailedId: integer().references(() => requestFailedItems.id, { onDelete: "restrict" }),
     compactionFailedId: integer().references(() => compactionFailedItems.id, {
       onDelete: "restrict",

--- a/source/session-history/schema/session-history-schema.ts
+++ b/source/session-history/schema/session-history-schema.ts
@@ -107,7 +107,7 @@ export const historyItems = sqliteTable(
   "history_items",
   {
     id: integer().primaryKey({ autoIncrement: true }),
-    modelJson: text(),
+    modelJson: text().notNull(),
     requestFailedId: integer().references(() => requestFailedItems.id, { onDelete: "restrict" }),
     compactionFailedId: integer().references(() => compactionFailedItems.id, {
       onDelete: "restrict",

--- a/source/session-history/schema/session-history-schema.ts
+++ b/source/session-history/schema/session-history-schema.ts
@@ -107,6 +107,7 @@ export const historyItems = sqliteTable(
   "history_items",
   {
     id: integer().primaryKey({ autoIncrement: true }),
+    modelNickname: text(),
     requestFailedId: integer().references(() => requestFailedItems.id, { onDelete: "restrict" }),
     compactionFailedId: integer().references(() => compactionFailedItems.id, {
       onDelete: "restrict",

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -7,6 +7,7 @@ import { useAppStore, nextToolAction } from "./state.ts";
 import type { Config } from "./config.ts";
 import type { HistoryNode } from "./session-history/index.ts";
 import { createSession, insertHistoryItems } from "./session-history/index.ts";
+import { serializeModelJson } from "./session-history/model-json.ts";
 import { compilerUsage } from "./libocto/compilers/compiler-interface.ts";
 import { answeredToolCallId } from "./libocto/llm-ir.ts";
 import type { ToolCall } from "./libocto/tool-def.ts";
@@ -130,7 +131,7 @@ function setupToolBatch(callA: ShellToolCall, callB: ShellToolCall) {
         },
       },
     ],
-    config.models[0].nickname,
+    serializeModelJson(config.models[0]),
   );
   useAppStore.getState().hydrateSession(nodes);
   const abortController = new AbortController();

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -109,24 +109,29 @@ async function waitFor(cond: () => boolean, timeoutMs = 10_000): Promise<void> {
 
 function setupToolBatch(callA: ShellToolCall, callB: ShellToolCall) {
   const session = createSession(process.cwd(), { kind: "local" });
-  const nodes = insertHistoryItems(session, null, [
-    {
-      type: "llm-ir",
-      ir: {
-        role: "user",
-        content: [{ type: "text", content: "Run these two commands" }],
+  const nodes = insertHistoryItems(
+    session,
+    null,
+    [
+      {
+        type: "llm-ir",
+        ir: {
+          role: "user",
+          content: [{ type: "text", content: "Run these two commands" }],
+        },
       },
-    },
-    {
-      type: "llm-ir",
-      ir: {
-        role: "assistant",
-        content: "On it.",
-        usage: compilerUsage(0, 0),
-        toolCalls: [callA, callB],
+      {
+        type: "llm-ir",
+        ir: {
+          role: "assistant",
+          content: "On it.",
+          usage: compilerUsage(0, 0),
+          toolCalls: [callA, callB],
+        },
       },
-    },
-  ]);
+    ],
+    config.models[0].nickname,
+  );
   useAppStore.getState().hydrateSession(nodes);
   const abortController = new AbortController();
   useAppStore.setState({
@@ -152,7 +157,7 @@ describe("aborting a tool batch", () => {
     // The user presses ESC while call_b is still pending. The UI drops the remaining requests
     // (ToolRequestsRenderer unmounts), so the store must record that call_b never ran —
     // otherwise the next request sends an assistant message with an unanswered tool call.
-    useAppStore.getState().abortResponse(session);
+    useAppStore.getState().abortResponse(session, config);
 
     expect(unansweredToolCallIds(useAppStore.getState().history)).toEqual([]);
     expect(useAppStore.getState().modeData.mode).toBe("input");
@@ -172,7 +177,7 @@ describe("aborting a tool batch", () => {
 
     // Wait for the shell command to actually start, then ESC mid-run.
     await waitFor(() => existsSync(marker));
-    useAppStore.getState().abortResponse(session);
+    useAppStore.getState().abortResponse(session, config);
     await running;
 
     expect(unansweredToolCallIds(useAppStore.getState().history)).toEqual([]);
@@ -197,7 +202,7 @@ describe("aborting a tool batch", () => {
      * settle, so the store must synchronously mark every unanswered call as skipped —
      * including the running one. Assert before `running` resolves.
      */
-    useAppStore.getState().abortResponse(session, { exiting: true });
+    useAppStore.getState().abortResponse(session, config, { exiting: true });
     expect(unansweredToolCallIds(useAppStore.getState().history)).toEqual([]);
 
     await running;

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -38,6 +38,8 @@ const config: Config = {
   ],
 };
 
+const testModelJson = serializeModelJson(config.models[0]);
+
 const tempDirs: string[] = [];
 
 beforeEach(() => {
@@ -131,7 +133,7 @@ function setupToolBatch(callA: ShellToolCall, callB: ShellToolCall) {
         },
       },
     ],
-    serializeModelJson(config.models[0]),
+    testModelJson,
   );
   useAppStore.getState().hydrateSession(nodes);
   const abortController = new AbortController();
@@ -231,6 +233,7 @@ function assistantNode(calls: ShellToolCall[], nodeId: number): HistoryNode {
   return {
     type: "llm-ir",
     nodeId,
+    modelJson: testModelJson,
     ir: {
       role: "assistant",
       content: "On it.",
@@ -244,6 +247,7 @@ function toolOutputNode(call: ShellToolCall, nodeId: number): HistoryNode {
   return {
     type: "llm-ir",
     nodeId,
+    modelJson: testModelJson,
     ir: {
       role: "tool-output",
       toolCall: call,
@@ -291,6 +295,7 @@ describe("nextToolAction", () => {
       {
         type: "llm-ir",
         nodeId: 2,
+        modelJson: testModelJson,
         ir: { role: "tool-skip-output", toolCall: callA, reason: "skipped" },
       },
     ];
@@ -331,34 +336,39 @@ describe("tool call IDs reused across batches", () => {
   it("runs a colliding tool call to completion", async () => {
     const transport = new LocalTransport();
     const session = createSession(process.cwd(), { kind: "local" });
-    const nodes = insertHistoryItems(session, null, [
-      {
-        type: "llm-ir",
-        ir: {
-          role: "assistant",
-          content: "First.",
-          usage: compilerUsage(0, 0),
-          toolCalls: [firstBatchCall],
+    const nodes = insertHistoryItems(
+      session,
+      null,
+      [
+        {
+          type: "llm-ir",
+          ir: {
+            role: "assistant",
+            content: "First.",
+            usage: compilerUsage(0, 0),
+            toolCalls: [firstBatchCall],
+          },
         },
-      },
-      {
-        type: "llm-ir",
-        ir: {
-          role: "tool-output",
-          toolCall: firstBatchCall,
-          content: [{ type: "text", content: "first" }],
+        {
+          type: "llm-ir",
+          ir: {
+            role: "tool-output",
+            toolCall: firstBatchCall,
+            content: [{ type: "text", content: "first" }],
+          },
         },
-      },
-      {
-        type: "llm-ir",
-        ir: {
-          role: "assistant",
-          content: "Second.",
-          usage: compilerUsage(0, 0),
-          toolCalls: [secondBatchCall],
+        {
+          type: "llm-ir",
+          ir: {
+            role: "assistant",
+            content: "Second.",
+            usage: compilerUsage(0, 0),
+            toolCalls: [secondBatchCall],
+          },
         },
-      },
-    ]);
+      ],
+      testModelJson,
+    );
     useAppStore.getState().hydrateSession(nodes);
     useAppStore.setState({
       modeData: {
@@ -381,34 +391,39 @@ describe("tool call IDs reused across batches", () => {
   it("rejects and skips within the current batch when IDs collide with an earlier batch", () => {
     const session = createSession(process.cwd(), { kind: "local" });
     const secondBatchSecondCall = shellCall("call_1", "echo later");
-    const nodes = insertHistoryItems(session, null, [
-      {
-        type: "llm-ir",
-        ir: {
-          role: "assistant",
-          content: "First.",
-          usage: compilerUsage(0, 0),
-          toolCalls: [firstBatchCall],
+    const nodes = insertHistoryItems(
+      session,
+      null,
+      [
+        {
+          type: "llm-ir",
+          ir: {
+            role: "assistant",
+            content: "First.",
+            usage: compilerUsage(0, 0),
+            toolCalls: [firstBatchCall],
+          },
         },
-      },
-      {
-        type: "llm-ir",
-        ir: {
-          role: "tool-output",
-          toolCall: firstBatchCall,
-          content: [{ type: "text", content: "first" }],
+        {
+          type: "llm-ir",
+          ir: {
+            role: "tool-output",
+            toolCall: firstBatchCall,
+            content: [{ type: "text", content: "first" }],
+          },
         },
-      },
-      {
-        type: "llm-ir",
-        ir: {
-          role: "assistant",
-          content: "Second.",
-          usage: compilerUsage(0, 0),
-          toolCalls: [secondBatchCall, secondBatchSecondCall],
+        {
+          type: "llm-ir",
+          ir: {
+            role: "assistant",
+            content: "Second.",
+            usage: compilerUsage(0, 0),
+            toolCalls: [secondBatchCall, secondBatchSecondCall],
+          },
         },
-      },
-    ]);
+      ],
+      testModelJson,
+    );
     useAppStore.getState().hydrateSession(nodes);
     useAppStore.setState({
       modeData: {
@@ -421,7 +436,7 @@ describe("tool call IDs reused across batches", () => {
 
     // Rejecting the first call of the new batch must reject *this* batch's call_0 and skip only
     // this batch's remaining call — the earlier batch's answered call_0 must not confuse it.
-    useAppStore.getState().rejectTool(secondBatchCall, session);
+    useAppStore.getState().rejectTool(secondBatchCall, session, config);
 
     expect(answerCountsByToolCallId(useAppStore.getState().history)).toEqual({
       call_0: 2, // earlier output + this batch's reject marker
@@ -432,34 +447,39 @@ describe("tool call IDs reused across batches", () => {
 
   it("marks colliding calls as skipped on abort rather than treating them as answered", () => {
     const session = createSession(process.cwd(), { kind: "local" });
-    const nodes = insertHistoryItems(session, null, [
-      {
-        type: "llm-ir",
-        ir: {
-          role: "assistant",
-          content: "First.",
-          usage: compilerUsage(0, 0),
-          toolCalls: [firstBatchCall],
+    const nodes = insertHistoryItems(
+      session,
+      null,
+      [
+        {
+          type: "llm-ir",
+          ir: {
+            role: "assistant",
+            content: "First.",
+            usage: compilerUsage(0, 0),
+            toolCalls: [firstBatchCall],
+          },
         },
-      },
-      {
-        type: "llm-ir",
-        ir: {
-          role: "tool-output",
-          toolCall: firstBatchCall,
-          content: [{ type: "text", content: "first" }],
+        {
+          type: "llm-ir",
+          ir: {
+            role: "tool-output",
+            toolCall: firstBatchCall,
+            content: [{ type: "text", content: "first" }],
+          },
         },
-      },
-      {
-        type: "llm-ir",
-        ir: {
-          role: "assistant",
-          content: "Second.",
-          usage: compilerUsage(0, 0),
-          toolCalls: [secondBatchCall],
+        {
+          type: "llm-ir",
+          ir: {
+            role: "assistant",
+            content: "Second.",
+            usage: compilerUsage(0, 0),
+            toolCalls: [secondBatchCall],
+          },
         },
-      },
-    ]);
+      ],
+      testModelJson,
+    );
     useAppStore.getState().hydrateSession(nodes);
     useAppStore.setState({
       modeData: {
@@ -470,7 +490,7 @@ describe("tool call IDs reused across batches", () => {
       runningToolCallId: null,
     });
 
-    useAppStore.getState().abortResponse(session);
+    useAppStore.getState().abortResponse(session, config);
 
     // The new call_0 gets its own skip marker, not silently treated as answered by the old one:
     // otherwise the aborted batch leaves a dangling tool call that Anthropic hard-400s on.
@@ -529,7 +549,7 @@ describe("menu round-trips during a tool batch", () => {
     );
 
     // Clean up: abort the batch so the test doesn't wait on the sleeping tool.
-    useAppStore.getState().abortResponse(session);
+    useAppStore.getState().abortResponse(session, config);
     await running;
 
     // Exactly one answer for the in-flight tool: it was never re-run.

--- a/source/state.ts
+++ b/source/state.ts
@@ -11,6 +11,7 @@ import {
   createSession,
   HistoryNode,
   insertHistoryItems,
+  latestModelNickname,
   HistoryItem,
   Session,
 } from "./session-history/index.ts";
@@ -121,6 +122,7 @@ export type UiState = {
   query: string;
   readonly history: readonly HistoryNode[];
   clearNonce: number;
+  sessionHydrationNonce: number;
   lastUserPromptIndex: number | null;
   whitelist: Set<string>;
   notifyReadyForInput: (config: Config) => void;
@@ -129,8 +131,8 @@ export type UiState = {
   setNotifySession: (notifySession: boolean) => void;
   input: (args: RunArgs & { query: string; images?: ImageInfo[] }) => Promise<void>;
   runTool: (args: RunArgs & { toolReq: ToolCallRequest }) => Promise<void>;
-  rejectTool: (toolCall: ToolCallRequest, session: Session) => void;
-  abortResponse: (session: Session, opts?: { exiting?: boolean }) => void;
+  rejectTool: (toolCall: ToolCallRequest, session: Session, config: Config) => void;
+  abortResponse: (session: Session, config: Config, opts?: { exiting?: boolean }) => void;
   toggleMenu: () => void;
   openMenu: () => void;
   closeMenu: () => void;
@@ -144,7 +146,7 @@ export type UiState = {
   ) => Promise<void>;
   clearAuthError: () => void;
   editAndRetryFrom: (mode: "request-error" | "compaction-error", args: RunArgs) => void;
-  notify: (notif: string, session: Session) => void;
+  notify: (notif: string, session: Session, config: Config) => void;
   addToWhitelist: (whitelistKey: string) => Promise<void>;
   isWhitelisted: (whitelistKey: string) => Promise<boolean>;
   hydrateSession: (history: readonly HistoryNode[]) => void;
@@ -157,9 +159,13 @@ function appendAndPersistHistory(
   session: Session,
   prevHistory: readonly HistoryNode[],
   itemsToInsert: HistoryItem[],
+  modelNickname: string,
 ): HistoryNode[] {
   const parentNodeId = prevHistory.at(-1)?.nodeId ?? null;
-  return [...prevHistory, ...insertHistoryItems(session, parentNodeId, itemsToInsert)];
+  return [
+    ...prevHistory,
+    ...insertHistoryItems(session, parentNodeId, itemsToInsert, modelNickname),
+  ];
 }
 
 /*
@@ -242,6 +248,7 @@ export const useAppStore = create<UiState>((set, get) => ({
   byteCount: 0,
   query: "",
   clearNonce: 0,
+  sessionHydrationNonce: 0,
   lastUserPromptIndex: null,
   whitelist: new Set<string>(),
 
@@ -297,7 +304,8 @@ export const useAppStore = create<UiState>((set, get) => ({
       },
     };
 
-    const history = appendAndPersistHistory(session, get().history, [userMessage]);
+    const model = getModelFromConfig(config, get().modelOverride);
+    const history = appendAndPersistHistory(session, get().history, [userMessage], model.nickname);
     set({ history, lastUserPromptIndex: history.length - 1 });
     await get().runAgent({ config, transport, session });
   },
@@ -350,7 +358,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     }));
   },
 
-  rejectTool: (toolCall, session) => {
+  rejectTool: (toolCall, session, config) => {
     const history = get().history;
 
     // If we reject a tool call, we need to mark all subsequent tool calls as skipped, so the LLM
@@ -390,17 +398,23 @@ export const useAppStore = create<UiState>((set, get) => ({
         }
       }
     }
+    const model = getModelFromConfig(config, get().modelOverride);
     set({
-      history: appendAndPersistHistory(session, get().history, [
-        {
-          type: "llm-ir",
-          ir: {
-            role: "tool-reject",
-            toolCall,
+      history: appendAndPersistHistory(
+        session,
+        get().history,
+        [
+          {
+            type: "llm-ir",
+            ir: {
+              role: "tool-reject",
+              toolCall,
+            },
           },
-        },
-        ...skippedCalls,
-      ]),
+          ...skippedCalls,
+        ],
+        model.nickname,
+      ),
       modeData: {
         mode: "input",
         vimMode: "INSERT",
@@ -408,7 +422,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     });
   },
 
-  abortResponse: (session: Session, opts?: { exiting?: boolean }) => {
+  abortResponse: (session: Session, config, opts?: { exiting?: boolean }) => {
     const { modeData, runningToolCallId } = get();
     if ("abortController" in modeData) modeData.abortController.abort();
     if (modeData.mode !== "tool-call") return;
@@ -445,7 +459,8 @@ export const useAppStore = create<UiState>((set, get) => ({
     }
 
     if (skipped.length > 0) {
-      set({ history: appendAndPersistHistory(session, get().history, skipped) });
+      const model = getModelFromConfig(config, get().modelOverride);
+      set({ history: appendAndPersistHistory(session, get().history, skipped, model.nickname) });
     }
 
     /*
@@ -529,23 +544,31 @@ export const useAppStore = create<UiState>((set, get) => ({
     set({ modelOverride: model });
   },
 
-  notify: (notif, session) => {
+  notify: (notif, session, config) => {
+    const model = getModelFromConfig(config, get().modelOverride);
     set({
-      history: appendAndPersistHistory(session, get().history, [
-        {
-          type: "notification",
-          content: notif,
-        },
-      ]),
+      history: appendAndPersistHistory(
+        session,
+        get().history,
+        [
+          {
+            type: "notification",
+            content: notif,
+          },
+        ],
+        model.nickname,
+      ),
     });
   },
 
   hydrateSession: history => {
     set(state => ({
       history,
+      modelOverride: latestModelNickname(history),
       lastUserPromptIndex: null,
       byteCount: 0,
       clearNonce: state.clearNonce + 1,
+      sessionHydrationNonce: state.sessionHydrationNonce + 1,
       sessionAutoNotify: false,
       // A hydrated session has no in-flight tool; don't leak a stale ID from the previous one.
       runningToolCallId: null,
@@ -605,27 +628,38 @@ export const useAppStore = create<UiState>((set, get) => ({
     const tools = await loadTools(transport, abortController.signal, config);
 
     const result = await runTool(abortController.signal, transport, tools, toolReq, config);
+    const model = getModelFromConfig(config, get().modelOverride);
     if (!result.success) {
       set({
-        history: appendAndPersistHistory(session, get().history, [
-          {
-            type: "llm-ir",
-            ir: {
-              role: "tool-runtime-error",
-              error: result.error,
-              toolCall: toolReq,
+        history: appendAndPersistHistory(
+          session,
+          get().history,
+          [
+            {
+              type: "llm-ir",
+              ir: {
+                role: "tool-runtime-error",
+                error: result.error,
+                toolCall: toolReq,
+              },
             },
-          },
-        ]),
+          ],
+          model.nickname,
+        ),
       });
     } else {
       set({
-        history: appendAndPersistHistory(session, get().history, [
-          {
-            type: "llm-ir",
-            ir: toolRunResultToIR(result.data, toolReq),
-          },
-        ]),
+        history: appendAndPersistHistory(
+          session,
+          get().history,
+          [
+            {
+              type: "llm-ir",
+              ir: toolRunResultToIR(result.data, toolReq),
+            },
+          ],
+          model.nickname,
+        ),
       });
     }
 
@@ -750,7 +784,12 @@ export const useAppStore = create<UiState>((set, get) => ({
               ir: event.checkpoint,
             };
             set({
-              history: appendAndPersistHistory(session, historyCopy, [checkpointItem]),
+              history: appendAndPersistHistory(
+                session,
+                historyCopy,
+                [checkpointItem],
+                model.nickname,
+              ),
             });
           },
 
@@ -779,14 +818,24 @@ export const useAppStore = create<UiState>((set, get) => ({
           retryTool: event => {
             throttle.flush();
             set({
-              history: appendAndPersistHistory(session, historyCopy, outputToHistory(event.irs)),
+              history: appendAndPersistHistory(
+                session,
+                historyCopy,
+                outputToHistory(event.irs),
+                model.nickname,
+              ),
             });
           },
         },
       });
       throttle.flush();
       set({
-        history: appendAndPersistHistory(session, historyCopy, outputToHistory(finish.irs)),
+        history: appendAndPersistHistory(
+          session,
+          historyCopy,
+          outputToHistory(finish.irs),
+          model.nickname,
+        ),
       });
       const finishReason = finish.reason;
       if (finishReason.type === "abort" || finishReason.type === "needs-response") {
@@ -834,11 +883,16 @@ export const useAppStore = create<UiState>((set, get) => ({
             error: finishReason.requestError,
             curlCommand: finishReason.curl,
           },
-          history: appendAndPersistHistory(session, get().history, [
-            {
-              type: "compaction-failed",
-            },
-          ]),
+          history: appendAndPersistHistory(
+            session,
+            get().history,
+            [
+              {
+                type: "compaction-failed",
+              },
+            ],
+            model.nickname,
+          ),
         });
         return;
       }

--- a/source/state.ts
+++ b/source/state.ts
@@ -1,6 +1,7 @@
 import {
   AuthError,
   Config,
+  ModelConfig,
   useConfig,
   getModelFromConfig,
   readAuthForModel,
@@ -11,10 +12,11 @@ import {
   createSession,
   HistoryNode,
   insertHistoryItems,
-  latestModelNickname,
+  latestModelJson,
   HistoryItem,
   Session,
 } from "./session-history/index.ts";
+import { serializeModelJson } from "./session-history/model-json.ts";
 import type { ParsedCliArgs } from "./cli/cli-args.ts";
 import { runTool } from "./tools/index.ts";
 import type { ToolRunResult } from "./tools/index.ts";
@@ -138,7 +140,7 @@ export type UiState = {
   closeMenu: () => void;
   setVimMode: (vimMode: "INSERT" | "NORMAL") => void;
   resetPreMenuVimMode: () => void;
-  setModelOverride: (m: string, session: Session) => void;
+  setModelOverride: (m: ModelConfig, session: Session) => void;
   setQuery: (query: string) => void;
   retryFrom: (
     mode: "payment-error" | "rate-limit-error" | "request-error" | "compaction-error",
@@ -159,12 +161,12 @@ function appendAndPersistHistory(
   session: Session,
   prevHistory: readonly HistoryNode[],
   itemsToInsert: HistoryItem[],
-  modelNickname: string,
+  model: ModelConfig,
 ): HistoryNode[] {
   const parentNodeId = prevHistory.at(-1)?.nodeId ?? null;
   return [
     ...prevHistory,
-    ...insertHistoryItems(session, parentNodeId, itemsToInsert, modelNickname),
+    ...insertHistoryItems(session, parentNodeId, itemsToInsert, serializeModelJson(model)),
   ];
 }
 
@@ -305,7 +307,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     };
 
     const model = getModelFromConfig(config, get().modelOverride);
-    const history = appendAndPersistHistory(session, get().history, [userMessage], model.nickname);
+    const history = appendAndPersistHistory(session, get().history, [userMessage], model);
     set({ history, lastUserPromptIndex: history.length - 1 });
     await get().runAgent({ config, transport, session });
   },
@@ -413,7 +415,7 @@ export const useAppStore = create<UiState>((set, get) => ({
           },
           ...skippedCalls,
         ],
-        model.nickname,
+        model,
       ),
       modeData: {
         mode: "input",
@@ -460,7 +462,7 @@ export const useAppStore = create<UiState>((set, get) => ({
 
     if (skipped.length > 0) {
       const model = getModelFromConfig(config, get().modelOverride);
-      set({ history: appendAndPersistHistory(session, get().history, skipped, model.nickname) });
+      set({ history: appendAndPersistHistory(session, get().history, skipped, model) });
     }
 
     /*
@@ -541,7 +543,7 @@ export const useAppStore = create<UiState>((set, get) => ({
   },
 
   setModelOverride: (model, _session) => {
-    set({ modelOverride: model });
+    set({ modelOverride: serializeModelJson(model) });
   },
 
   notify: (notif, session, config) => {
@@ -556,7 +558,7 @@ export const useAppStore = create<UiState>((set, get) => ({
             content: notif,
           },
         ],
-        model.nickname,
+        model,
       ),
     });
   },
@@ -564,7 +566,7 @@ export const useAppStore = create<UiState>((set, get) => ({
   hydrateSession: history => {
     set(state => ({
       history,
-      modelOverride: latestModelNickname(history),
+      modelOverride: latestModelJson(history),
       lastUserPromptIndex: null,
       byteCount: 0,
       clearNonce: state.clearNonce + 1,
@@ -644,7 +646,7 @@ export const useAppStore = create<UiState>((set, get) => ({
               },
             },
           ],
-          model.nickname,
+          model,
         ),
       });
     } else {
@@ -658,7 +660,7 @@ export const useAppStore = create<UiState>((set, get) => ({
               ir: toolRunResultToIR(result.data, toolReq),
             },
           ],
-          model.nickname,
+          model,
         ),
       });
     }
@@ -784,12 +786,7 @@ export const useAppStore = create<UiState>((set, get) => ({
               ir: event.checkpoint,
             };
             set({
-              history: appendAndPersistHistory(
-                session,
-                historyCopy,
-                [checkpointItem],
-                model.nickname,
-              ),
+              history: appendAndPersistHistory(session, historyCopy, [checkpointItem], model),
             });
           },
 
@@ -822,7 +819,7 @@ export const useAppStore = create<UiState>((set, get) => ({
                 session,
                 historyCopy,
                 outputToHistory(event.irs),
-                model.nickname,
+                model,
               ),
             });
           },
@@ -830,12 +827,7 @@ export const useAppStore = create<UiState>((set, get) => ({
       });
       throttle.flush();
       set({
-        history: appendAndPersistHistory(
-          session,
-          historyCopy,
-          outputToHistory(finish.irs),
-          model.nickname,
-        ),
+        history: appendAndPersistHistory(session, historyCopy, outputToHistory(finish.irs), model),
       });
       const finishReason = finish.reason;
       if (finishReason.type === "abort" || finishReason.type === "needs-response") {
@@ -891,7 +883,7 @@ export const useAppStore = create<UiState>((set, get) => ({
                 type: "compaction-failed",
               },
             ],
-            model.nickname,
+            model,
           ),
         });
         return;


### PR DESCRIPTION
With this fix, whichever model was used most recently when a session was exited, will be the same model used on resumption. We store the model config as a stringified versioned json in the DB. We first try an exact match and if that doesn't work, a fuzzy match with model name and the base url.

If the fuzzy match can't find a model in the `octofriend.json` config, it will default to `octo`'s default model.
<img width="853" height="244" alt="Screenshot 2026-07-28 at 3 24 59 PM" src="https://github.com/user-attachments/assets/00910b64-61dd-4ee2-83df-65a07f3d7109" />
