### PR TITLE
Show toast when text is copied

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -190,6 +190,7 @@ export default function App({
   bootSkills,
 }: Props) {
   const { paintCannon } = useApp();
+  const showToast = useToast();
   const [hasFocus, setHasFocus] = useState(paintCannon.hasFocus);
   const transcriptRef = useRef<DivElement>(null);
   const followTranscriptRef = useRef(true);
@@ -203,11 +204,15 @@ export default function App({
     const handleBlur = () => setHasFocus(false);
     const handleFocus = () => setHasFocus(true);
 
+    const handleClipboardWrite = () => showToast("Copied to clipboard");
+
     paintCannon.addEventListener("blur", handleBlur);
     paintCannon.addEventListener("focus", handleFocus);
+    paintCannon.addEventListener("clipboardWrite", handleClipboardWrite);
     return () => {
       paintCannon.removeEventListener("blur", handleBlur);
       paintCannon.removeEventListener("focus", handleFocus);
+      paintCannon.removeEventListener("clipboardWrite", handleClipboardWrite);
     };
   }, [paintCannon]);
   const scrollTranscriptToBottom = useCallback(() => {

--- a/source/components/toast.tsx
+++ b/source/components/toast.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
-import { useAnimation } from "paintcannon-react";
+import { Span, useAnimation } from "paintcannon-react";
 import { TerminalFlex } from "./terminal-flex.tsx";
 import { TOAST_Z_INDEX, BACKGROUND_COLOR, THEME_COLOR } from "../theme.ts";
 
@@ -77,7 +77,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const showToast = useCallback<ToastFn>((children, options) => {
     setToast({
       id: nextToastId.current++,
-      children,
+      children: typeof children === "string" ? <Span>{children}</Span> : children,
       visibilityDurationMs: options?.durationMs ?? DEFAULT_TOAST_DURATION_MS,
       phase: "entering",
     });


### PR DESCRIPTION
Uses paintcannon's `clipboardWrite` event to display a toast when the user has copied text in octo.
<img width="307" height="162" alt="Screenshot 2026-07-28 at 4 24 53 PM" src="https://github.com/user-attachments/assets/939c538c-1704-4e3f-a01f-306399e15699" />

Also adds special handling in `useToast` when the child is just a string (vs an element) since i noticed the formatting/borders were wonked without them

Before
<img width="320" height="77" alt="Screenshot 2026-07-28 at 4 11 53 PM" src="https://github.com/user-attachments/assets/700bbcaa-9293-44b5-badb-8fbdcbb731aa" />
After
<img width="355" height="89" alt="Screenshot 2026-07-28 at 4 14 08 PM" src="https://github.com/user-attachments/assets/fab218ab-cf53-432e-a221-db2c8c753478" />

However, with this change I noticed that `Span` doesn't preserve the colored version of the ⚠️ emoji. Clanker says paintcannon needs to operate on grapheme clusters instead of Rust `char`s. Gonna open up a issue in paintcannon for tracking purposes but the fix is not urgent!