### PR TITLE
Test+comment for easier trigger maintenance

### DIFF
--- a/source/session-history/index.test.ts
+++ b/source/session-history/index.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { db } from "../db/db.ts";
+import { historyItems, llmIrs, notifications } from "./schema/session-history-schema.ts";
 import {
   createSession,
   deleteSession,
@@ -17,6 +19,14 @@ function userMessage(content: string): HistoryItem {
       role: "user",
       content: [{ type: "text", content }],
     },
+  };
+}
+
+function countRows() {
+  return {
+    historyItems: db().select({ id: historyItems.id }).from(historyItems).all().length,
+    llmIrs: db().select({ id: llmIrs.id }).from(llmIrs).all().length,
+    notifications: db().select({ id: notifications.id }).from(notifications).all().length,
   };
 }
 
@@ -51,5 +61,41 @@ describe("deleteSession", () => {
       sessionId,
       message: `Session ${sessionId} does not exist.`,
     });
+  });
+
+  it("removes the session's history items and their payload rows", () => {
+    const session = createSession("/test/delete-payloads", LOCAL_CLI_ARGS);
+    const baseline = countRows();
+
+    insertHistoryItems(session, null, [
+      userMessage("Garbage collect me"),
+      { type: "notification", content: "and me" },
+    ]);
+    expect(countRows()).toEqual({
+      historyItems: baseline.historyItems + 2,
+      llmIrs: baseline.llmIrs + 1,
+      notifications: baseline.notifications + 1,
+    });
+
+    expect(deleteSession(session.metadata.sessionId!)).toBe(true);
+    expect(countRows()).toEqual(baseline);
+  });
+
+  it("leaves other sessions' history rows intact", () => {
+    const keep = createSession("/test/keep-session", LOCAL_CLI_ARGS);
+    insertHistoryItems(keep, null, [userMessage("Keep me")]);
+    const drop = createSession("/test/drop-session", LOCAL_CLI_ARGS);
+    insertHistoryItems(drop, null, [userMessage("Drop me")]);
+
+    expect(deleteSession(drop.metadata.sessionId!)).toBe(true);
+
+    expect(loadSession(keep.metadata.sessionId!)).not.toBeNull();
+    const remaining = db()
+      .select({ json: llmIrs.json })
+      .from(llmIrs)
+      .all()
+      .map(row => row.json);
+    expect(remaining.some(json => json.includes("Keep me"))).toBe(true);
+    expect(remaining.some(json => json.includes("Drop me"))).toBe(false);
   });
 });

--- a/source/session-history/schema/session-history-schema.ts
+++ b/source/session-history/schema/session-history-schema.ts
@@ -95,6 +95,14 @@ export const llmIrs = sqliteTable("llm_irs", {
   json: text().notNull(),
 });
 
+/*
+ * Deletion of history items and their payloads is handled by AFTER DELETE triggers in
+ * drizzle/0003_tree_node_triggers.sql, NOT by FK cascades — drizzle schemas can't express
+ * triggers, so you must read that migration file to see the full deletion behavior. (The FK
+ * arrows here point from each row to the rows it was built from, which is opposite the
+ * deletion order, so cascades can't express it.) The `restrict` actions below make the trigger
+ * chain the only deletion path: payloads can't be deleted while a history item references them.
+ */
 export const historyItems = sqliteTable(
   "history_items",
   {
@@ -125,6 +133,9 @@ export const treeNodes = sqliteTable(
   "tree_nodes",
   {
     id: integer().primaryKey({ autoIncrement: true }),
+    // No onDelete action here on purpose: deleting a tree node must delete its history item
+    // (a child delete propagating to the parent), which FKs can't express. The
+    // tree_nodes_delete_history_item trigger handles it; see the comment above historyItems.
     historyItemId: integer()
       .notNull()
       .references(() => historyItems.id),


### PR DESCRIPTION
Adds a test for history item GC, and leaves a comment in the schema file explaining the triggers. Kimi misidentified this as a bug, but the test proved it was working, and we eventually remembered about the triggers. Test+comment should help future maintainers remember too :)