### PR TITLE
Add syn: model aliases instead of hard coded model strings

### DIFF
--- a/source/components/auto-detect-models.tsx
+++ b/source/components/auto-detect-models.tsx
@@ -518,6 +518,21 @@ function ImportModelsFrom({
       >
         <Span>Which of the following models would you like to import?</Span>
       </TerminalFlex>
+      {provider.description ? (
+        <TerminalFlex
+          style={{
+            marginBottom: 1,
+          }}
+        >
+          <Span
+            style={{
+              color: "gray",
+            }}
+          >
+            {provider.description}
+          </Span>
+        </TerminalFlex>
+      ) : null}
 
       <SelectInput
         items={items}

--- a/source/providers.ts
+++ b/source/providers.ts
@@ -35,13 +35,30 @@ export const PROVIDERS = {
     baseUrl: "https://api.synthetic.new/openai/v1",
     models: [
       {
-        model: "hf:zai-org/GLM-5.2",
-        nickname: "GLM-5.2",
-        context: 384 * 1024,
+        model: "syn:large:text",
+        nickname: "Syn Large Text",
+        context: 512 * 1024,
       },
       {
-        model: "hf:moonshotai/Kimi-K2.7-Code",
-        nickname: "Kimi K2.7-Code",
+        model: "syn:small:text",
+        nickname: "Syn Small Text",
+        context: 192 * 1024,
+      },
+      {
+        model: "syn:large:vision",
+        nickname: "Syn Large Vision",
+        context: 512 * 1024,
+        modalities: {
+          image: {
+            enabled: true,
+            maxSizeMB: 10,
+            acceptedMimeTypes: ["image/jpeg", "image/png", "image/webp", "image/gif"],
+          },
+        },
+      },
+      {
+        model: "syn:small:vision",
+        nickname: "Syn Small Vision",
         context: 256 * 1024,
         modalities: {
           image: {
@@ -51,20 +68,8 @@ export const PROVIDERS = {
           },
         },
       },
-      {
-        model: "hf:Qwen/Qwen3.6-27B",
-        nickname: "Qwen 3.6 27B",
-        context: 128 * 1024,
-        modalities: {
-          image: {
-            enabled: true,
-            maxSizeMB: 10,
-            acceptedMimeTypes: ["image/jpeg", "image/png", "image/webp", "image/gif"],
-          },
-        },
-      },
     ],
-    testModel: "hf:MiniMaxAI/MiniMax-M2.1",
+    testModel: "syn:small:text",
   } satisfies ProviderConfig,
 
   codex: {
@@ -202,7 +207,7 @@ export const PROVIDERS = {
 };
 
 export const DEFAULT_MULTIMODAL_IMAGE_MODEL_EXAMPLE =
-  PROVIDERS.synthetic.models.find(m => m.modalities?.image.enabled)?.nickname ?? "Kimi K2.5";
+  PROVIDERS.synthetic.models.find(m => m.modalities?.image.enabled)?.nickname ?? "Syn Large Vision";
 
 export type CanDisplayImageResult = { ok: true } | { ok: false; reason: string };
 

--- a/source/providers.ts
+++ b/source/providers.ts
@@ -15,6 +15,7 @@ export type ProviderConfig = {
   shortcut: Hotkey;
   type?: "standard" | "openai-responses" | "anthropic" | "codex";
   name: string;
+  description?: string;
   envVar: string;
   baseUrl: string;
   models: Array<{
@@ -31,22 +32,24 @@ export const PROVIDERS = {
   synthetic: {
     shortcut: "s" as const,
     name: "Synthetic",
+    description:
+      "Synthetic offers syn: aliases that auto-route to the latest recommended models, so these never go stale. \n\nFor more details, see https://dev.synthetic.new/docs/api/overview",
     envVar: "SYNTHETIC_API_KEY",
     baseUrl: "https://api.synthetic.new/openai/v1",
     models: [
       {
         model: "syn:large:text",
-        nickname: "Syn Large Text",
+        nickname: "syn:large:text",
         context: 512 * 1024,
       },
       {
         model: "syn:small:text",
-        nickname: "Syn Small Text",
+        nickname: "syn:small:text",
         context: 192 * 1024,
       },
       {
         model: "syn:large:vision",
-        nickname: "Syn Large Vision",
+        nickname: "syn:large:vision",
         context: 512 * 1024,
         modalities: {
           image: {
@@ -58,7 +61,7 @@ export const PROVIDERS = {
       },
       {
         model: "syn:small:vision",
-        nickname: "Syn Small Vision",
+        nickname: "syn:small:vision",
         context: 256 * 1024,
         modalities: {
           image: {


### PR DESCRIPTION
Noticed even on latest octo the synthetic model imports are already out of date:

<img width="1702" height="352" alt="CleanShot 2026-07-28 at 16 09 48@2x" src="https://github.com/user-attachments/assets/efa20fb9-da6f-4a99-8adf-6d943a748d7b" />

I know this will be fixed by libclank + reading our `/models` endpoint, but a small proposal for now to use the neat `syn:` aliases Matt put in for now, to avoid a poor experience. Context window might still drift, but at least this guides users to use our more durable endpoints for a better experience.

<img width="1698" height="498" alt="CleanShot 2026-07-28 at 16 32 10@2x" src="https://github.com/user-attachments/assets/06155e6e-86a9-4eef-915f-cdd2c73c9581" />
