### PR TITLE
Lift attached images into the app store

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -640,6 +640,10 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
     vimMode: storedVimMode,
     query,
     setQuery,
+    attachedImages,
+    addAttachedImage,
+    removeLastAttachedImage,
+    clearAttachedImages,
     queuedMessages,
     queueMessage,
   } = useAppStore(
@@ -654,6 +658,10 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
       vimMode: state.vimMode,
       query: state.query,
       setQuery: state.setQuery,
+      attachedImages: state.attachedImages,
+      addAttachedImage: state.addAttachedImage,
+      removeLastAttachedImage: state.removeLastAttachedImage,
+      clearAttachedImages: state.clearAttachedImages,
       queuedMessages: state.queuedUserMessages,
       queueMessage: state.enqueueUserMessage,
     })),
@@ -757,6 +765,10 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
           inputHistory={inputHistory}
           value={query}
           onChange={setQuery}
+          attachedImages={attachedImages}
+          addAttachedImage={addAttachedImage}
+          removeLastAttachedImage={removeLastAttachedImage}
+          clearAttachedImages={clearAttachedImages}
           onSubmit={onSubmit}
           vimEnabled={vimEnabled}
           vimMode={vimMode}
@@ -841,6 +853,10 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
         inputHistory={inputHistory}
         value={query}
         onChange={setQuery}
+        attachedImages={attachedImages}
+        addAttachedImage={addAttachedImage}
+        removeLastAttachedImage={removeLastAttachedImage}
+        clearAttachedImages={clearAttachedImages}
         onSubmit={onSubmit}
         vimEnabled={vimEnabled}
         vimMode={vimMode}

--- a/source/components/multimedia-input.tsx
+++ b/source/components/multimedia-input.tsx
@@ -15,6 +15,10 @@ interface Props {
   inputHistory: InputHistory;
   value: string;
   onChange: (s: string) => any;
+  attachedImages: ImageInfo[];
+  addAttachedImage: (image: ImageInfo) => void;
+  removeLastAttachedImage: () => void;
+  clearAttachedImages: () => void;
   onSubmit: (text: string, images: ImageInfo[]) => any;
   vimEnabled?: boolean;
   vimMode?: "NORMAL" | "INSERT";
@@ -22,17 +26,16 @@ interface Props {
   modalities?: MultimodalConfig;
 }
 export const MultimediaInput = (props: Props) => {
-  const [attachedImages, setAttachedImages] = useState<ImageInfo[]>([]);
   const [showLoadingImageBadge, setShowLoadingImageBadge] = useState(false);
   const [errorMessages, setErrorMessages] = useState<string[]>([]);
   useCtrlC(() => {
     if (props.vimEnabled) return;
-    setAttachedImages([]);
+    props.clearAttachedImages();
     setErrorMessages([]);
   });
   const handleRemoveLastImage = useCallback(() => {
-    setAttachedImages(prev => prev.slice(0, -1));
-  }, []);
+    props.removeLastAttachedImage();
+  }, [props.removeLastAttachedImage]);
   const handleImageFilesAttached = useCallback(
     async (files: PaintFile[]) => {
       if (!props.modalities?.image?.enabled) {
@@ -47,7 +50,7 @@ export const MultimediaInput = (props: Props) => {
         try {
           const image = await loadImageFromPaintFile(file);
           const imageCheck = canDisplayImage(props.modalities, image);
-          if (imageCheck.ok) setAttachedImages(prev => [...prev, image]);
+          if (imageCheck.ok) props.addAttachedImage(image);
           else setErrorMessages(prev => [...prev, imageCheck.reason]);
         } catch (error) {
           setErrorMessages(prev => [
@@ -59,15 +62,15 @@ export const MultimediaInput = (props: Props) => {
         }
       }
     },
-    [props.modalities],
+    [props.modalities, props.addAttachedImage],
   );
   const handleSubmit = useCallback(() => {
-    if (props.value.trim() || attachedImages.length > 0) {
-      props.onSubmit(props.value, attachedImages);
-      setAttachedImages([]);
+    if (props.value.trim() || props.attachedImages.length > 0) {
+      props.onSubmit(props.value, props.attachedImages);
+      props.clearAttachedImages();
       setErrorMessages([]);
     }
-  }, [props, attachedImages]);
+  }, [props]);
   return (
     <TerminalFlex
       style={{
@@ -93,7 +96,7 @@ export const MultimediaInput = (props: Props) => {
         </TerminalFlex>
       ))}
       <InputWithHistory
-        attachedImages={attachedImages}
+        attachedImages={props.attachedImages}
         showLoadingImageBadge={showLoadingImageBadge}
         inputHistory={props.inputHistory}
         value={props.value}

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -49,6 +49,8 @@ beforeEach(() => {
     lastUserPromptIndex: null,
     runningToolCallId: null,
     queuedUserMessages: [],
+    query: "",
+    attachedImages: [],
     modeData: { mode: "ready-for-request" },
     vimMode: "INSERT",
   });

--- a/source/state.ts
+++ b/source/state.ts
@@ -154,6 +154,7 @@ export type UiState = {
   byteCount: number;
   vimMode: "NORMAL" | "INSERT";
   query: string;
+  attachedImages: ImageInfo[];
   queuedUserMessages: readonly QueuedUserMessage[];
   readonly history: readonly HistoryNode[];
   clearNonce: number;
@@ -174,6 +175,9 @@ export type UiState = {
   setVimMode: (vimMode: "INSERT" | "NORMAL") => void;
   setModelOverride: (m: ModelConfig, session: Session) => void;
   setQuery: (query: string) => void;
+  addAttachedImage: (image: ImageInfo) => void;
+  removeLastAttachedImage: () => void;
+  clearAttachedImages: () => void;
   enqueueUserMessage: (msg: Omit<QueuedUserMessage, "id">) => void;
   _appendQueuedUserMessages: (session: Session, config: Config) => void;
   retryFrom: (
@@ -296,6 +300,7 @@ export const useAppStore = create<UiState>((set, get) => ({
   quotaData: null,
   byteCount: 0,
   query: "",
+  attachedImages: [],
   queuedUserMessages: [],
   clearNonce: 0,
   sessionHydrationNonce: 0,
@@ -583,6 +588,18 @@ export const useAppStore = create<UiState>((set, get) => ({
 
   setQuery: query => {
     set({ query });
+  },
+
+  addAttachedImage: image => {
+    set(state => ({ attachedImages: [...state.attachedImages, image] }));
+  },
+
+  removeLastAttachedImage: () => {
+    set(state => ({ attachedImages: state.attachedImages.slice(0, -1) }));
+  },
+
+  clearAttachedImages: () => {
+    set({ attachedImages: [] });
   },
 
   enqueueUserMessage: msg => {


### PR DESCRIPTION
A small proposal to lift the image storage from the component local state (`useState()`) to the global zustand state, like the text prompt already is.

The motivation is #266, which does the "ESC when user hasn't output tokens yet rewinds state". To also restore images, we need them in the global state, since the rewind code can't otherwise access component local state.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>