### PR TITLE
Fix tools possibly running multiple times when opening menu

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -54,7 +54,7 @@ import { ParsedSchema as EditParsedSchema } from "./tools/tool-defs/edit.ts";
 import { useShallow } from "zustand/react/shallow";
 import { KbShortcutPanel } from "./components/kb-select/kb-shortcut-panel.tsx";
 import { Item, ShortcutArray } from "./components/kb-select/kb-shortcut-select.tsx";
-import { useAppStore, RunArgs, useModel, InflightResponseType } from "./state.ts";
+import { useAppStore, RunArgs, useModel, InflightResponseType, nextToolAction } from "./state.ts";
 import { SessionNotFoundError } from "./session-history/index.ts";
 import type { HistoryNode, Session } from "./session-history/index.ts";
 import { Octo } from "./components/octo.tsx";
@@ -1237,14 +1237,23 @@ function ToolRequestsRenderer({
   onContentLayout: () => void;
 } & RunArgs) {
   const runAgent = useAppStore(state => state.runAgent);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const onDone = useCallback(() => {
-    setCurrentIndex(i => i + 1);
-  }, []);
+  const { history, runningToolCallId } = useAppStore(
+    useShallow(state => ({
+      history: state.history,
+      runningToolCallId: state.runningToolCallId,
+    })),
+  );
+  /*
+   * Derive the current action from history rather than tracking a cursor in component state:
+   * this component unmounts when the menu opens, and a cursor would reset to 0 on remount,
+   * re-running tools that already executed.
+   */
+  const action = nextToolAction(toolReqs, runningToolCallId, history);
+  const actionKey = action.kind === "done" ? "done" : `${action.kind}:${action.req.toolCallId}`;
   useLayoutEffect(() => {
     onContentLayout();
-  }, [currentIndex, onContentLayout]);
-  if (currentIndex >= toolReqs.length) {
+  }, [actionKey, onContentLayout]);
+  if (action.kind === "done") {
     return (
       <FinishToolRequests
         runAgent={runAgent}
@@ -1254,7 +1263,7 @@ function ToolRequestsRenderer({
       />
     );
   }
-  const currentToolReq = toolReqs[currentIndex];
+  const currentToolReq = action.req;
   return (
     <TerminalFlex
       style={{
@@ -1267,7 +1276,6 @@ function ToolRequestsRenderer({
         config={config}
         transport={transport}
         session={session}
-        onDone={onDone}
         onContentLayout={onContentLayout}
       />
     </TerminalFlex>
@@ -1295,11 +1303,9 @@ function ToolRequestRenderer({
   config,
   transport,
   session,
-  onDone,
   onContentLayout,
 }: {
   toolReq: ToolCallRequest;
-  onDone: () => void;
   onContentLayout: () => void;
 } & RunArgs) {
   const themeColor = useColor();
@@ -1445,7 +1451,6 @@ function ToolRequestRenderer({
           transport,
           session,
         });
-        onDone();
       } else {
         await runTool({
           toolReq,
@@ -1453,45 +1458,32 @@ function ToolRequestRenderer({
           transport,
           session,
         });
-        onDone();
       }
     },
-    [
-      toolReq,
-      config,
-      transport,
-      session,
-      addToWhitelist,
-      runTool,
-      rejectTool,
-      whitelistKey,
-      onDone,
-    ],
+    [toolReq, config, transport, session, addToWhitelist, runTool, rejectTool, whitelistKey],
   );
-  const { modeData } = useAppStore(
-    useShallow(state => ({
-      modeData: state.modeData,
-    })),
-  );
-  const isRunning =
-    modeData.mode === "tool-call" && modeData.runningToolCallId === toolReq.toolCallId;
+  const runningToolCallId = useAppStore(state => state.runningToolCallId);
+  const isRunning = runningToolCallId === toolReq.toolCallId;
   const noConfirmationNeeded =
     unchained || SKIP_CONFIRMATION_TOOLS.includes(toolReq.name) || isToolWhitelisted === true;
   useLayoutEffect(() => {
     onContentLayout();
   }, [isRunning, noConfirmationNeeded, onContentLayout]);
   useEffect(() => {
+    // Already in flight (e.g. remounted mid-run after the menu closed): render progress without
+    // re-invoking the tool.
+    if (isRunning) return;
     if (noConfirmationNeeded) {
       runTool({
         toolReq,
         config,
         transport,
         session,
-      }).then(onDone);
+      });
     } else {
       notifyReadyForInput(config);
     }
-  }, [toolReq, noConfirmationNeeded, config, transport, session, onDone]);
+  }, [toolReq, isRunning, noConfirmationNeeded, config, transport, session]);
   if (noConfirmationNeeded || isRunning) {
     return (
       <Loading

--- a/source/libocto/ir-roles.ts
+++ b/source/libocto/ir-roles.ts
@@ -1,0 +1,20 @@
+/*
+ * The roles of every IR shape built into libocto, in contrast to tool-defined extension IRs
+ * (see ToolExtensionIR) whose roles are not statically known here. Keep this list exhaustive:
+ * the _BuiltinIRRolesMatch assertion in llm-ir.ts forces the built-in IR union to stay in sync
+ * with it, and answeredToolCallId relies on that to switch exhaustively over built-in roles.
+ */
+export const BUILTIN_IR_ROLES = {
+  assistant: true,
+  user: true,
+  checkpoint: true,
+  "lowered-checkpoint": true,
+  "tool-output": true,
+  "tool-runtime-error": true,
+  "tool-validation-error": true,
+  "tool-parse-error": true,
+  "tool-skip-output": true,
+  trajectory: true,
+} as const;
+
+export type BuiltinIRRole = keyof typeof BUILTIN_IR_ROLES;

--- a/source/libocto/llm-ir.ts
+++ b/source/libocto/llm-ir.ts
@@ -1,6 +1,14 @@
 import { ImageInfo } from "../utils/image-utils.ts";
+import { BUILTIN_IR_ROLES } from "./ir-roles.ts";
+import type { BuiltinIRRole } from "./ir-roles.ts";
 import type { CompilerUsage } from "./compilers/compiler-interface.ts";
-import type { ToolCall, ToolFactoryRequirements, ToolMap, ToolSubagentNames } from "./tool-def.ts";
+import type {
+  ToolCall,
+  ToolExtensionIR,
+  ToolFactoryRequirements,
+  ToolMap,
+  ToolSubagentNames,
+} from "./tool-def.ts";
 
 /*
  * LLM IR
@@ -19,7 +27,7 @@ import type { ToolCall, ToolFactoryRequirements, ToolMap, ToolSubagentNames } fr
  * have, and what extended IRs they use.
  */
 export type Agent<
-  Extra,
+  Extra extends ToolExtensionIR<any>,
   SubagentDirectory extends AgentDirectory,
   Tools extends ToolMap<Extract<keyof SubagentDirectory, string>, Extra>,
 > = {
@@ -290,6 +298,73 @@ type AgentExtra<A extends Agent<any, any, any>> = ToolExtra<A["tools"][keyof A["
 export type LlmIR<A extends Agent<any, any, any>> =
   | CheckpointedIRWithTrajectories<A>
   | AgentExtra<A>;
+
+/*
+ * Returns the tool call ID that an IR answers, or null if the IR is not tool-output-shaped.
+ *
+ * The parameter is expressed in terms of the genuinely generic IR types rather than a single
+ * "all built-in IRs" union type: AgentTrajectory is invariant in its agent directory, so no
+ * monomorphic AgentTrajectory instantiation (even AgentTrajectory<any, any>) accepts every
+ * trajectory — the type parameters must be quantified at the function level.
+ *
+ * Every tool extension IR (see ToolExtensionIR) carries the tool call it answers by definition,
+ * so non-built-in IRs are answered unconditionally. The built-in shapes are switched
+ * exhaustively: adding a new built-in IR role breaks compilation of the default branch,
+ * forcing an explicit decision here.
+ */
+function isBuiltinRole(role: string): role is BuiltinIRRole {
+  return role in BUILTIN_IR_ROLES;
+}
+
+function isBuiltinIR<Role extends string, T extends AgentDirectory, Name extends keyof T>(
+  ir: LoweredIR<any> | Checkpoint | AgentTrajectory<T, Name> | ToolExtensionIR<Role>,
+): ir is LoweredIR<any> | Checkpoint | AgentTrajectory<T, Name> {
+  return isBuiltinRole(ir.role);
+}
+
+export function answeredToolCallId<
+  Role extends string,
+  T extends AgentDirectory,
+  Name extends keyof T,
+>(
+  ir: LoweredIR<any> | Checkpoint | AgentTrajectory<T, Name> | ToolExtensionIR<Role>,
+): string | null {
+  if (!isBuiltinIR(ir)) return ir.toolCall.toolCallId;
+  switch (ir.role) {
+    case "tool-parse-error":
+      return ir.malformedRequest.toolCallId;
+    case "assistant":
+    case "user":
+    case "checkpoint":
+    case "lowered-checkpoint":
+    case "trajectory":
+      return null;
+    case "tool-output":
+    case "tool-runtime-error":
+    case "tool-validation-error":
+    case "tool-skip-output":
+      return ir.toolCall.toolCallId;
+    default: {
+      const _exhaustive: never = ir;
+      return _exhaustive;
+    }
+  }
+}
+
+type AssertNever<T extends never> = T;
+// Keeps BUILTIN_IR_ROLES in sync with the roles of the built-in IR shapes handled above.
+// Indexed access (rather than assignability) keeps this insensitive to AgentTrajectory's
+// invariance in its agent directory.
+type _BuiltinIRRolesMatch = AssertNever<
+  | Exclude<
+      LoweredIR<any>["role"] | Checkpoint["role"] | AgentTrajectory<any, any>["role"],
+      BuiltinIRRole
+    >
+  | Exclude<
+      BuiltinIRRole,
+      LoweredIR<any>["role"] | Checkpoint["role"] | AgentTrajectory<any, any>["role"]
+    >
+>;
 
 /*
  * Agent dependency compile-time validation/branding

--- a/source/libocto/tool-def.ts
+++ b/source/libocto/tool-def.ts
@@ -1,6 +1,7 @@
 import { t } from "structural";
 import type { Transport } from "../transports/transport-common.ts";
 import { Result, ok } from "./result.ts";
+import type { BuiltinIRRole } from "./ir-roles.ts";
 import type { Content } from "./llm-ir.ts";
 
 /*
@@ -200,6 +201,21 @@ type AnySubagentNames = any;
 type AnyCustomIR = any;
 type AnyToolData = any;
 
+/*
+ * Tool extension IRs are, by definition, tool-output-shaped IRs: they exist only as the result
+ * of running a tool call, so they must carry the tool call they answer. Constraining extension
+ * IRs to this shape lets libocto treat every extension IR as a tool output without clients
+ * re-deriving that decision.
+ */
+export type ToolExtensionIR<Role extends string> = Role extends BuiltinIRRole
+  ? never
+  : {
+      role: Role;
+      toolCall: {
+        toolCallId: string;
+      };
+    };
+
 // Public tool factories are the precise raw factory type plus the capability brand. Keeping the raw
 // factory in the intersection preserves literal tool names and parsed argument types.
 export type ToolFactory<
@@ -207,7 +223,7 @@ export type ToolFactory<
   S extends AnyToolSchema,
   Parsed,
   SubagentNames extends string,
-  Extra,
+  Extra extends ToolExtensionIR<any>,
 > = RawToolFactory<Data, S, Parsed, SubagentNames, Extra> &
   ToolFactoryRequirements<SubagentNames, Extra>;
 
@@ -311,7 +327,7 @@ export class DeclaredTool<
   Arguments,
   Parsed,
   SubagentNames extends string,
-  Extra,
+  Extra extends ToolExtensionIR<any>,
   RequiresParse extends boolean,
   CustomIR,
 > {
@@ -416,11 +432,11 @@ export class DeclaredTool<
 // A shared tool builder for callers that do not need a dedicated builder instance.
 export const TOOL_BUILDER = new ToolBuilder();
 
-export type ToolMap<SubagentNames extends string, Extra> = {
+export type ToolMap<SubagentNames extends string, Extra extends ToolExtensionIR<any>> = {
   [key: string]: ToolFactory<AnyToolData, AnyToolSchema, AnyParsedArguments, SubagentNames, Extra>;
 };
 
-type CustomIRBuilderMap = Record<string, (toolCall: any) => (args: any) => any>;
+type CustomIRBuilderMap = Record<string, (toolCall: any) => (args: any) => ToolExtensionIR<any>>;
 
 type DeclaredToolMap<
   Data,
@@ -428,7 +444,7 @@ type DeclaredToolMap<
   Arguments,
   Parsed,
   SubagentNames extends string,
-  Extra,
+  Extra extends ToolExtensionIR<any>,
 > = {
   [K in Name]: ToolFactory<Data, { name: K; arguments: Arguments }, Parsed, SubagentNames, Extra>;
 };
@@ -443,7 +459,9 @@ type DeclaredToolCall<
 
 type CustomIRData<Builders extends CustomIRBuilderMap, Call> = {
   [K in keyof Builders]: Builders[K] extends (toolCall: Call) => (args: any) => infer IR
-    ? IR
+    ? IR extends ToolExtensionIR<any>
+      ? IR
+      : never
     : never;
 }[keyof Builders];
 
@@ -529,7 +547,10 @@ type Covariant<T> = () => T;
 
 // Required phantom fields keep Extra and SubagentNames visible when checking assignability to a
 // ToolMap. They are never read or written at runtime.
-export type ToolFactoryRequirements<SubagentNames extends string, Extra> = {
+export type ToolFactoryRequirements<
+  SubagentNames extends string,
+  Extra extends ToolExtensionIR<any>,
+> = {
   readonly [toolFactoryExtra]: Covariant<Extra>;
   readonly [toolFactorySubagents]: Covariant<SubagentNames>;
 };

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -3,11 +3,12 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { useAppStore } from "./state.ts";
+import { useAppStore, nextToolAction } from "./state.ts";
 import type { Config } from "./config.ts";
 import type { HistoryNode } from "./session-history/index.ts";
 import { createSession, insertHistoryItems } from "./session-history/index.ts";
 import { compilerUsage } from "./libocto/compilers/compiler-interface.ts";
+import { answeredToolCallId } from "./libocto/llm-ir.ts";
 import type { ToolCall } from "./libocto/tool-def.ts";
 import type toolMap from "./tools/tool-defs/index.ts";
 import { LocalTransport } from "./transports/local.ts";
@@ -43,6 +44,7 @@ beforeEach(() => {
     history: [],
     preMenuModeData: null,
     lastUserPromptIndex: null,
+    runningToolCallId: null,
     modeData: { mode: "input", vimMode: "INSERT" },
   });
 });
@@ -131,9 +133,9 @@ function setupToolBatch(callA: ShellToolCall, callB: ShellToolCall) {
     modeData: {
       mode: "tool-call",
       toolReqs: [callA, callB],
-      runningToolCallId: null,
       abortController,
     },
+    runningToolCallId: null,
   });
   return { session, abortController };
 }
@@ -199,5 +201,194 @@ describe("aborting a tool batch", () => {
     expect(unansweredToolCallIds(useAppStore.getState().history)).toEqual([]);
 
     await running;
+  }, 30_000);
+});
+
+/*
+ * Regression tests for BUGS.md #1: opening and closing the menu mid-tool-batch unmounts and
+ * remounts ToolRequestsRenderer, which must not re-run already-executed (or in-flight) tools.
+ * The renderer derives its behavior from nextToolAction; these tests pin that derivation.
+ */
+
+function answerCountsByToolCallId(history: readonly HistoryNode[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const item of history) {
+    if (item.type !== "llm-ir") continue;
+    const id = answeredToolCallId(item.ir);
+    if (id == null) continue;
+    counts[id] = (counts[id] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function assistantNode(calls: ShellToolCall[], nodeId: number): HistoryNode {
+  return {
+    type: "llm-ir",
+    nodeId,
+    ir: {
+      role: "assistant",
+      content: "On it.",
+      usage: compilerUsage(0, 0),
+      toolCalls: calls,
+    },
+  };
+}
+
+function toolOutputNode(call: ShellToolCall, nodeId: number): HistoryNode {
+  return {
+    type: "llm-ir",
+    nodeId,
+    ir: {
+      role: "tool-output",
+      toolCall: call,
+      content: [{ type: "text", content: "done" }],
+    },
+  };
+}
+
+describe("nextToolAction", () => {
+  const callA = shellCall("call_a", "echo a");
+  const callB = shellCall("call_b", "echo b");
+  const batch = [callA, callB];
+  const base = [assistantNode(batch, 1)];
+
+  it("runs the first tool when nothing is answered", () => {
+    expect(nextToolAction(batch, null, base)).toEqual({ kind: "pending", req: callA });
+  });
+
+  it("runs the first unanswered tool", () => {
+    expect(nextToolAction(batch, null, [...base, toolOutputNode(callA, 2)])).toEqual({
+      kind: "pending",
+      req: callB,
+    });
+  });
+
+  it("is done when every tool is answered", () => {
+    const history = [...base, toolOutputNode(callA, 2), toolOutputNode(callB, 3)];
+    expect(nextToolAction(batch, null, history)).toEqual({ kind: "done" });
+  });
+
+  it("waits for the in-flight tool rather than re-running it", () => {
+    expect(nextToolAction(batch, "call_a", base)).toEqual({ kind: "wait", req: callA });
+  });
+
+  it("ignores a stale running ID for an already-answered tool", () => {
+    expect(nextToolAction(batch, "call_a", [...base, toolOutputNode(callA, 2)])).toEqual({
+      kind: "pending",
+      req: callB,
+    });
+  });
+
+  it("treats tool-skip-output as answered", () => {
+    const history: HistoryNode[] = [
+      ...base,
+      {
+        type: "llm-ir",
+        nodeId: 2,
+        ir: { role: "tool-skip-output", toolCall: callA, reason: "skipped" },
+      },
+    ];
+    expect(nextToolAction(batch, null, history)).toEqual({ kind: "pending", req: callB });
+  });
+});
+
+describe("menu round-trips during a tool batch", () => {
+  it("resumes at the first unanswered tool when remounting between tools", async () => {
+    const transport = new LocalTransport();
+    const callA = shellCall("call_a", "echo a");
+    const callB = shellCall("call_b", "echo b");
+    const { session } = setupToolBatch(callA, callB);
+
+    await useAppStore.getState().runTool({ config, transport, session, toolReq: callA });
+
+    // Opening the menu unmounts ToolRequestsRenderer; closing it remounts. The remounted
+    // renderer must resume at call_b, not re-run call_a.
+    useAppStore.getState().openMenu();
+    useAppStore.getState().closeMenu();
+
+    const state = useAppStore.getState();
+    if (state.modeData.mode !== "tool-call") throw new Error("expected tool-call mode");
+    expect(nextToolAction(state.modeData.toolReqs, state.runningToolCallId, state.history)).toEqual(
+      { kind: "pending", req: callB },
+    );
+
+    await useAppStore.getState().runTool({ config, transport, session, toolReq: callB });
+    expect(answerCountsByToolCallId(useAppStore.getState().history)).toEqual({
+      call_a: 1,
+      call_b: 1,
+    });
+  });
+
+  it("waits for the in-flight tool when remounting mid-run", async () => {
+    const transport = new LocalTransport();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "octo-state-test-"));
+    tempDirs.push(dir);
+    const marker = path.join(dir, "started");
+
+    const callA = shellCall("call_a", `touch ${marker} && sleep 30`);
+    const callB = shellCall("call_b", "echo b");
+    const { session } = setupToolBatch(callA, callB);
+
+    const running = useAppStore.getState().runTool({ config, transport, session, toolReq: callA });
+    await waitFor(() => existsSync(marker));
+
+    useAppStore.getState().openMenu();
+    useAppStore.getState().closeMenu();
+
+    const state = useAppStore.getState();
+    if (state.modeData.mode !== "tool-call") throw new Error("expected tool-call mode");
+    expect(nextToolAction(state.modeData.toolReqs, state.runningToolCallId, state.history)).toEqual(
+      { kind: "wait", req: callA },
+    );
+
+    // Clean up: abort the batch so the test doesn't wait on the sleeping tool.
+    useAppStore.getState().abortResponse(session);
+    await running;
+
+    // Exactly one answer for the in-flight tool: it was never re-run.
+    expect(answerCountsByToolCallId(useAppStore.getState().history)["call_a"]).toBe(1);
+  }, 30_000);
+
+  it("clears the running tool ID when a tool settles while the menu is open", async () => {
+    const transport = new LocalTransport();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "octo-state-test-"));
+    tempDirs.push(dir);
+    const marker = path.join(dir, "started");
+
+    const callA = shellCall("call_a", `touch ${marker} && sleep 0.5`);
+    const callB = shellCall("call_b", "echo b");
+    const { session } = setupToolBatch(callA, callB);
+
+    const prevCanary = process.env["CANARY_OCTO"];
+    process.env["CANARY_OCTO"] = "1";
+    try {
+      const running = useAppStore
+        .getState()
+        .runTool({ config, transport, session, toolReq: callA });
+      await waitFor(() => existsSync(marker));
+      useAppStore.getState().openMenu();
+      await running; // settles while the menu is open
+
+      // The running ID is top-level state, cleared on settle even though the tool-call
+      // modeData is stashed in preMenuModeData.
+      expect(useAppStore.getState().runningToolCallId).toBeNull();
+
+      useAppStore.getState().closeMenu();
+      const state = useAppStore.getState();
+      if (state.modeData.mode !== "tool-call") throw new Error("expected tool-call mode");
+      expect(
+        nextToolAction(state.modeData.toolReqs, state.runningToolCallId, state.history),
+      ).toEqual({ kind: "pending", req: callB });
+
+      // The canary double-run guard must not fire when running the next tool.
+      await useAppStore.getState().runTool({ config, transport, session, toolReq: callB });
+      expect(answerCountsByToolCallId(useAppStore.getState().history)).toEqual({
+        call_a: 1,
+        call_b: 1,
+      });
+    } finally {
+      if (prevCanary == null) delete process.env["CANARY_OCTO"];
+      else process.env["CANARY_OCTO"] = prevCanary;
+    }
   }, 30_000);
 });

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -253,12 +253,12 @@ describe("nextToolAction", () => {
   const base = [assistantNode(batch, 1)];
 
   it("runs the first tool when nothing is answered", () => {
-    expect(nextToolAction(batch, null, base)).toEqual({ kind: "pending", req: callA });
+    expect(nextToolAction(batch, null, base)).toEqual({ kind: "ready", req: callA });
   });
 
   it("runs the first unanswered tool", () => {
     expect(nextToolAction(batch, null, [...base, toolOutputNode(callA, 2)])).toEqual({
-      kind: "pending",
+      kind: "ready",
       req: callB,
     });
   });
@@ -269,12 +269,12 @@ describe("nextToolAction", () => {
   });
 
   it("waits for the in-flight tool rather than re-running it", () => {
-    expect(nextToolAction(batch, "call_a", base)).toEqual({ kind: "wait", req: callA });
+    expect(nextToolAction(batch, "call_a", base)).toEqual({ kind: "in-flight", req: callA });
   });
 
   it("ignores a stale running ID for an already-answered tool", () => {
     expect(nextToolAction(batch, "call_a", [...base, toolOutputNode(callA, 2)])).toEqual({
-      kind: "pending",
+      kind: "ready",
       req: callB,
     });
   });
@@ -288,7 +288,7 @@ describe("nextToolAction", () => {
         ir: { role: "tool-skip-output", toolCall: callA, reason: "skipped" },
       },
     ];
-    expect(nextToolAction(batch, null, history)).toEqual({ kind: "pending", req: callB });
+    expect(nextToolAction(batch, null, history)).toEqual({ kind: "ready", req: callB });
   });
 });
 
@@ -309,7 +309,7 @@ describe("menu round-trips during a tool batch", () => {
     const state = useAppStore.getState();
     if (state.modeData.mode !== "tool-call") throw new Error("expected tool-call mode");
     expect(nextToolAction(state.modeData.toolReqs, state.runningToolCallId, state.history)).toEqual(
-      { kind: "pending", req: callB },
+      { kind: "ready", req: callB },
     );
 
     await useAppStore.getState().runTool({ config, transport, session, toolReq: callB });
@@ -338,7 +338,7 @@ describe("menu round-trips during a tool batch", () => {
     const state = useAppStore.getState();
     if (state.modeData.mode !== "tool-call") throw new Error("expected tool-call mode");
     expect(nextToolAction(state.modeData.toolReqs, state.runningToolCallId, state.history)).toEqual(
-      { kind: "wait", req: callA },
+      { kind: "in-flight", req: callA },
     );
 
     // Clean up: abort the batch so the test doesn't wait on the sleeping tool.
@@ -378,7 +378,7 @@ describe("menu round-trips during a tool batch", () => {
       if (state.modeData.mode !== "tool-call") throw new Error("expected tool-call mode");
       expect(
         nextToolAction(state.modeData.toolReqs, state.runningToolCallId, state.history),
-      ).toEqual({ kind: "pending", req: callB });
+      ).toEqual({ kind: "ready", req: callB });
 
       // The canary double-run guard must not fire when running the next tool.
       await useAppStore.getState().runTool({ config, transport, session, toolReq: callB });

--- a/source/state.ts
+++ b/source/state.ts
@@ -173,8 +173,8 @@ export function answeredToolCallIds(history: readonly HistoryNode[]): Set<string
 }
 
 export type ToolAction =
-  | { kind: "wait"; req: ToolCallRequest }
-  | { kind: "pending"; req: ToolCallRequest }
+  | { kind: "in-flight"; req: ToolCallRequest }
+  | { kind: "ready"; req: ToolCallRequest }
   | { kind: "done" };
 
 /*
@@ -182,8 +182,8 @@ export type ToolAction =
  * cursor in component state. ToolRequestsRenderer unmounts when the menu opens, and a
  * component-local cursor would reset to 0 on remount, re-running tools that already executed.
  * Deriving from history makes unmount/remount cycles safe: a remounted renderer re-derives the
- * same action. An unanswered in-flight tool yields "wait" so the renderer shows progress without
- * re-invoking the tool.
+ * same action. An unanswered in-flight tool yields "in-flight" so the renderer shows progress
+ * without re-invoking the tool.
  */
 export function nextToolAction(
   toolReqs: ToolCallRequest[],
@@ -191,13 +191,15 @@ export function nextToolAction(
   history: readonly HistoryNode[],
 ): ToolAction {
   const answered = answeredToolCallIds(history);
-  const pending = toolReqs.filter(req => req.type === "tool-call" && !answered.has(req.toolCallId));
+  const unanswered = toolReqs.filter(
+    req => req.type === "tool-call" && !answered.has(req.toolCallId),
+  );
   if (runningToolCallId != null) {
-    const running = pending.find(req => req.toolCallId === runningToolCallId);
-    if (running) return { kind: "wait", req: running };
+    const running = unanswered.find(req => req.toolCallId === runningToolCallId);
+    if (running) return { kind: "in-flight", req: running };
   }
-  const [first] = pending;
-  if (first) return { kind: "pending", req: first };
+  const [first] = unanswered;
+  if (first) return { kind: "ready", req: first };
   return { kind: "done" };
 }
 
@@ -519,6 +521,8 @@ export const useAppStore = create<UiState>((set, get) => ({
       byteCount: 0,
       clearNonce: state.clearNonce + 1,
       sessionAutoNotify: false,
+      // A hydrated session has no in-flight tool; don't leak a stale ID from the previous one.
+      runningToolCallId: null,
     }));
   },
 
@@ -538,6 +542,9 @@ export const useAppStore = create<UiState>((set, get) => ({
       sessionAutoNotify: false,
       modeData: { mode: "input", vimMode: "INSERT" },
       preMenuModeData: null,
+      // An aborted tool clears this itself when it settles, but until it does the new session
+      // must not see the old session's in-flight ID.
+      runningToolCallId: null,
     }));
     return createSession(cwd, cliArgs);
   },

--- a/source/state.ts
+++ b/source/state.ts
@@ -24,6 +24,7 @@ import { Transport } from "./transports/transport-common.ts";
 import { trajectoryArc } from "./agent/trajectory-arc.ts";
 import type { ModelData } from "./compilers/run.ts";
 import type { ToolCall } from "./libocto/tool-def.ts";
+import { answeredToolCallId } from "./libocto/llm-ir.ts";
 import type toolMap from "./tools/tool-defs/index.ts";
 import { QuotaData } from "./utils/quota.ts";
 import { throttledBuffer } from "./throttled-buffer.ts";
@@ -61,7 +62,6 @@ export type UiState = {
     | {
         mode: "tool-call";
         toolReqs: ToolCallRequest[];
-        runningToolCallId: string | null;
         abortController: AbortController;
       }
     | {
@@ -106,6 +106,14 @@ export type UiState = {
     | {
         mode: "menu";
       };
+
+  /*
+   * The currently in-flight tool call, if any. Tracked at the top level rather than inside the
+   * tool-call modeData: modeData gets stashed in preMenuModeData when the menu opens, and
+   * maintainers reasonably treat that stash as UI-only state. The running tool keeps executing
+   * while the menu is open, so its ID must live outside UI mode transitions.
+   */
+  runningToolCallId: string | null;
 
   modelOverride: string | null;
   quotaData: QuotaData | null;
@@ -154,6 +162,45 @@ function appendAndPersistHistory(
   return [...prevHistory, ...insertHistoryItems(session, parentNodeId, itemsToInsert)];
 }
 
+export function answeredToolCallIds(history: readonly HistoryNode[]): Set<string> {
+  const answered = new Set<string>();
+  for (const item of history) {
+    if (item.type !== "llm-ir") continue;
+    const id = answeredToolCallId(item.ir);
+    if (id != null) answered.add(id);
+  }
+  return answered;
+}
+
+export type ToolAction =
+  | { kind: "wait"; req: ToolCallRequest }
+  | { kind: "pending"; req: ToolCallRequest }
+  | { kind: "done" };
+
+/*
+ * Derives what the tool renderer should do for a batch from the history, rather than tracking a
+ * cursor in component state. ToolRequestsRenderer unmounts when the menu opens, and a
+ * component-local cursor would reset to 0 on remount, re-running tools that already executed.
+ * Deriving from history makes unmount/remount cycles safe: a remounted renderer re-derives the
+ * same action. An unanswered in-flight tool yields "wait" so the renderer shows progress without
+ * re-invoking the tool.
+ */
+export function nextToolAction(
+  toolReqs: ToolCallRequest[],
+  runningToolCallId: string | null,
+  history: readonly HistoryNode[],
+): ToolAction {
+  const answered = answeredToolCallIds(history);
+  const pending = toolReqs.filter(req => req.type === "tool-call" && !answered.has(req.toolCallId));
+  if (runningToolCallId != null) {
+    const running = pending.find(req => req.toolCallId === runningToolCallId);
+    if (running) return { kind: "wait", req: running };
+  }
+  const [first] = pending;
+  if (first) return { kind: "pending", req: first };
+  return { kind: "done" };
+}
+
 export const useAppStore = create<UiState>((set, get) => ({
   preMenuModeData: null,
   _notifyTimer: null,
@@ -163,6 +210,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     mode: "input" as const,
     vimMode: "INSERT" as const,
   },
+  runningToolCallId: null,
   history: [],
   modelOverride: null,
   quotaData: null,
@@ -336,7 +384,7 @@ export const useAppStore = create<UiState>((set, get) => ({
   },
 
   abortResponse: (session: Session, opts?: { exiting?: boolean }) => {
-    const { modeData } = get();
+    const { modeData, runningToolCallId } = get();
     if ("abortController" in modeData) modeData.abortController.abort();
     if (modeData.mode !== "tool-call") return;
 
@@ -348,28 +396,13 @@ export const useAppStore = create<UiState>((set, get) => ({
      * output when it settles — but when the process is exiting it will never settle, so mark
      * it as skipped too.
      */
-    const answered = new Set<string>();
-    for (const item of get().history) {
-      if (item.type !== "llm-ir") continue;
-      const ir = item.ir;
-      if (
-        ir.role === "tool-output" ||
-        ir.role === "tool-skip-output" ||
-        ir.role === "tool-runtime-error" ||
-        ir.role === "tool-validation-error" ||
-        ir.role === "tool-reject" ||
-        ir.role === "file-read" ||
-        ir.role === "file-mutate"
-      ) {
-        answered.add(ir.toolCall.toolCallId);
-      }
-    }
+    const answered = answeredToolCallIds(get().history);
 
     const skipped: HistoryItem[] = [];
     for (const req of modeData.toolReqs) {
       if (req.type !== "tool-call") continue;
       if (answered.has(req.toolCallId)) continue;
-      const isRunning = req.toolCallId === modeData.runningToolCallId;
+      const isRunning = req.toolCallId === runningToolCallId;
       if (isRunning && !opts?.exiting) continue;
       skipped.push({
         type: "llm-ir",
@@ -391,7 +424,7 @@ export const useAppStore = create<UiState>((set, get) => ({
      * If no tool is currently running, nothing else will flip the mode back to input, so do it
      * here. If a tool is running, runTool's _maybeHandleAbort flips it once the tool settles.
      */
-    if (modeData.runningToolCallId == null) {
+    if (runningToolCallId == null) {
       set({
         modeData: {
           mode: "input",
@@ -521,11 +554,11 @@ export const useAppStore = create<UiState>((set, get) => ({
   },
 
   runTool: async ({ config, toolReq, transport, session }) => {
-    let { modeData } = get();
+    const { modeData } = get();
     if (modeData.mode !== "tool-call") {
       throw new Error(`Impossible tool mode: ${modeData.mode}`);
     }
-    if (modeData.runningToolCallId != null) {
+    if (get().runningToolCallId != null) {
       if (process.env["CANARY_OCTO"] === "1") {
         throw new Error(
           "Canary build error: attempted to run a tool when a tool was already running",
@@ -534,7 +567,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     }
 
     const abortController = modeData.abortController;
-    set({ modeData: { ...modeData, runningToolCallId: toolReq.toolCallId } });
+    set({ runningToolCallId: toolReq.toolCallId });
 
     const tools = await loadTools(transport, abortController.signal, config);
 
@@ -563,13 +596,10 @@ export const useAppStore = create<UiState>((set, get) => ({
       });
     }
 
+    set({ runningToolCallId: null });
+
     if (get()._maybeHandleAbort(abortController.signal)) {
       return;
-    }
-
-    ({ modeData } = get());
-    if (modeData.mode === "tool-call") {
-      set({ modeData: { ...modeData, runningToolCallId: null } });
     }
   },
 
@@ -784,9 +814,9 @@ export const useAppStore = create<UiState>((set, get) => ({
         modeData: {
           mode: "tool-call",
           toolReqs: finishReason.toolCalls,
-          runningToolCallId: null,
           abortController: new AbortController(),
         },
+        runningToolCallId: null,
       });
     } catch (e) {
       if (get()._maybeHandleAbort(abortController.signal)) {


### PR DESCRIPTION
Since the current tool to run was stored in the ToolRequestsRenderer state, when we opened the menu (which unmounted the ToolRequestsRenderer) we lost track of which tools had already ran. If you opened the menu in the middle of a batch of tools running(i.e. if you had already run some of the tools, but not all of them), it would re-run the earlier tools when it was remounted on menu close. This generally would be bad, since e.g. edits might not re-apply, etc.

This fixes the bug by deriving the current tool to run from the Zustand state:

1. We always store the current tool ID (or null, if no tools are running) in Zustand
2. In the component, instead of storing state, we derive which tools haven't run yet by examining which tools don't have outputs yet by querying Zustand
3. We also skip the tool that's currently running and wait for it to finish , if one is running

This means that mounting or unmounting the component doesn't have any impact.

This change also includes some type-level changes to LlmIR in order to correctly determine which LlmIRs correspond to tool outputs and which don't (so that we can derive the unanswered tools from the current state). However, it does not change their actual in-memory shape, and so we don't need to do any IR migrations.

This bug was found+fixed by Kimi K3.