### PR TITLE
Restore terminal title to original text on octo exit

### DIFF
--- a/source/cli/cli.tsx
+++ b/source/cli/cli.tsx
@@ -42,6 +42,7 @@ import {
 import { KeyboardProvider } from "../hooks/use-keyboard.ts";
 import { render, type CreateRootOptions } from "paintcannon-react";
 import { ToastProvider } from "../components/toast.tsx";
+import { setOctoTitles } from "./titles.ts";
 
 const __dirname = import.meta.dirname;
 
@@ -102,15 +103,7 @@ const cli = withOctoFlags(
       };
     }
 
-    try {
-      // Set terminal title for tmux
-      process.title = "\\_o_O.//";
-      // Set terminal title for xterm-compatible term emulators
-      process.stdout.write("\x1b]0;" + "\\\\_o_O.//" + "\x07");
-      await runMain(runConfig);
-    } finally {
-      await runConfig.transport.close();
-    }
+    await runMain(runConfig);
   });
 
 const docker = cli.command("docker").description("Sandbox Octo inside Docker");
@@ -122,20 +115,16 @@ withOctoFlags(docker.command("connect"))
       type: "container",
       container: target,
     });
-    try {
-      await runMain({
-        transport,
-        loadedSession: null,
-        parsedCliArgs: {
-          kind: "docker-connect",
-          target,
-          config: opts.config,
-          unchained: opts.unchained,
-        },
-      });
-    } finally {
-      await transport.close();
-    }
+    await runMain({
+      transport,
+      loadedSession: null,
+      parsedCliArgs: {
+        kind: "docker-connect",
+        target,
+        config: opts.config,
+        unchained: opts.unchained,
+      },
+    });
   });
 
 withOctoFlags(docker.command("run"))
@@ -149,20 +138,16 @@ withOctoFlags(docker.command("run"))
       image: await manageContainer(args),
     });
 
-    try {
-      await runMain({
-        transport,
-        loadedSession: null,
-        parsedCliArgs: {
-          kind: "docker-run",
-          dockerRunArgs: args,
-          config: opts.config,
-          unchained: opts.unchained,
-        },
-      });
-    } finally {
-      await transport.close();
-    }
+    await runMain({
+      transport,
+      loadedSession: null,
+      parsedCliArgs: {
+        kind: "docker-run",
+        dockerRunArgs: args,
+        config: opts.config,
+        unchained: opts.unchained,
+      },
+    });
   });
 
 async function buildConfigForResuming(
@@ -231,6 +216,7 @@ async function runMain(opts: {
   transport: Transport;
   loadedSession?: LoadedSession | null;
 }) {
+  const restoreTitles = setOctoTitles();
   let session: Session;
   if (opts.loadedSession != null) {
     session = {
@@ -313,6 +299,8 @@ async function runMain(opts: {
   } finally {
     await shutdownLspClients();
     await shutdownMcpClients();
+    restoreTitles();
+    await opts.transport.close();
   }
 }
 

--- a/source/cli/titles.ts
+++ b/source/cli/titles.ts
@@ -1,0 +1,37 @@
+const OCTO_PROCESS_TITLE = "\\_o_O.//"; // tmux window name
+const OCTO_TERMINAL_TITLE = "\\\\_o_O.//"; // terminal title bar
+// Escape sequence refs: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+// search webpage for "XTWINOPS 2 2  (save/push title) and 2 3  (restore/pop title)"
+const SAVE_TERMINAL_TITLE = "\x1b[22;0t";
+const RESTORE_TERMINAL_TITLE = "\x1b[23;0t";
+
+export function setOctoTitles() {
+  const originalProcessTitle = process.title;
+  const isTTY = process.stdout.isTTY;
+  let restored = false;
+
+  const writeSequence = (sequence: string) => {
+    if (isTTY) process.stdout.write(sequence);
+  };
+
+  writeSequence(SAVE_TERMINAL_TITLE);
+  process.title = OCTO_PROCESS_TITLE;
+  writeSequence(`\x1b]0;${OCTO_TERMINAL_TITLE}\x07`);
+
+  const restoreTitles = () => {
+    if (restored) return;
+    restored = true;
+    process.title = originalProcessTitle;
+    try {
+      writeSequence(RESTORE_TERMINAL_TITLE);
+    } catch {
+      // can technically fail, but not much we can do at that point
+    }
+  };
+  process.once("exit", restoreTitles);
+
+  return () => {
+    process.off("exit", restoreTitles);
+    restoreTitles();
+  };
+}


### PR DESCRIPTION
Noticed we would set the title to `\_o_O.//` but then would leave it there even after octo was exited.

This PR restores it to what the title was before launch!