### PR TITLE
Rewind the prompt when ESC aborts an unanswered response

### DIFF
--- a/source/session-history/index.test.ts
+++ b/source/session-history/index.test.ts
@@ -3,9 +3,11 @@ import { db } from "../db/db.ts";
 import { historyItems, llmIrs, notifications } from "./schema/session-history-schema.ts";
 import {
   createSession,
+  deleteHistoryNodes,
   deleteSession,
   insertHistoryItems,
   latestModelJson,
+  listSessions,
   loadSession,
   SessionNotFoundError,
   type HistoryItem,
@@ -123,6 +125,68 @@ describe("deleteSession", () => {
       .map(row => row.json);
     expect(remaining.some(json => json.includes("Keep me"))).toBe(true);
     expect(remaining.some(json => json.includes("Drop me"))).toBe(false);
+  });
+});
+
+describe("deleteHistoryNodes", () => {
+  it("deletes a leaf node and its payload rows", () => {
+    const session = createSession("/test/delete-leaf", LOCAL_CLI_ARGS);
+    const baseline = countRows();
+    const nodes = insertHistoryItems(
+      session,
+      null,
+      [userMessage("First"), userMessage("Second")],
+      TEST_MODEL_JSON,
+    );
+
+    deleteHistoryNodes(session, [nodes[1]!.nodeId]);
+
+    expect(countRows()).toEqual({
+      historyItems: baseline.historyItems + 1,
+      llmIrs: baseline.llmIrs + 1,
+      notifications: baseline.notifications,
+    });
+    const loaded = loadSession(session.metadata.sessionId!)!;
+    expect(loaded.history).toHaveLength(1);
+    expect(loaded.history[0].type).toBe("llm-ir");
+    if (loaded.history[0].type === "llm-ir" && loaded.history[0].ir.role === "user") {
+      expect(loaded.history[0].ir.content).toEqual([{ type: "text", content: "First" }]);
+    } else {
+      throw new Error("expected the remaining node to be the first user message");
+    }
+  });
+
+  it("refuses to delete a node that has children", () => {
+    const session = createSession("/test/delete-non-leaf", LOCAL_CLI_ARGS);
+    const nodes = insertHistoryItems(
+      session,
+      null,
+      [userMessage("First"), userMessage("Second")],
+      TEST_MODEL_JSON,
+    );
+
+    deleteHistoryNodes(session, [nodes[0]!.nodeId]);
+
+    const loaded = loadSession(session.metadata.sessionId!)!;
+    expect(loaded.history).toHaveLength(2);
+  });
+
+  it("updates the session preview to the latest remaining user message", () => {
+    const cwd = "/test/delete-preview";
+    const session = createSession(cwd, LOCAL_CLI_ARGS);
+    const nodes = insertHistoryItems(
+      session,
+      null,
+      [userMessage("First"), userMessage("Second")],
+      TEST_MODEL_JSON,
+    );
+    expect(listSessions(cwd)[0]?.preview).toBe("Second");
+
+    deleteHistoryNodes(session, [nodes[1]!.nodeId]);
+    expect(listSessions(cwd)[0]?.preview).toBe("First");
+
+    deleteHistoryNodes(session, [nodes[0]!.nodeId]);
+    expect(listSessions(cwd)[0]?.preview).toBeNull();
   });
 });
 

--- a/source/session-history/index.ts
+++ b/source/session-history/index.ts
@@ -1,5 +1,5 @@
 import { ParsedCliArgs } from "../cli/cli-args.ts";
