### PR TITLE
Fix data duplication

### DIFF
--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -1,4 +1,5 @@
 import fs from "fs/promises";
+import { registry } from "antipattern";
 import type { OctoIR } from "../ir/octo-ir.ts";
 import type {
   Content,
@@ -86,12 +87,9 @@ export type StateEvents = {
   };
   startCompaction: null;
   compactionProgress: AutocompactionStream;
-  compactionParsed: CompactionType;
   autofixingJson: null;
   autofixingDiff: null;
-  retryTool: {
-    irs: TrajectoryOutputIR[];
-  };
+  onMessage: TrajectoryOutputIR;
   onQuotaUpdated: QuotaData;
 };
 
@@ -99,7 +97,6 @@ export type AnyState = keyof StateEvents;
 
 type Finish = {
   type: "finish";
-  irs: TrajectoryOutputIR[];
   reason:
     | {
         type: "abort";
@@ -132,330 +129,311 @@ type Finish = {
  * Given some LLM IR, it runs the next arc of the trajectory until one of the finish reasons defined
  * above is hit.
  */
-export async function trajectoryArc({
-  modelData,
-  messages,
-  config,
-  transport,
-  abortSignal,
-  handler,
-}: {
-  modelData: ModelData;
-  messages: OctoIR[];
-  config: Config;
-  transport: Transport;
-  abortSignal: AbortSignal;
-  handler: {
-    [K in AnyState]: (state: StateEvents[K]) => void;
-  };
-}): Promise<Finish> {
-  if (abortSignal.aborted) return abort([]);
-
-  const messagesCopy = [...messages];
-  const autofixJson = makeAutofixJson(config);
-  let irs: TrajectoryOutputIR[] = [];
-  const tools = await loadTools(transport, abortSignal, config);
-  const { model } = modelData;
-
-  const parsedCompaction = await maybeAutocompact({
+export const trajectoryArc = registry({
+  async run({
     modelData,
-    abortSignal,
+    messages,
+    config,
     transport,
-    autofixJson,
-    messages: messagesCopy,
+    abortSignal,
+    handler,
+  }: {
+    modelData: ModelData;
+    messages: OctoIR[];
+    config: Config;
+    transport: Transport;
+    abortSignal: AbortSignal;
     handler: {
-      startCompaction: () => handler.startCompaction(null),
-      compactionProgress: stream => handler.compactionProgress(stream),
-    },
-  });
-  if (!parsedCompaction.success) {
-    if (
-      isRecoverableRequestError(parsedCompaction.error) ||
-      parsedCompaction.error.type === "auth-error"
-    ) {
-      return {
-        type: "finish",
-        irs,
-        reason: parsedCompaction.error,
-      };
-    }
+      [K in AnyState]: (state: StateEvents[K]) => void;
+    };
+  }): Promise<Finish> {
+    const messagesCopy = [...messages];
+    const autofixJson = makeAutofixJson(config);
+    let irs: TrajectoryOutputIR[] = [];
+    const emitIrs = (delta: TrajectoryOutputIR[]) => {
+      for (const ir of delta) handler.onMessage(ir);
+    };
+    const finishWith = (reason: Finish["reason"], remaining: TrajectoryOutputIR[] = []): Finish => {
+      emitIrs(remaining);
+      return { type: "finish", reason };
+    };
+    if (abortSignal.aborted) return finishWith({ type: "abort" });
 
-    return {
-      type: "finish",
-      irs,
-      reason: {
+    const tools = await loadTools(transport, abortSignal, config);
+    const { model } = modelData;
+
+    const parsedCompaction = await maybeAutocompact({
+      modelData,
+      abortSignal,
+      transport,
+      autofixJson,
+      messages: messagesCopy,
+      handler: {
+        startCompaction: () => handler.startCompaction(null),
+        compactionProgress: stream => handler.compactionProgress(stream),
+      },
+    });
+    if (!parsedCompaction.success) {
+      if (
+        isRecoverableRequestError(parsedCompaction.error) ||
+        parsedCompaction.error.type === "auth-error"
+      ) {
+        return finishWith(parsedCompaction.error);
+      }
+
+      return finishWith({
         type: "compaction-error",
         requestError: parsedCompaction.error.requestError,
         curl: parsedCompaction.error.curl,
+      });
+    }
+
+    if (parsedCompaction.data) {
+      emitIrs([parsedCompaction.data.checkpoint]);
+      messagesCopy.push(parsedCompaction.data.checkpoint);
+    }
+    if (abortSignal.aborted) return finishWith({ type: "abort" });
+
+    handler.startResponse(null);
+
+    let buffer: AssistantBuffer<ResponseTokenTypes> = {};
+    const loweredMessages = lowerOcto(messagesCopy, model.modalities);
+    const result = await run({
+      modelData,
+      autofixJson,
+      abortSignal,
+      transport,
+      tools,
+      messages: loweredMessages,
+      handlers: {
+        onTokens: (tokens, type) => {
+          if (!buffer[type]) buffer[type] = "";
+          buffer[type] += tokens;
+          handler.responseProgress({
+            buffer,
+            delta: { type, value: tokens },
+          });
+        },
+        onAutofixJson: () => {
+          handler.autofixingJson(null);
+        },
       },
-    };
-  }
-
-  if (parsedCompaction.data) {
-    handler.compactionParsed(parsedCompaction.data);
-    messagesCopy.push(parsedCompaction.data.checkpoint);
-    irs.push(parsedCompaction.data.checkpoint);
-  }
-  if (abortSignal.aborted) return abort([]);
-
-  handler.startResponse(null);
-
-  let buffer: AssistantBuffer<ResponseTokenTypes> = {};
-  const loweredMessages = lowerOcto(messagesCopy, model.modalities);
-  const result = await run({
-    modelData,
-    autofixJson,
-    abortSignal,
-    transport,
-    tools,
-    messages: loweredMessages,
-    handlers: {
-      onTokens: (tokens, type) => {
-        if (!buffer[type]) buffer[type] = "";
-        buffer[type] += tokens;
-        handler.responseProgress({
-          buffer,
-          delta: { type, value: tokens },
+      systemPrompt: async () => {
+        return systemPrompt({
+          config,
+          transport,
+          signal: abortSignal,
         });
       },
-      onAutofixJson: () => {
-        handler.autofixingJson(null);
-      },
-    },
-    systemPrompt: async () => {
-      return systemPrompt({
+    });
+
+    function maybeBufferedMessage(): TrajectoryOutputIR[] {
+      if (buffer.content || buffer.reasoning || buffer.tool) {
+        return [
+          ...irs,
+          {
+            role: "assistant",
+            content: buffer.content || "",
+            reasoningContent: buffer.reasoning,
+            usage: compilerUsage(0, 0),
+          },
+        ];
+      }
+      return [];
+    }
+
+    const headers = result.success
+      ? result.data.headers
+      : "headers" in result.error
+        ? result.error.headers
+        : undefined;
+    const quota = parseQuotaFromHeaders(headers);
+    if (quota) handler.onQuotaUpdated(quota);
+
+    if (abortSignal.aborted) return finishWith({ type: "abort" }, maybeBufferedMessage());
+
+    if (!result.success) {
+      return finishWith(compilerErrorToFinishReason(result.error), maybeBufferedMessage());
+    }
+
+    let assistantMessage = result.data.output;
+    irs = [...irs, assistantMessage];
+
+    // Retry malformed tool calls
+    let malformedRequests = false;
+    for (const call of assistantMessage.toolCalls || []) {
+      if (call.type === "malformed-tool-request") {
+        malformedRequests = true;
+        break;
+      }
+    }
+
+    if (malformedRequests) {
+      // Insert tool skips for all of the non-malformed tool call IRs, and ensure the original order
+      // is kept in terms of input ordering vs output message ordering
+      for (const call of assistantMessage.toolCalls || []) {
+        if (call.type === "tool-call") {
+          irs.push({
+            role: "tool-skip-output",
+            toolCall: call,
+            reason: "Another tool call in this batch was malformed, so this tool call was skipped",
+          });
+        } else {
+          const _: "malformed-tool-request" = call.type;
+          irs.push({
+            role: "tool-parse-error",
+            malformedRequest: call,
+          });
+        }
+      }
+
+      emitIrs(irs);
+      const retried = await trajectoryArc.run({
+        modelData,
         config,
         transport,
-        signal: abortSignal,
+        abortSignal,
+        messages: messagesCopy.concat(irs),
+        handler,
       });
-    },
-  });
 
-  function maybeBufferedMessage(): TrajectoryOutputIR[] {
-    if (buffer.content || buffer.reasoning || buffer.tool) {
-      return [
-        ...irs,
+      return finishWith(retried.reason);
+    }
+
+    const { toolCalls } = assistantMessage;
+
+    if (toolCalls == null) {
+      return finishWith({ type: "needs-response" }, irs);
+    }
+
+    let retryIrs: TrajectoryOutputIR[] = [];
+    const wellformedToolCalls: Array<ToolCallRequest> = [];
+    for (const toolCall of toolCalls) {
+      if (toolCall.type === "malformed-tool-request") {
+        throw new Error(
+          "Impossible tool ordering: encountered a malformed tool with no malformed response",
+        );
+      }
+      wellformedToolCalls.push(toolCall);
+    }
+
+    // TODO: use Promise.all to do this in parallel
+    // Requires changing the signature somewhat; currently we expect that the handlers are called
+    // sequentially (i.e. we only autofix one tool at a time), but this would imply we could call the
+    // handlers multiple times within a single validation step
+    for (const toolCall of wellformedToolCalls) {
+      const validation = await validateTool(abortSignal, transport, tools, toolCall, config);
+
+      if (validation.success) {
+        // If we got this far, the tool validated successfully. Proactively push a tool-skip-output IR for
+        // it, in case other tool calls fail to validate (since all tool calls will be skipped if any
+        // are invalid).
+        retryIrs.push({
+          role: "tool-skip-output",
+          toolCall: toolCall,
+          reason: SKIP_INVALID_REASON,
+        });
+        continue;
+      }
+
+      const validationError = validation.error;
+      const fn = toolCall;
+      if (fn.name === "edit") {
+        handler.autofixingDiff(null);
+        const path = fn.parsed.filePath;
+        const file = await fs.readFile(path, "utf8");
+        const fix = await autofixEdit(config, file, fn.parsed, abortSignal);
+
+        // If we aborted the autofix, slice off the messed up tool call and replace it with a failed
+        // tool call
+        if (abortSignal.aborted) {
+          return finishWith({ type: "abort" }, [
+            ...irs.slice(0, -1),
+            {
+              role: "tool-validation-error",
+              toolCall: toolCall,
+              error: validationError,
+              aborted: true,
+            },
+          ]);
+        }
+
+        if (fix) {
+          // Validate that the edit applies before marking as fixed
+          const fixed = {
+            ...fn.parsed,
+            ...fix,
+          } as const;
+
+          const fixedValidation = await validateTool(
+            abortSignal,
+            transport,
+            tools,
+            { ...fn, parsed: fixed },
+            config,
+          );
+          if (fixedValidation.success) {
+            // If we got this far, it's valid: update the state and keep going
+            fn.parsed = {
+              ...fn.parsed,
+              ...fix,
+            };
+
+            // Push a tool skip proactively
+            retryIrs.push({
+              role: "tool-skip-output",
+              toolCall: toolCall,
+              reason: SKIP_INVALID_REASON,
+            });
+
+            continue;
+          }
+        }
+      }
+
+      retryIrs = [
+        ...retryIrs,
         {
-          role: "assistant",
-          content: buffer.content || "",
-          reasoningContent: buffer.reasoning,
-          usage: compilerUsage(0, 0),
+          role: "tool-validation-error" as const,
+          toolCall: toolCall,
+          error: validationError,
+          aborted: false,
         },
       ];
     }
-    return [];
-  }
 
-  const headers = result.success
-    ? result.data.headers
-    : "headers" in result.error
-      ? result.error.headers
-      : undefined;
-  const quota = parseQuotaFromHeaders(headers);
-  if (quota) handler.onQuotaUpdated(quota);
-
-  if (abortSignal.aborted) return abort(maybeBufferedMessage());
-
-  if (!result.success) {
-    return {
-      type: "finish",
-      irs: maybeBufferedMessage(),
-      reason: compilerErrorToFinishReason(result.error),
-    };
-  }
-
-  let assistantMessage = result.data.output;
-  irs = [...irs, assistantMessage];
-
-  // Retry malformed tool calls
-  let malformedRequests = false;
-  for (const call of assistantMessage.toolCalls || []) {
-    if (call.type === "malformed-tool-request") {
-      malformedRequests = true;
-      break;
-    }
-  }
-
-  if (malformedRequests) {
-    // Insert tool skips for all of the non-malformed tool call IRs, and ensure the original order
-    // is kept in terms of input ordering vs output message ordering
-    for (const call of assistantMessage.toolCalls || []) {
-      if (call.type === "tool-call") {
-        irs.push({
-          role: "tool-skip-output",
-          toolCall: call,
-          reason: "Another tool call in this batch was malformed, so this tool call was skipped",
-        });
-      } else {
-        const _: "malformed-tool-request" = call.type;
-        irs.push({
-          role: "tool-parse-error",
-          malformedRequest: call,
-        });
+    // If you have any IRs that need to be retried, retry them
+    let needsRetry = false;
+    for (const ir of retryIrs) {
+      if (ir.role !== "tool-skip-output") {
+        needsRetry = true;
+        break;
       }
     }
+    if (needsRetry) {
+      const fullRetryTrajectory = [...irs, ...retryIrs];
+      emitIrs(fullRetryTrajectory);
+      const retried = await trajectoryArc.run({
+        modelData,
+        config,
+        transport,
+        abortSignal,
+        messages: messagesCopy.concat(fullRetryTrajectory),
+        handler,
+      });
+      return finishWith(retried.reason);
+    }
 
-    handler.retryTool({ irs });
-    const retried = await trajectoryArc({
-      modelData,
-      config,
-      transport,
-      abortSignal,
-      messages: messagesCopy.concat(irs),
-      handler,
-    });
-
-    return {
-      type: "finish",
-      irs: [...irs, ...retried.irs],
-      reason: retried.reason,
-    };
-  }
-
-  const { toolCalls } = assistantMessage;
-
-  if (toolCalls == null) {
-    return {
-      type: "finish",
-      reason: {
-        type: "needs-response",
+    // Got this far? Everything validated. Return the tool calls
+    return finishWith(
+      {
+        type: "request-tool",
+        toolCalls: wellformedToolCalls,
       },
       irs,
-    };
-  }
-
-  let retryIrs: TrajectoryOutputIR[] = [];
-  const wellformedToolCalls: Array<ToolCallRequest> = [];
-  for (const toolCall of toolCalls) {
-    if (toolCall.type === "malformed-tool-request") {
-      throw new Error(
-        "Impossible tool ordering: encountered a malformed tool with no malformed response",
-      );
-    }
-    wellformedToolCalls.push(toolCall);
-  }
-
-  // TODO: use Promise.all to do this in parallel
-  // Requires changing the signature somewhat; currently we expect that the handlers are called
-  // sequentially (i.e. we only autofix one tool at a time), but this would imply we could call the
-  // handlers multiple times within a single validation step
-  for (const toolCall of wellformedToolCalls) {
-    const validation = await validateTool(abortSignal, transport, tools, toolCall, config);
-
-    if (validation.success) {
-      // If we got this far, the tool validated successfully. Proactively push a tool-skip-output IR for
-      // it, in case other tool calls fail to validate (since all tool calls will be skipped if any
-      // are invalid).
-      retryIrs.push({
-        role: "tool-skip-output",
-        toolCall: toolCall,
-        reason: SKIP_INVALID_REASON,
-      });
-      continue;
-    }
-
-    const validationError = validation.error;
-    const fn = toolCall;
-    if (fn.name === "edit") {
-      handler.autofixingDiff(null);
-      const path = fn.parsed.filePath;
-      const file = await fs.readFile(path, "utf8");
-      const fix = await autofixEdit(config, file, fn.parsed, abortSignal);
-
-      // If we aborted the autofix, slice off the messed up tool call and replace it with a failed
-      // tool call
-      if (abortSignal.aborted) {
-        return abort([
-          ...irs.slice(0, -1),
-          {
-            role: "tool-validation-error",
-            toolCall: toolCall,
-            error: validationError,
-            aborted: true,
-          },
-        ]);
-      }
-
-      if (fix) {
-        // Validate that the edit applies before marking as fixed
-        const fixed = {
-          ...fn.parsed,
-          ...fix,
-        } as const;
-
-        const fixedValidation = await validateTool(
-          abortSignal,
-          transport,
-          tools,
-          { ...fn, parsed: fixed },
-          config,
-        );
-        if (fixedValidation.success) {
-          // If we got this far, it's valid: update the state and keep going
-          fn.parsed = {
-            ...fn.parsed,
-            ...fix,
-          };
-
-          // Push a tool skip proactively
-          retryIrs.push({
-            role: "tool-skip-output",
-            toolCall: toolCall,
-            reason: SKIP_INVALID_REASON,
-          });
-
-          continue;
-        }
-      }
-    }
-
-    retryIrs = [
-      ...retryIrs,
-      {
-        role: "tool-validation-error" as const,
-        toolCall: toolCall,
-        error: validationError,
-        aborted: false,
-      },
-    ];
-  }
-
-  // If you have any IRs that need to be retried, retry them
-  let needsRetry = false;
-  for (const ir of retryIrs) {
-    if (ir.role !== "tool-skip-output") {
-      needsRetry = true;
-      break;
-    }
-  }
-  if (needsRetry) {
-    const fullRetryTrajectory = [...irs, ...retryIrs];
-    handler.retryTool({ irs: fullRetryTrajectory });
-    const retried = await trajectoryArc({
-      modelData,
-      config,
-      transport,
-      abortSignal,
-      messages: messagesCopy.concat(fullRetryTrajectory),
-      handler,
-    });
-    return {
-      type: "finish",
-      irs: [...fullRetryTrajectory, ...retried.irs],
-      reason: retried.reason,
-    };
-  }
-
-  // Got this far? Everything validated. Return the tool calls
-  return {
-    type: "finish",
-    reason: {
-      type: "request-tool",
-      toolCalls: wellformedToolCalls,
-    },
-    irs,
-  };
-}
+    );
+  },
+});
 
 function parseQuotaFromHeaders(headers: Headers | undefined): QuotaData | undefined {
   const raw = headers?.get("x-synthetic-quotas");
@@ -535,12 +513,4 @@ async function maybeAutocompact({
       content: checkpointContent.data,
     },
   });
-}
-
-function abort(irs: TrajectoryOutputIR[]): Finish {
-  return {
-    type: "finish",
-    reason: { type: "abort" },
-    irs,
-  };
 }

--- a/source/ir/convert-history-ir.ts
+++ b/source/ir/convert-history-ir.ts
@@ -1,13 +1,5 @@
 import type { OctoIR } from "./octo-ir.ts";
-import type { TrajectoryOutputIR } from "../agent/trajectory-arc.ts";
 import type { HistoryItem } from "../session-history/index.ts";
-
-export function outputToHistory(output: TrajectoryOutputIR[]): HistoryItem[] {
-  return output.map(ir => ({
-    type: "llm-ir",
-    ir,
-  }));
-}
 
 export function toLlmIR(history: HistoryItem[]): OctoIR[] {
   const irs: OctoIR[] = [];

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -3,16 +3,29 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { withMock } from "antipattern";
 import { useAppStore, nextToolAction } from "./state.ts";
 import type { Config } from "./config.ts";
+import { db } from "./db/db.ts";
 import type { HistoryNode } from "./session-history/index.ts";
 import { createSession, insertHistoryItems } from "./session-history/index.ts";
 import { serializeModelJson } from "./session-history/model-json.ts";
+import {
+  historyItems,
+  llmIrs,
+  treeNodes,
+  trees,
+} from "./session-history/schema/session-history-schema.ts";
 import { compilerUsage } from "./libocto/compilers/compiler-interface.ts";
 import { answeredToolCallId } from "./libocto/llm-ir.ts";
 import type { ToolCall } from "./libocto/tool-def.ts";
+import { trajectoryArc } from "./agent/trajectory-arc.ts";
 import type toolMap from "./tools/tool-defs/index.ts";
 import { LocalTransport } from "./transports/local.ts";
+
+type TrajectoryArcArgs = Parameters<typeof trajectoryArc.run>[0];
+type TrajectoryArcFinish = Awaited<ReturnType<typeof trajectoryArc.run>>;
 
 /*
  * Regression tests for BUGS.md #2: aborting a multi-tool batch must not leave dangling tool
@@ -705,5 +718,201 @@ describe("edit and retry", () => {
     expect(state.query).toBe("original prompt");
     // The compaction-failed marker and the last user prompt are both rewound past.
     expect(state.history).toHaveLength(0);
+  });
+});
+
+function dbNodeCount(sessionId: string): number {
+  return db()
+    .select({ id: treeNodes.id })
+    .from(treeNodes)
+    .innerJoin(trees, eq(trees.id, treeNodes.treeId))
+    .where(eq(trees.name, sessionId))
+    .all().length;
+}
+
+function dbLlmIrCount(sessionId: string, marker: string): number {
+  return db()
+    .select({ json: llmIrs.json })
+    .from(llmIrs)
+    .innerJoin(historyItems, eq(historyItems.llmIrId, llmIrs.id))
+    .innerJoin(treeNodes, eq(treeNodes.historyItemId, historyItems.id))
+    .innerJoin(trees, eq(trees.id, treeNodes.treeId))
+    .where(eq(trees.name, sessionId))
+    .all()
+    .filter(row => row.json.includes(marker)).length;
+}
+
+function historyRoles(): string[] {
+  return useAppStore
+    .getState()
+    .history.map(node => (node.type === "llm-ir" ? node.ir.role : node.type));
+}
+
+describe("runAgent history persistence (BUGS.md #8, #12)", () => {
+  const agentConfig: Config = {
+    yourName: "Test",
+    models: [
+      {
+        nickname: "test-model",
+        model: "test-model",
+        context: 128_000,
+        baseUrl: "http://localhost",
+        apiEnvVar: "OCTO_STATE_TEST_API_KEY",
+      },
+    ],
+  };
+
+  const checkpointIr = {
+    role: "checkpoint" as const,
+    content: [{ type: "text" as const, content: "bug8-checkpoint-marker" }],
+  };
+  const assistantIr = {
+    role: "assistant" as const,
+    content: "bug8-assistant-marker",
+    usage: compilerUsage(0, 0),
+  };
+
+  beforeEach(() => {
+    process.env["OCTO_STATE_TEST_API_KEY"] = "test-key";
+  });
+
+  it("persists a compaction checkpoint exactly once", async () => {
+    const transport = new LocalTransport();
+    const session = createSession(process.cwd(), { kind: "local" });
+    const fakeArc = async ({ handler }: TrajectoryArcArgs): Promise<TrajectoryArcFinish> => {
+      handler.onMessage(checkpointIr);
+      handler.onMessage(assistantIr);
+      return { type: "finish", reason: { type: "needs-response" } };
+    };
+
+    await withMock(trajectoryArc, "run", fakeArc, async () => {
+      await useAppStore.getState().input({ config: agentConfig, transport, session, query: "hi" });
+    });
+
+    expect(historyRoles()).toEqual(["user", "checkpoint", "assistant"]);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-checkpoint-marker")).toBe(1);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-assistant-marker")).toBe(1);
+    expect(dbNodeCount(session.metadata.sessionId!)).toBe(3);
+  });
+
+  it("persists retried-arc IRs exactly once", async () => {
+    const transport = new LocalTransport();
+    const session = createSession(process.cwd(), { kind: "local" });
+
+    const retriedAssistant = {
+      role: "assistant" as const,
+      content: "bug8-retry-assistant-marker",
+      usage: compilerUsage(0, 0),
+    };
+    const parseError = {
+      role: "tool-parse-error" as const,
+      malformedRequest: {
+        type: "malformed-tool-request" as const,
+        error: "bad json",
+        call: { original: { name: "shell", arguments: "{oops" } },
+        toolCallId: "call_bad",
+      },
+    };
+    const finalAssistant = {
+      role: "assistant" as const,
+      content: "bug8-retry-final-marker",
+      usage: compilerUsage(0, 0),
+    };
+    const fakeArc = async ({ handler }: TrajectoryArcArgs): Promise<TrajectoryArcFinish> => {
+      handler.onMessage(retriedAssistant);
+      handler.onMessage(parseError);
+      handler.onMessage(finalAssistant);
+      return { type: "finish", reason: { type: "needs-response" } };
+    };
+
+    await withMock(trajectoryArc, "run", fakeArc, async () => {
+      await useAppStore.getState().input({ config: agentConfig, transport, session, query: "hi" });
+    });
+
+    expect(historyRoles()).toEqual(["user", "assistant", "tool-parse-error", "assistant"]);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-retry-assistant-marker")).toBe(1);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "call_bad")).toBe(1);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-retry-final-marker")).toBe(1);
+    expect(dbNodeCount(session.metadata.sessionId!)).toBe(4);
+  });
+
+  it("persists each IR exactly once when compaction and retry happen in the same run", async () => {
+    const transport = new LocalTransport();
+    const session = createSession(process.cwd(), { kind: "local" });
+
+    const retriedAssistant = {
+      role: "assistant" as const,
+      content: "bug8-mixed-retry-marker",
+      usage: compilerUsage(0, 0),
+    };
+    const parseError = {
+      role: "tool-parse-error" as const,
+      malformedRequest: {
+        type: "malformed-tool-request" as const,
+        error: "bad json",
+        call: { original: { name: "shell", arguments: "{oops" } },
+        toolCallId: "call_mixed",
+      },
+    };
+    const fakeArc = async ({ handler }: TrajectoryArcArgs): Promise<TrajectoryArcFinish> => {
+      handler.onMessage(checkpointIr);
+      handler.onMessage(retriedAssistant);
+      handler.onMessage(parseError);
+      handler.onMessage(assistantIr);
+      return { type: "finish", reason: { type: "needs-response" } };
+    };
+
+    await withMock(trajectoryArc, "run", fakeArc, async () => {
+      await useAppStore.getState().input({ config: agentConfig, transport, session, query: "hi" });
+    });
+
+    expect(historyRoles()).toEqual([
+      "user",
+      "checkpoint",
+      "assistant",
+      "tool-parse-error",
+      "assistant",
+    ]);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-checkpoint-marker")).toBe(1);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-mixed-retry-marker")).toBe(1);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "call_mixed")).toBe(1);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-assistant-marker")).toBe(1);
+    expect(dbNodeCount(session.metadata.sessionId!)).toBe(5);
+  });
+
+  it("keeps notifications appended mid-run on the same branch", async () => {
+    const transport = new LocalTransport();
+    const session = createSession(process.cwd(), { kind: "local" });
+    const fakeArc = async ({ handler }: TrajectoryArcArgs): Promise<TrajectoryArcFinish> => {
+      handler.onMessage(checkpointIr);
+      useAppStore.getState().notify("bug8-notify-marker", session);
+      handler.onMessage(assistantIr);
+      return { type: "finish", reason: { type: "needs-response" } };
+    };
+
+    await withMock(trajectoryArc, "run", fakeArc, async () => {
+      await useAppStore.getState().input({ config: agentConfig, transport, session, query: "hi" });
+    });
+
+    expect(historyRoles()).toEqual(["user", "checkpoint", "notification", "assistant"]);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-checkpoint-marker")).toBe(1);
+    expect(dbNodeCount(session.metadata.sessionId!)).toBe(4);
+  });
+
+  it("keeps the compaction checkpoint when the run aborts before any tokens stream", async () => {
+    const transport = new LocalTransport();
+    const session = createSession(process.cwd(), { kind: "local" });
+    const fakeArc = async ({ handler }: TrajectoryArcArgs): Promise<TrajectoryArcFinish> => {
+      handler.onMessage(checkpointIr);
+      return { type: "finish", reason: { type: "abort" } };
+    };
+
+    await withMock(trajectoryArc, "run", fakeArc, async () => {
+      await useAppStore.getState().input({ config: agentConfig, transport, session, query: "hi" });
+    });
+
+    expect(historyRoles()).toEqual(["user", "checkpoint"]);
+    expect(dbLlmIrCount(session.metadata.sessionId!, "bug8-checkpoint-marker")).toBe(1);
+    expect(dbNodeCount(session.metadata.sessionId!)).toBe(2);
   });
 });

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -885,7 +885,7 @@ describe("runAgent history persistence (BUGS.md #8, #12)", () => {
     const session = createSession(process.cwd(), { kind: "local" });
     const fakeArc = async ({ handler }: TrajectoryArcArgs): Promise<TrajectoryArcFinish> => {
       handler.onMessage(checkpointIr);
-      useAppStore.getState().notify("bug8-notify-marker", session);
+      useAppStore.getState().notify("bug8-notify-marker", session, agentConfig);
       handler.onMessage(assistantIr);
       return { type: "finish", reason: { type: "needs-response" } };
     };

--- a/source/state.ts
+++ b/source/state.ts
@@ -22,7 +22,7 @@ import { runTool } from "./tools/index.ts";
 import type { ToolRunResult } from "./tools/index.ts";
 import { create } from "zustand";
 import { useShallow } from "zustand/shallow";
-import { toLlmIR, outputToHistory } from "./ir/convert-history-ir.ts";
+import { toLlmIR } from "./ir/convert-history-ir.ts";
 import { Transport } from "./transports/transport-common.ts";
 import { trajectoryArc } from "./agent/trajectory-arc.ts";
 import type { ModelData } from "./compilers/run.ts";
@@ -794,7 +794,7 @@ export const useAppStore = create<UiState>((set, get) => ({
     const throttle = throttledBuffer<Partial<Parameters<typeof set>[0]>>(300, set);
 
     try {
-      const finish = await trajectoryArc({
+      const finish = await trajectoryArc.run({
         modelData,
         messages: toLlmIR(historyCopy),
         config,
@@ -863,17 +863,6 @@ export const useAppStore = create<UiState>((set, get) => ({
             });
           },
 
-          compactionParsed: event => {
-            throttle.flush();
-            const checkpointItem: HistoryItem = {
-              type: "llm-ir",
-              ir: event.checkpoint,
-            };
-            set({
-              history: appendAndPersistHistory(session, historyCopy, [checkpointItem], model),
-            });
-          },
-
           autofixingJson: () => {
             throttle.flush();
             set({
@@ -896,13 +885,13 @@ export const useAppStore = create<UiState>((set, get) => ({
 
           onQuotaUpdated: quota => set({ quotaData: quota }),
 
-          retryTool: event => {
+          onMessage: ir => {
             throttle.flush();
             set({
               history: appendAndPersistHistory(
                 session,
-                historyCopy,
-                outputToHistory(event.irs),
+                get().history,
+                [{ type: "llm-ir", ir }],
                 model,
               ),
             });
@@ -910,9 +899,6 @@ export const useAppStore = create<UiState>((set, get) => ({
         },
       });
       throttle.flush();
-      set({
-        history: appendAndPersistHistory(session, historyCopy, outputToHistory(finish.irs), model),
-      });
       const finishReason = finish.reason;
       if (finishReason.type === "abort") {
         get().notifyReadyForInput(config);


### PR DESCRIPTION
Previously, we had two bugs:

1. When appending history, we actually wrote quite a bit more into the DB than we expected. Since both `retryTool` and `compactionParsed` called `appendAndPersistHistory`, and then we called `appendAndPersistHistory` again on the returned IRs, we wrote some IRs to the DB twice! Thanks to our branch-handling code, this was actually fine; the earlier writes would be considered abandoned branches and we'd ignore them. But, still mildly annoying to be bloating disk space.
2. Sending an abort immediately after a compaction would drop the compaction IR, since we called `abort([])` instead of passing along the compaction IR.

This PR fixes both bugs, by redesigning `trajectoryArc` to be a bit easier to hold. Instead of returning the IRs at the end while also having some IR-specific handlers that run midway through (which you then need to track and not serialize at the end...), we strip it all out in favor of an `onMessage` handlers that runs for all IRs, and we no longer return the IRs at the end: if you want them, you need to use the `onMessage` handler.