-import { desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { db, DbTransaction, schema } from "../db/db.ts";
 import { OctoIR } from "../ir/octo-ir.ts";
 import {
@@ -365,6 +365,54 @@ export function insertHistoryItems(
   session.treeId = result.treeId;
   session.launchId = result.launchId;
   return result.insertedNodes;
+}
+
+export function deleteHistoryNodes(session: Session, nodeIds: readonly number[]): void {
+  if (nodeIds.length === 0) return;
+  db().transaction(tx => {
+    for (const nodeId of nodeIds) {
+      /*
+       * Only leaves may be deleted: tree_nodes_parent_same_tree_fk cascades deletes to a
+       * node's children, so deleting a node with children would wipe later history that
+       * branched off it. Deleting a leaf deletes its history item and payload via the
+       * tree_nodes_delete_history_item trigger chain.
+       */
+      tx.delete(treeNodes)
+        .where(and(eq(treeNodes.id, nodeId), eq(treeNodes.isLeaf, true)))
+        .run();
+    }
+    const treeId = session.treeId;
+    const sessionId = session.metadata.sessionId;
+    if (treeId == null || sessionId == null) return;
+    tx.update(trees).set({ updatedAt: Date.now() }).where(eq(trees.id, treeId)).run();
+    refreshUserMessagePreview(tx, sessionId, treeId);
+  });
+}
+
+/*
+ * The session list preview shows the latest user message; after removing history nodes the
+ * stored preview may point at a message that no longer exists. Re-derive it from the most
+ * recent remaining user message, or clear it if none remain.
+ */
+function refreshUserMessagePreview(tx: DbTransaction, sessionId: string, treeId: number) {
+  const rows = tx
+    .select({ json: llmIrs.json })
+    .from(treeNodes)
+    .innerJoin(historyItems, eq(historyItems.id, treeNodes.historyItemId))
+    .innerJoin(llmIrs, eq(llmIrs.id, historyItems.llmIrId))
+    .where(eq(treeNodes.treeId, treeId))
+    .orderBy(desc(treeNodes.id))
+    .all();
+  for (const row of rows) {
+    const ir = deserializeLlmIr(row.json);
+    if (ir.role !== "user") continue;
+    const userMessageContent = ir.content.find(content => content.type === "text")?.content;
+    if (userMessageContent) {
+      updateSessionPreview(tx, sessionId, excerpt(userMessageContent), "latest-user-message");
+      return;
+    }
+  }
+  tx.delete(previews).where(eq(previews.sessionId, sessionId)).run();
 }
 
 function treeIdForHistoryInsert(tx: DbTransaction, session: Session, sessionId: string): number {

--- a/source/session-history/tree-node-fk.test.ts
+++ b/source/session-history/tree-node-fk.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { db } from "../db/db.ts";
+import { historyItems, llmIrs, treeNodes } from "./schema/session-history-schema.ts";
+import {
+  createSession,
+  deleteHistoryNodes,
+  insertHistoryItems,
+  loadSession,
+  type HistoryItem,
+} from "./index.ts";
+import { serializeModelJson } from "./model-json.ts";
+
+/*
+ * The ESC-rewind design relies on the database rejecting stale writes: when a prompt is
+ * rewound its tree node is deleted, and any in-flight arc that later tries to append history
+ * under the deleted node must fail (the caller catches and moves on) rather than resurrect
+ * the prompt. These tests pin that the drizzle schema + SQLite actually enforce it:
+ *
+ * - the composite FK (parent_id, tree_id) → tree_nodes(id, tree_id) rejects inserts whose
+ *   parent is deleted, nonexistent, or in another tree,
+ * - enforcement is atomic: a failing multi-item insert rolls back the whole transaction,
+ * - ON DELETE CASCADE removes whole subtrees (and, via triggers, their payloads),
+ * - the connection stays usable after a rejected write, so "catch and move on" works.
+ */
+
+const LOCAL_CLI_ARGS = { kind: "local" } as const;
+const TEST_MODEL_JSON = serializeModelJson({
+  nickname: "test-model",
+  model: "test-model",
+  context: 128_000,
+  baseUrl: "http://localhost",
+});
+
+function userMessage(content: string): HistoryItem {
+  return {
+    type: "llm-ir",
+    ir: {
+      role: "user",
+      content: [{ type: "text", content }],
+    },
+  };
+}
+
+function countRows() {
+  return {
+    historyItems: db().select({ id: historyItems.id }).from(historyItems).all().length,
+    llmIrs: db().select({ id: llmIrs.id }).from(llmIrs).all().length,
+    treeNodes: db().select({ id: treeNodes.id }).from(treeNodes).all().length,
+  };
+}
+
+describe("tree node foreign key enforcement", () => {
+  it("enables foreign key enforcement on the app connection", () => {
+    // FK constraints are per-connection in SQLite; everything below depends on this pragma.
+    const rows = db().all<{ foreign_keys: number }>(sql`PRAGMA foreign_keys`);
+    expect(rows[0]?.foreign_keys).toBe(1);
+  });
+
+  it("rejects appending history under a deleted node, rolling back the whole batch", () => {
+    const session = createSession("/test/fk-deleted-parent", LOCAL_CLI_ARGS);
+    const [, b] = insertHistoryItems(
+      session,
+      null,
+      [userMessage("A"), userMessage("B")],
+      TEST_MODEL_JSON,
+    );
+    deleteHistoryNodes(session, [b.nodeId]);
+    const afterDelete = countRows();
+
+    // A stale in-flight arc still holds b's nodeId as its history tip and tries to append.
+    expect(() =>
+      insertHistoryItems(
+        session,
+        b.nodeId,
+        [userMessage("stale 1"), userMessage("stale 2")],
+        TEST_MODEL_JSON,
+      ),
+    ).toThrowError(/FOREIGN KEY constraint failed/i);
+
+    // The multi-item insert is one transaction: none of it may survive the failure.
+    expect(countRows()).toEqual(afterDelete);
+  });
+
+  it("rejects appending under a parent id that never existed", () => {
+    const session = createSession("/test/fk-missing-parent", LOCAL_CLI_ARGS);
+    insertHistoryItems(session, null, [userMessage("A")], TEST_MODEL_JSON);
+    const baseline = countRows();
+
+    expect(() =>
+      insertHistoryItems(session, 999_999_999, [userMessage("B")], TEST_MODEL_JSON),
+    ).toThrowError(/FOREIGN KEY constraint failed/i);
+    expect(countRows()).toEqual(baseline);
+  });
+
+  it("rejects a parent node from a different session tree", () => {
+    const first = createSession("/test/fk-tree-1", LOCAL_CLI_ARGS);
+    const second = createSession("/test/fk-tree-2", LOCAL_CLI_ARGS);
+    const [a] = insertHistoryItems(first, null, [userMessage("A")], TEST_MODEL_JSON);
+    insertHistoryItems(second, null, [userMessage("root")], TEST_MODEL_JSON);
+    const baseline = countRows();
+
+    expect(() =>
+      insertHistoryItems(second, a.nodeId, [userMessage("B")], TEST_MODEL_JSON),
+    ).toThrowError(/FOREIGN KEY constraint failed/i);
+    expect(countRows()).toEqual(baseline);
+  });
+
+  it("accepts multi-item inserts chained within one transaction", () => {
+    const session = createSession("/test/fk-chain", LOCAL_CLI_ARGS);
+    const nodes = insertHistoryItems(
+      session,
+      null,
+      [userMessage("A"), userMessage("B"), userMessage("C")],
+      TEST_MODEL_JSON,
+    );
+    expect(nodes).toHaveLength(3);
+    expect(loadSession(session.metadata.sessionId!)!.history).toHaveLength(3);
+  });
+
+  it("leaves the database usable after a rejected stale append", () => {
+    const session = createSession("/test/fk-recover", LOCAL_CLI_ARGS);
+    const [a, b] = insertHistoryItems(
+      session,
+      null,
+      [userMessage("A"), userMessage("B")],
+      TEST_MODEL_JSON,
+    );
+    deleteHistoryNodes(session, [b.nodeId]);
+
+    // The stale write is rejected; the caller catches it and moves on...
+    expect(() =>
+      insertHistoryItems(session, b.nodeId, [userMessage("stale")], TEST_MODEL_JSON),
+    ).toThrowError(/FOREIGN KEY constraint failed/i);
+
+    // ...and the real continuation appends under the new tip without issue.
+    const [c] = insertHistoryItems(session, a.nodeId, [userMessage("C")], TEST_MODEL_JSON);
+    const loaded = loadSession(session.metadata.sessionId!)!;
+    expect(loaded.history.map(node => node.nodeId)).toEqual([a.nodeId, c.nodeId]);
+  });
+
+  it("cascades deletion of a whole subtree and its payloads", () => {
+    const session = createSession("/test/fk-cascade", LOCAL_CLI_ARGS);
+    const [a] = insertHistoryItems(
+      session,
+      null,
+      [userMessage("A"), userMessage("B"), userMessage("C")],
+      TEST_MODEL_JSON,
+    );
+    const baseline = countRows();
+
+    // Deleting a node with children (raw delete, bypassing deleteHistoryNodes' leaf guard)
+    // must cascade to the entire subtree; triggers then delete items and payloads.
+    db().delete(treeNodes).where(eq(treeNodes.id, a.nodeId)).run();
+
+    expect(countRows()).toEqual({
+      historyItems: baseline.historyItems - 3,
+      llmIrs: baseline.llmIrs - 3,
+      treeNodes: baseline.treeNodes - 3,
+    });
+    expect(loadSession(session.metadata.sessionId!)).toBeNull();
+  });
+
+  it("allows a new root after the old root's subtree was deleted", () => {
+    const session = createSession("/test/fk-new-root", LOCAL_CLI_ARGS);
+    const [a] = insertHistoryItems(session, null, [userMessage("A")], TEST_MODEL_JSON);
+    db().delete(treeNodes).where(eq(treeNodes.id, a.nodeId)).run();
+
+    const [fresh] = insertHistoryItems(session, null, [userMessage("fresh")], TEST_MODEL_JSON);
+    const loaded = loadSession(session.metadata.sessionId!)!;
+    expect(loaded.history.map(node => node.nodeId)).toEqual([fresh.nodeId]);
+  });
+
+  it("rejects a second root node for the same tree", () => {
+    const session = createSession("/test/fk-second-root", LOCAL_CLI_ARGS);
+    insertHistoryItems(session, null, [userMessage("A")], TEST_MODEL_JSON);
+    const baseline = countRows();
+
+    expect(() =>
+      insertHistoryItems(session, null, [userMessage("second root")], TEST_MODEL_JSON),
+    ).toThrowError(/UNIQUE constraint failed/i);
+    expect(countRows()).toEqual(baseline);
+  });
+});

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -818,10 +818,9 @@ describe("rewinding an unanswered prompt on abort", () => {
   });
 
   /*
-   * The rewind needs no bookkeeping flag: the in-flight arc's history copy stops being a
-   * prefix of the live history, so when the arc settles its stale copy (and any partial
-   * response) is dropped instead of resurrecting the prompt. SQLite independently rejects
-   * the stale append via the tree's foreign key constraint (see tree-node-fk.test.ts).
+   * The rewind needs no bookkeeping: the arc's emissions chain under the rewound (deleted)
+   * node, and SQLite's foreign key constraint rejects them — the settling arc can't
+   * resurrect the prompt or its partial response (see tree-node-fk.test.ts).
    */
   it("drops the stale history copy when the rewound arc settles", async () => {
     const prevEnv = process.env["OCTO_STATE_TEST_API_KEY"];
@@ -1156,5 +1155,40 @@ describe("runAgent history persistence (BUGS.md #8, #12)", () => {
     expect(historyRoles()).toEqual(["user", "checkpoint"]);
     expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-checkpoint-marker")).toBe(1);
     expect(dbNodeCount(session.metadata.sessionId!)).toBe(2);
+  });
+
+  it("drops arc emissions after the prompt is rewound, rejected by SQLite", async () => {
+    const transport = new LocalTransport();
+    const session = createSession(process.cwd(), { kind: "local" });
+    const reasoningAssistant = {
+      role: "assistant" as const,
+      content: "",
+      reasoningContent: "bug8-rewound-reasoning-marker",
+      usage: compilerUsage(0, 0),
+    };
+    const fakeArc = async ({ handler }: TrajectoryArcArgs): Promise<TrajectoryArcFinish> => {
+      handler.startResponse(null);
+      /*
+       * ESC while the model is still reasoning (no content tokens): the prompt is rewound
+       * and its node deleted, so this emission chains under a deleted parent and SQLite
+       * rejects it.
+       */
+      useAppStore.getState().abortResponse(session, agentConfig);
+      handler.onMessage(reasoningAssistant);
+      return { type: "finish", reason: { type: "abort" } };
+    };
+
+    await withMock(trajectoryArc, "run", fakeArc, async () => {
+      await useAppStore
+        .getState()
+        .input({ config: agentConfig, transport, session, query: "change me" });
+    });
+
+    const state = useAppStore.getState();
+    expect(state.query).toBe("change me");
+    expect(state.modeData.mode).toBe("ready-for-request");
+    expect(state.history).toHaveLength(0);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-rewound-reasoning-marker")).toBe(0);
+    expect(dbNodeCount(session.metadata.sessionId!)).toBe(0);
   });
 });

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -9,7 +9,7 @@ import { useAppStore, nextToolAction } from "./state.ts";
 import type { Config } from "./config.ts";
 import { db } from "./db/db.ts";
 import type { HistoryNode } from "./session-history/index.ts";
-import { createSession, insertHistoryItems } from "./session-history/index.ts";
+import { createSession, insertHistoryItems, loadSession } from "./session-history/index.ts";
 import { serializeModelJson } from "./session-history/model-json.ts";
 import {
   historyItems,
@@ -23,6 +23,7 @@ import type { ToolCall } from "./libocto/tool-def.ts";
 import { trajectoryArc } from "./agent/trajectory-arc.ts";
 import type toolMap from "./tools/tool-defs/index.ts";
 import { LocalTransport } from "./transports/local.ts";
+import type { ImageInfo } from "./utils/image-utils.ts";
 
 type TrajectoryArcArgs = Parameters<typeof trajectoryArc.run>[0];
 type TrajectoryArcFinish = Awaited<ReturnType<typeof trajectoryArc.run>>;
@@ -60,6 +61,7 @@ beforeEach(() => {
     history: [],
     preMenuModeData: null,
     lastUserPromptIndex: null,
+    promptRewindPending: false,
     runningToolCallId: null,
     queuedUserMessages: [],
     query: "",
@@ -641,6 +643,204 @@ describe("message queue", () => {
     useAppStore.getState().abortResponse(session, config);
     expect(useAppStore.getState().queuedUserMessages).toHaveLength(0);
     expect(useAppStore.getState().history).toHaveLength(0);
+  });
+});
+
+/*
+ * ESC before the model has streamed any non-reasoning tokens means "I want to change my
+ * prompt": the just-submitted user message is removed from history (in-memory and persisted)
+ * and its text is restored to the input field. Once real content streams, ESC is a plain
+ * interrupt and history keeps both the prompt and the partial response.
+ */
+describe("rewinding an unanswered prompt on abort", () => {
+  function setupResponding(content: string, reasoningContent?: string) {
+    const session = createSession(process.cwd(), { kind: "local" });
+    const nodes = insertHistoryItems(
+      session,
+      null,
+      [
+        {
+          type: "llm-ir",
+          ir: {
+            role: "user",
+            content: [{ type: "text", content: "first prompt" }],
+          },
+        },
+        {
+          type: "llm-ir",
+          ir: {
+            role: "assistant",
+            content: "first response",
+            usage: compilerUsage(0, 0),
+          },
+        },
+        {
+          type: "llm-ir",
+          ir: {
+            role: "user",
+            content: [{ type: "text", content: "second prompt" }],
+          },
+        },
+      ],
+      testModelJson,
+    );
+    useAppStore.getState().hydrateSession(nodes);
+    useAppStore.setState({
+      lastUserPromptIndex: 2,
+      modeData: {
+        mode: "responding",
+        inflightResponse: { type: "inflight-response", content, reasoningContent },
+        abortController: new AbortController(),
+      },
+    });
+    return session;
+  }
+
+  it("removes the prompt from history and restores it to the input", () => {
+    const session = setupResponding("");
+    useAppStore.getState().abortResponse(session, config);
+
+    const state = useAppStore.getState();
+    expect(state.query).toBe("second prompt");
+    expect(state.history).toHaveLength(2);
+    expect(state.lastUserPromptIndex).toBeNull();
+
+    // The persisted session no longer contains the rewound prompt either.
+    const loaded = loadSession(session.metadata.sessionId!)!;
+    expect(loaded.history).toHaveLength(2);
+    const persisted = JSON.stringify(loaded.history);
+    expect(persisted).not.toContain("second prompt");
+  });
+
+  it("rewinds while the model is still reasoning", () => {
+    const session = setupResponding("", "thinking out loud...");
+    useAppStore.getState().abortResponse(session, config);
+
+    const state = useAppStore.getState();
+    expect(state.query).toBe("second prompt");
+    expect(state.history).toHaveLength(2);
+  });
+
+  it("restores attached images alongside the prompt text", () => {
+    const session = createSession(process.cwd(), { kind: "local" });
+    const image: ImageInfo = {
+      mimeType: "image/png",
+      base64Data: "aGVsbG8=",
+      dataUrl: "data:image/png;base64,aGVsbG8=",
+      filePath: "/tmp/pasted.png",
+      sizeBytes: 5,
+    };
+    const nodes = insertHistoryItems(
+      session,
+      null,
+      [
+        {
+          type: "llm-ir",
+          ir: {
+            role: "user",
+            content: [
+              { type: "text", content: "what is this?" },
+              { type: "image", image },
+            ],
+          },
+        },
+      ],
+      testModelJson,
+    );
+    useAppStore.getState().hydrateSession(nodes);
+    useAppStore.setState({
+      modeData: {
+        mode: "responding",
+        inflightResponse: { type: "inflight-response", content: "" },
+        abortController: new AbortController(),
+      },
+    });
+
+    useAppStore.getState().abortResponse(session, config);
+
+    const state = useAppStore.getState();
+    expect(state.query).toBe("what is this?");
+    expect(state.attachedImages).toEqual([image]);
+    expect(state.history).toHaveLength(0);
+  });
+
+  it("keeps the prompt in history once the model streams content", () => {
+    const session = setupResponding("partial response");
+    useAppStore.getState().abortResponse(session, config);
+
+    const state = useAppStore.getState();
+    expect(state.query).toBe("");
+    expect(state.history).toHaveLength(3);
+    const loaded = loadSession(session.metadata.sessionId!)!;
+    expect(loaded.history).toHaveLength(3);
+  });
+
+  it("does not rewind mid-trajectory, when the newest history item isn't the prompt", () => {
+    const session = setupResponding("");
+    const callA = shellCall("call_a", "echo a");
+    const extra = insertHistoryItems(
+      session,
+      useAppStore.getState().history.at(-1)!.nodeId,
+      [
+        {
+          type: "llm-ir",
+          ir: {
+            role: "assistant",
+            content: "",
+            usage: compilerUsage(0, 0),
+            toolCalls: [callA],
+          },
+        },
+        {
+          type: "llm-ir",
+          ir: {
+            role: "tool-output",
+            toolCall: callA,
+            content: [{ type: "text", content: "done" }],
+          },
+        },
+      ],
+      testModelJson,
+    );
+    useAppStore.getState().hydrateSession([...useAppStore.getState().history, ...extra]);
+    useAppStore.setState({
+      modeData: {
+        mode: "responding",
+        inflightResponse: { type: "inflight-response", content: "" },
+        abortController: new AbortController(),
+      },
+    });
+
+    useAppStore.getState().abortResponse(session, config);
+
+    const state = useAppStore.getState();
+    expect(state.query).toBe("");
+    expect(state.history).toHaveLength(5);
+    expect(state.promptRewindPending).toBe(false);
+  });
+
+  it("flags the rewind so the settling arc doesn't re-persist the prompt", () => {
+    const session = setupResponding("");
+    useAppStore.getState().abortResponse(session, config);
+    expect(useAppStore.getState().promptRewindPending).toBe(true);
+
+    // The aborted arc settled with an exception rather than an abort finish: the flag must
+    // be cleared so the next run doesn't skip persisting its response.
+    const controller = new AbortController();
+    controller.abort();
+    expect(useAppStore.getState()._maybeHandleAbort(controller.signal)).toBe(true);
+    expect(useAppStore.getState().promptRewindPending).toBe(false);
+    expect(useAppStore.getState().modeData.mode).toBe("ready-for-request");
+  });
+
+  it("does not rewind when exiting", () => {
+    const session = setupResponding("");
+    useAppStore.getState().abortResponse(session, config, { exiting: true });
+
+    const state = useAppStore.getState();
+    expect(state.query).toBe("");
+    expect(state.history).toHaveLength(3);
+    expect(state.promptRewindPending).toBe(false);
   });
 });
 

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -61,7 +61,6 @@ beforeEach(() => {
     history: [],
     preMenuModeData: null,
     lastUserPromptIndex: null,
-    promptRewindPending: false,
     runningToolCallId: null,
     queuedUserMessages: [],
     query: "",
@@ -816,22 +815,66 @@ describe("rewinding an unanswered prompt on abort", () => {
     const state = useAppStore.getState();
     expect(state.query).toBe("");
     expect(state.history).toHaveLength(5);
-    expect(state.promptRewindPending).toBe(false);
   });
 
-  it("flags the rewind so the settling arc doesn't re-persist the prompt", () => {
-    const session = setupResponding("");
-    useAppStore.getState().abortResponse(session, config);
-    expect(useAppStore.getState().promptRewindPending).toBe(true);
+  /*
+   * The rewind needs no bookkeeping flag: the in-flight arc's history copy stops being a
+   * prefix of the live history, so when the arc settles its stale copy (and any partial
+   * response) is dropped instead of resurrecting the prompt. SQLite independently rejects
+   * the stale append via the tree's foreign key constraint (see tree-node-fk.test.ts).
+   */
+  it("drops the stale history copy when the rewound arc settles", async () => {
+    const prevEnv = process.env["OCTO_STATE_TEST_API_KEY"];
+    process.env["OCTO_STATE_TEST_API_KEY"] = "test-key";
+    try {
+      const authConfig: Config = {
+        yourName: "Test",
+        models: [
+          {
+            nickname: "test-model",
+            model: "test-model",
+            context: 128_000,
+            baseUrl: "http://localhost:1",
+            auth: { type: "env", name: "OCTO_STATE_TEST_API_KEY" },
+          },
+        ],
+      };
+      const session = createSession(process.cwd(), { kind: "local" });
+      const nodes = insertHistoryItems(
+        session,
+        null,
+        [
+          {
+            type: "llm-ir",
+            ir: { role: "user", content: [{ type: "text", content: "change me" }] },
+          },
+        ],
+        testModelJson,
+      );
+      useAppStore.getState().hydrateSession(nodes);
+      useAppStore.setState({ modelOverride: null });
 
-    // The aborted arc settled with an exception rather than an abort finish: the flag must
-    // be cleared so the next run doesn't skip persisting its response.
-    const controller = new AbortController();
-    controller.abort();
-    expect(useAppStore.getState()._maybeHandleAbort(controller.signal)).toBe(true);
-    expect(useAppStore.getState().promptRewindPending).toBe(false);
-    expect(useAppStore.getState().modeData.mode).toBe("ready-for-request");
-  });
+      // ESC the moment the response starts — synchronously, before the request goes out.
+      const unsubscribe = useAppStore.subscribe(state => {
+        if (state.modeData.mode !== "responding") return;
+        unsubscribe();
+        useAppStore.getState().abortResponse(session, authConfig);
+      });
+
+      const transport = new LocalTransport();
+      await useAppStore.getState().runAgent({ config: authConfig, transport, session });
+
+      const state = useAppStore.getState();
+      expect(state.query).toBe("change me");
+      expect(state.modeData.mode).toBe("ready-for-request");
+      // The rewound prompt was not resurrected — in state or in the persisted session.
+      expect(state.history).toHaveLength(0);
+      expect(loadSession(session.metadata.sessionId!)).toBeNull();
+    } finally {
+      if (prevEnv == null) delete process.env["OCTO_STATE_TEST_API_KEY"];
+      else process.env["OCTO_STATE_TEST_API_KEY"] = prevEnv;
+    }
+  }, 30_000);
 
   it("does not rewind when exiting", () => {
     const session = setupResponding("");
@@ -840,7 +883,6 @@ describe("rewinding an unanswered prompt on abort", () => {
     const state = useAppStore.getState();
     expect(state.query).toBe("");
     expect(state.history).toHaveLength(3);
-    expect(state.promptRewindPending).toBe(false);
   });
 });
 

--- a/source/state.ts
+++ b/source/state.ts
@@ -227,17 +227,12 @@ function appendAndPersistHistory(
 }
 
 /*
- * Whether `prefix` is still a prefix of `full`, by node identity. An in-flight arc captures
- * a history copy at start; the arc's own handlers only ever append to the live history, so
- * at settle time the copy remains a prefix — unless something external (a prompt rewind, a
- * new session) changed history underneath the arc.
+ * better-sqlite3 surfaces foreign key violations as a plain Error whose message is
+ * "FOREIGN KEY constraint failed" — there's no error code to match on, so match the
+ * message. Appending history under a deleted tree node (e.g. a rewound prompt) hits this.
  */
-function isHistoryPrefix(prefix: readonly HistoryNode[], full: readonly HistoryNode[]): boolean {
-  if (prefix.length > full.length) return false;
-  for (let i = 0; i < prefix.length; i++) {
-    if (prefix[i].nodeId !== full[i].nodeId) return false;
-  }
-  return true;
+function isForeignKeyViolation(e: unknown): boolean {
+  return e instanceof Error && /FOREIGN KEY constraint failed/i.test(e.message);
 }
 
 /*
@@ -816,6 +811,12 @@ export const useAppStore = create<UiState>((set, get) => ({
   runAgent: async ({ config, transport, session }) => {
     get()._appendQueuedUserMessages(session, config);
     const historyCopy = [...get().history];
+    /*
+     * The tip of this arc's history chain. Emissions are chained under it (see onMessage)
+     * rather than the live history tip, so that if the arc's context is deleted mid-flight
+     * (a prompt rewind), SQLite rejects the arc's appends.
+     */
+    let arcHistoryTip = historyCopy.at(-1)?.nodeId ?? null;
     const abortController = new AbortController();
     let compactionByteCount = 0;
     let responseByteCount = 0;
@@ -946,19 +947,22 @@ export const useAppStore = create<UiState>((set, get) => ({
           onMessage: ir => {
             throttle.flush();
             /*
-             * If the user rewound the prompt that kicked off this arc, this arc's captured
-             * history copy is no longer a prefix of the live history. Drop anything else the
-             * arc emits instead of resurrecting the prompt or its response.
+             * Emissions chain under the arc's own history tip (not the live tip): if the
+             * user rewound the prompt that kicked off this arc, the arc's tip is deleted and
+             * SQLite rejects the append — drop the emission.
              */
-            if (!isHistoryPrefix(historyCopy, get().history)) return;
-            set({
-              history: appendAndPersistHistory(
+            try {
+              const nodes = insertHistoryItems(
                 session,
-                get().history,
+                arcHistoryTip,
                 [{ type: "llm-ir", ir }],
-                model,
-              ),
-            });
+                serializeModelJson(model),
+              );
+              arcHistoryTip = nodes.at(-1)!.nodeId;
+              set({ history: [...get().history, ...nodes] });
+            } catch (e) {
+              if (!isForeignKeyViolation(e)) throw e;
+            }
           },
         },
       });

--- a/source/state.ts
+++ b/source/state.ts
@@ -165,10 +165,6 @@ export type UiState = {
   clearNonce: number;
   sessionHydrationNonce: number;
   lastUserPromptIndex: number | null;
-  /**
-   * If true, the user rewound their last prompt: don't persist stale history.
-   */
-  promptRewindPending: boolean;
   whitelist: Set<string>;
   notifyReadyForInput: (config: Config) => void;
   cancelNotifyReadyForInput: () => void;
@@ -228,6 +224,20 @@ function appendAndPersistHistory(
     ...prevHistory,
     ...insertHistoryItems(session, parentNodeId, itemsToInsert, serializeModelJson(model)),
   ];
+}
+
+/*
+ * Whether `prefix` is still a prefix of `full`, by node identity. An in-flight arc captures
+ * a history copy at start; the arc's own handlers only ever append to the live history, so
+ * at settle time the copy remains a prefix — unless something external (a prompt rewind, a
+ * new session) changed history underneath the arc.
+ */
+function isHistoryPrefix(prefix: readonly HistoryNode[], full: readonly HistoryNode[]): boolean {
+  if (prefix.length > full.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (prefix[i].nodeId !== full[i].nodeId) return false;
+  }
+  return true;
 }
 
 /*
@@ -314,7 +324,6 @@ export const useAppStore = create<UiState>((set, get) => ({
   clearNonce: 0,
   sessionHydrationNonce: 0,
   lastUserPromptIndex: null,
-  promptRewindPending: false,
   whitelist: new Set<string>(),
 
   setNotifyOnce: notifyOnce => {
@@ -504,6 +513,11 @@ export const useAppStore = create<UiState>((set, get) => ({
      *
      * Only rewinds when the user message is the newest history item: mid-trajectory aborts
      * (e.g. after tool calls) leave history alone.
+     *
+     * The in-flight arc still holds a history copy whose tip is the deleted node. When it
+     * settles, runAgent sees the copy is no longer a prefix of the live history and drops it
+     * (SQLite would reject the append anyway: the deleted tip violates the tree's foreign
+     * key constraint). The rewind needs no bookkeeping of its own.
      */
     if (
       !opts?.exiting &&
@@ -526,7 +540,6 @@ export const useAppStore = create<UiState>((set, get) => ({
           query,
           attachedImages,
           lastUserPromptIndex: null,
-          promptRewindPending: true,
         });
       }
     }
@@ -588,7 +601,6 @@ export const useAppStore = create<UiState>((set, get) => ({
     if (signal.aborted) {
       set({
         queuedUserMessages: [],
-        promptRewindPending: false,
         modeData: {
           mode: "ready-for-request",
         },
@@ -699,7 +711,6 @@ export const useAppStore = create<UiState>((set, get) => ({
       history: repairedHistory,
       modelOverride: latestModelJson(history),
       lastUserPromptIndex: null,
-      promptRewindPending: false,
       byteCount: 0,
       queuedUserMessages: [],
       clearNonce: state.clearNonce + 1,
@@ -721,7 +732,6 @@ export const useAppStore = create<UiState>((set, get) => ({
     set(state => ({
       history: [],
       lastUserPromptIndex: null,
-      promptRewindPending: false,
       byteCount: 0,
       queuedUserMessages: [],
       clearNonce: state.clearNonce + 1,
@@ -941,11 +951,13 @@ export const useAppStore = create<UiState>((set, get) => ({
           onMessage: ir => {
             throttle.flush();
             /*
-             * The prompt that kicked off this arc was rewound when the user aborted: don't
-             * persist anything else this arc emits — its history copy still contains the
-             * removed prompt, and these IRs are the response to it.
+             * If the user rewound the prompt that kicked off this arc, this arc's captured
+             * history copy is no longer a prefix of the live history: drop anything else the
+             * arc emits instead of resurrecting the prompt or its response. SQLite would
+             * reject a stale append under the deleted tip anyway (foreign key constraint) —
+             * the prefix check keeps in-memory state consistent too.
              */
-            if (get().promptRewindPending) return;
+            if (!isHistoryPrefix(historyCopy, get().history)) return;
             set({
               history: appendAndPersistHistory(
                 session,
@@ -963,7 +975,6 @@ export const useAppStore = create<UiState>((set, get) => ({
         get().notifyReadyForInput(config);
         set({
           queuedUserMessages: [],
-          promptRewindPending: false,
           modeData: { mode: "ready-for-request" },
           vimMode: "INSERT",
         });

--- a/source/state.ts
+++ b/source/state.ts
@@ -165,11 +165,8 @@ export type UiState = {
   clearNonce: number;
   sessionHydrationNonce: number;
   lastUserPromptIndex: number | null;
-  /*
-   * Set when an abort rewound the just-submitted prompt out of history (see abortResponse).
-   * The in-flight runAgent still holds a history copy containing that prompt; this tells it
-   * not to persist the stale copy (or the partially-streamed response) when the aborted arc
-   * settles.
+  /**
+   * If true, the user rewound their last prompt: don't persist stale history.
    */
   promptRewindPending: boolean;
   whitelist: Set<string>;

--- a/source/state.ts
+++ b/source/state.ts
@@ -10,6 +10,7 @@ import {
 import { ImageInfo } from "./utils/image-utils.ts";
 import {
   createSession,
+  deleteHistoryNodes,
   HistoryNode,
   insertHistoryItems,
   latestModelJson,
@@ -164,6 +165,13 @@ export type UiState = {
   clearNonce: number;
   sessionHydrationNonce: number;
   lastUserPromptIndex: number | null;
+  /*
+   * Set when an abort rewound the just-submitted prompt out of history (see abortResponse).
+   * The in-flight runAgent still holds a history copy containing that prompt; this tells it
+   * not to persist the stale copy (or the partially-streamed response) when the aborted arc
+   * settles.
+   */
+  promptRewindPending: boolean;
   whitelist: Set<string>;
   notifyReadyForInput: (config: Config) => void;
   cancelNotifyReadyForInput: () => void;
@@ -309,6 +317,7 @@ export const useAppStore = create<UiState>((set, get) => ({
   clearNonce: 0,
   sessionHydrationNonce: 0,
   lastUserPromptIndex: null,
+  promptRewindPending: false,
   whitelist: new Set<string>(),
 
   setNotifyOnce: notifyOnce => {
@@ -489,6 +498,42 @@ export const useAppStore = create<UiState>((set, get) => ({
     const { modeData, runningToolCallId } = get();
     if ("abortController" in modeData) modeData.abortController.abort();
     set({ queuedUserMessages: [] });
+
+    /*
+     * ESC before the model has streamed any non-reasoning tokens — while it's still
+     * thinking, or before it responded at all — means "I want to change my prompt": drop the
+     * just-submitted user message from history (in-memory and persisted) and put its text
+     * and attached images back in the input field.
+     *
+     * Only rewinds when the user message is the newest history item: mid-trajectory aborts
+     * (e.g. after tool calls) leave history alone.
+     */
+    if (
+      !opts?.exiting &&
+      modeData.mode === "responding" &&
+      modeData.inflightResponse.content.trim() === ""
+    ) {
+      const history = get().history;
+      const last = history.at(-1);
+      if (last && last.type === "llm-ir" && last.ir.role === "user") {
+        const query = last.ir.content
+          .filter(part => part.type === "text")
+          .map(part => part.content)
+          .join("\n");
+        const attachedImages = last.ir.content
+          .filter(part => part.type === "image")
+          .map(part => part.image);
+        deleteHistoryNodes(session, [last.nodeId]);
+        set({
+          history: history.slice(0, -1),
+          query,
+          attachedImages,
+          lastUserPromptIndex: null,
+          promptRewindPending: true,
+        });
+      }
+    }
+
     if (modeData.mode !== "tool-call") return;
 
     /*
@@ -546,6 +591,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     if (signal.aborted) {
       set({
         queuedUserMessages: [],
+        promptRewindPending: false,
         modeData: {
           mode: "ready-for-request",
         },
@@ -656,6 +702,7 @@ export const useAppStore = create<UiState>((set, get) => ({
       history: repairedHistory,
       modelOverride: latestModelJson(history),
       lastUserPromptIndex: null,
+      promptRewindPending: false,
       byteCount: 0,
       queuedUserMessages: [],
       clearNonce: state.clearNonce + 1,
@@ -677,6 +724,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     set(state => ({
       history: [],
       lastUserPromptIndex: null,
+      promptRewindPending: false,
       byteCount: 0,
       queuedUserMessages: [],
       clearNonce: state.clearNonce + 1,
@@ -895,6 +943,12 @@ export const useAppStore = create<UiState>((set, get) => ({
 
           onMessage: ir => {
             throttle.flush();
+            /*
+             * The prompt that kicked off this arc was rewound when the user aborted: don't
+             * persist anything else this arc emits — its history copy still contains the
+             * removed prompt, and these IRs are the response to it.
+             */
+            if (get().promptRewindPending) return;
             set({
               history: appendAndPersistHistory(
                 session,
@@ -912,6 +966,7 @@ export const useAppStore = create<UiState>((set, get) => ({
         get().notifyReadyForInput(config);
         set({
           queuedUserMessages: [],
+          promptRewindPending: false,
           modeData: { mode: "ready-for-request" },
           vimMode: "INSERT",
         });

--- a/source/state.ts
+++ b/source/state.ts
@@ -513,11 +513,6 @@ export const useAppStore = create<UiState>((set, get) => ({
      *
      * Only rewinds when the user message is the newest history item: mid-trajectory aborts
      * (e.g. after tool calls) leave history alone.
-     *
-     * The in-flight arc still holds a history copy whose tip is the deleted node. When it
-     * settles, runAgent sees the copy is no longer a prefix of the live history and drops it
-     * (SQLite would reject the append anyway: the deleted tip violates the tree's foreign
-     * key constraint). The rewind needs no bookkeeping of its own.
      */
     if (
       !opts?.exiting &&
@@ -952,10 +947,8 @@ export const useAppStore = create<UiState>((set, get) => ({
             throttle.flush();
             /*
              * If the user rewound the prompt that kicked off this arc, this arc's captured
-             * history copy is no longer a prefix of the live history: drop anything else the
-             * arc emits instead of resurrecting the prompt or its response. SQLite would
-             * reject a stale append under the deleted tip anyway (foreign key constraint) —
-             * the prefix check keeps in-memory state consistent too.
+             * history copy is no longer a prefix of the live history. Drop anything else the
+             * arc emits instead of resurrecting the prompt or its response.
              */
             if (!isHistoryPrefix(historyCopy, get().history)) return;
             set({


### PR DESCRIPTION
Adds the feature we talked about where ESC before the model streams any non-reasoning tokens removes the prompt from history and restores it (text + images) to the input.

https://github.com/user-attachments/assets/8da179a4-d0d9-432d-820e-02a00fee1480

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>