### PR TITLE
Fix orphaned tool output

### DIFF
--- a/source/agent/trajectory-arc.ts
+++ b/source/agent/trajectory-arc.ts
@@ -344,11 +344,14 @@ export const trajectoryArc = registry({
         const file = await fs.readFile(path, "utf8");
         const fix = await autofixEdit(config, file, fn.parsed, abortSignal);
 
-        // If we aborted the autofix, slice off the messed up tool call and replace it with a failed
-        // tool call
+        // If we aborted the autofix, end the turn with a failed tool call. The assistant message
+        // must stay in history: the tool-validation-error answers one of its tool calls, and
+        // emitting the answer without the call orphans the tool message — strict backends reject
+        // requests where a tool message's tool_call_id doesn't resolve to a preceding assistant
+        // tool_call, and any session containing this history 400s on every resumed request.
         if (abortSignal.aborted) {
           return finishWith({ type: "abort" }, [
-            ...irs.slice(0, -1),
+            ...irs,
             {
               role: "tool-validation-error",
               toolCall: toolCall,

--- a/source/libocto/compilers/standard.test.ts
+++ b/source/libocto/compilers/standard.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ChatCompletionAssistantMessageParam,
+  ChatCompletionToolMessageParam,
+} from "openai/resources/chat/completions";
+import { octoAgent } from "../../ir/octo-ir.ts";
+import { compilerUsage } from "./compiler-interface.ts";
+import { toLlmMessages } from "./standard.ts";
+import type { LoweredIR, MalformedToolRequest } from "../llm-ir.ts";
+import type { ToolCall } from "../tool-def.ts";
+import type toolMap from "../../tools/tool-defs/index.ts";
+
+type Ir = LoweredIR<typeof toolMap>;
+type ShellToolCall = Extract<ToolCall<typeof toolMap>, { name: "shell" }>;
+
+function shellCall(id: string): ShellToolCall {
+  return {
+    type: "tool-call",
+    name: "shell",
+    toolCallId: id,
+    original: { cmd: "ls", timeout: 60_000 },
+    parsed: { cmd: "ls", timeout: 60_000 },
+  };
+}
+
+function malformedShellRequest(): MalformedToolRequest {
+  return {
+    type: "malformed-tool-request",
+    toolCallId: "call_malformed",
+    error: "Syntax error: invalid JSON in tool call arguments",
+    call: {
+      original: {
+        name: "shell",
+        // Unterminated JSON, as streamed from the model before JSON parsing failed
+        arguments: '{"cmd": "ls",',
+      },
+    },
+  };
+}
+
+describe("toLlmMessages malformed tool requests", () => {
+  /*
+   * Regression tests for Kimi K3 400s:
+   *   "Error from inference backend: 400 Kimi K3 tool messages need a resolvable tool
+   *    name: carry `tool`/`name`, or match a preceding assistant tool_call by order."
+   *
+   * A malformed tool call produces an assistant IR carrying a malformed-tool-request plus a
+   * tool-parse-error IR answering the same call ID. The malformed call's arguments may be
+   * unparseable (e.g. a connection died mid-stream, leaving half a JSON string), so it must NOT
+   * be re-emitted as an assistant tool_call — and since it isn't, its tool-parse-error must NOT
+   * be emitted as a tool message either: backends hard-reject tool messages whose tool_call_id
+   * doesn't match a preceding assistant tool_call. The parse failure is delivered as a user
+   * message instead.
+   */
+  it("drops malformed tool requests from tool_calls and delivers the parse error as a user message", async () => {
+    const malformed = malformedShellRequest();
+    const irs: Ir[] = [
+      { role: "user", content: [{ type: "text", content: "run ls" }] },
+      {
+        role: "assistant",
+        content: "",
+        usage: compilerUsage(0, 0),
+        toolCalls: [malformed],
+      },
+      { role: "tool-parse-error", malformedRequest: malformed },
+    ];
+
+    const messages = await toLlmMessages<typeof octoAgent>(irs);
+    expect(messages.map(m => m.role)).toEqual(["user", "assistant", "user"]);
+
+    const assistant = messages[1] as ChatCompletionAssistantMessageParam;
+    expect(assistant.tool_calls == null || assistant.tool_calls.length === 0).toBe(true);
+
+    // No tool message may reference the malformed call...
+    expect(messages.filter(m => m.role === "tool")).toEqual([]);
+
+    // ...and the parse failure reaches the model as a user message.
+    const errorMessage = messages[2];
+    expect(errorMessage.role).toBe("user");
+    const text = JSON.stringify(errorMessage.content);
+    expect(text).toContain("Syntax error: invalid JSON in tool call arguments");
+  });
+
+  it("handles mixed valid and malformed calls in one assistant turn", async () => {
+    const malformed = malformedShellRequest();
+    const valid = shellCall("call_valid");
+    const irs: Ir[] = [
+      { role: "user", content: [{ type: "text", content: "run ls" }] },
+      {
+        role: "assistant",
+        content: "",
+        usage: compilerUsage(0, 0),
+        toolCalls: [valid, malformed],
+      },
+      {
+        role: "tool-output",
+        toolCall: valid,
+        content: [{ type: "text", content: "file.txt" }],
+      },
+      { role: "tool-parse-error", malformedRequest: malformed },
+    ];
+
+    const messages = await toLlmMessages<typeof octoAgent>(irs);
+
+    const assistant = messages.find(m => m.role === "assistant") as
+      | ChatCompletionAssistantMessageParam
+      | undefined;
+    expect(assistant).toBeDefined();
+    // The valid call is kept; the malformed one is not re-emitted.
+    expect(assistant!.tool_calls).toEqual([
+      {
+        type: "function",
+        id: "call_valid",
+        function: {
+          name: "shell",
+          arguments: JSON.stringify(valid.original),
+        },
+      },
+    ]);
+
+    // Every tool message resolves to a preceding assistant tool_call.
+    const precedingCallIds: string[] = [];
+    for (const message of messages) {
+      if (message.role === "assistant") {
+        for (const toolCall of (message as ChatCompletionAssistantMessageParam).tool_calls ?? []) {
+          precedingCallIds.push(toolCall.id);
+        }
+      }
+      if (message.role === "tool") {
+        const toolCallId = (message as ChatCompletionToolMessageParam).tool_call_id;
+        expect(
+          precedingCallIds,
+          `tool message with tool_call_id ${JSON.stringify(toolCallId)} has no matching preceding assistant tool_call`,
+        ).toContain(toolCallId);
+      }
+    }
+    expect(precedingCallIds).toContain("call_valid");
+    expect(precedingCallIds).not.toContain("call_malformed");
+
+    // The malformed call's failure reaches the model as a user message.
+    const errorMessage = messages.filter(m => m.role === "user").at(-1);
+    expect(JSON.stringify(errorMessage?.content)).toContain("Syntax error");
+  });
+});

--- a/source/libocto/compilers/standard.ts
+++ b/source/libocto/compilers/standard.ts
@@ -137,7 +137,7 @@ ${JSON.stringify(requestBody)}
 JSON`;
 }
 
-async function toLlmMessages<A extends Agent<any, any, any>>(
+export async function toLlmMessages<A extends Agent<any, any, any>>(
   messages: Array<CompilerIR<A>>,
   systemPrompt?: () => Promise<string>,
   modalities?: CompilerModalities,
@@ -168,7 +168,15 @@ function llmFromIr<A extends Agent<any, any, any>>(
     const reasoning: { reasoning_content?: string } = {};
     if (ir.reasoningContent) reasoning.reasoning_content = ir.reasoningContent;
 
-    if (toolCalls == null || toolCalls.length === 0) {
+    /*
+     * Malformed tool requests are dropped from tool_calls entirely: their arguments may be
+     * unparseable (e.g. a connection died mid-stream, leaving half a JSON string), and
+     * backends that validate historical tool call arguments would reject the request. The
+     * failure is re-delivered as a user message by the tool-parse-error branch below, so the
+     * model still learns its call malformed and can recover.
+     */
+    const validToolCalls = (toolCalls ?? []).filter((t: any) => t.type === "tool-call");
+    if (validToolCalls.length === 0) {
       return {
         ...reasoning,
         role: "assistant",
@@ -179,18 +187,16 @@ function llmFromIr<A extends Agent<any, any, any>>(
       ...reasoning,
       role: "assistant",
       content: ir.content,
-      tool_calls: toolCalls
-        .filter((t: any) => t.type === "tool-call")
-        .map((tc: any) => {
-          return {
-            type: "function" as const,
-            function: {
-              name: tc.name,
-              arguments: tc.original ? JSON.stringify(tc.original) : "{}",
-            },
-            id: tc.toolCallId,
-          };
-        }),
+      tool_calls: validToolCalls.map((tc: any) => {
+        return {
+          type: "function" as const,
+          function: {
+            name: tc.name,
+            arguments: tc.original ? JSON.stringify(tc.original) : "{}",
+          },
+          id: tc.toolCallId,
+        };
+      }),
     };
   }
   if (ir.role === "user") {
@@ -213,10 +219,16 @@ function llmFromIr<A extends Agent<any, any, any>>(
     };
   }
 
+  /*
+   * A tool-parse-error's malformed call is not re-emitted as an assistant tool_call (see the
+   * assistant branch above), so there is nothing for a tool message's tool_call_id to resolve
+   * to — and strict backends hard-reject tool messages without a matching preceding tool_call.
+   * Deliver the failure as a plain user message instead; a user message is always legal, and
+   * the model can see its call malformed and recover.
+   */
   if (ir.role === "tool-parse-error") {
     return {
-      role: "tool",
-      tool_call_id: ir.malformedRequest.toolCallId,
+      role: "user",
       content: [
         {
           type: "text",

--- a/source/session-history/tool-pairing.ts
+++ b/source/session-history/tool-pairing.ts
@@ -1,0 +1,223 @@
+import { answeredToolCallId } from "../libocto/llm-ir.ts";
+import type { OctoIR } from "../ir/octo-ir.ts";
+import type { HistoryNode } from "./index.ts";
+
+/*
+ * Tool call/output pairing assertions for hydrated session histories.
+ *
+ * Strict backends (e.g. Kimi K3) reject any request where a tool message's tool_call_id doesn't
+ * resolve to a preceding assistant tool_call. We already found one way Octo produced such
+ * requests (malformed tool requests dropped from assistant tool_calls while their tool messages
+ * were still emitted), but there may be others hiding in long-lived sessions. These checks run
+ * on session hydration and throw with a detailed violation report, so broken histories are
+ * caught at load time rather than surfacing as an opaque 400 deep into a resume.
+ */
+
+type AssistantCallEntry = {
+  id: string;
+  callType: "tool-call" | "malformed-tool-request";
+  // Index into the hydrated history array of the assistant IR carrying this call.
+  index: number;
+};
+
+export type PairingViolation = {
+  // Index into the hydrated history array of the offending IR.
+  index: number;
+  role: string;
+  callId: string;
+  problem: string;
+};
+
+export function findToolPairingViolations(history: readonly HistoryNode[]): PairingViolation[] {
+  const violations: PairingViolation[] = [];
+
+  const allCalls: AssistantCallEntry[] = [];
+  let lastCheckpointIndex = -1;
+  for (let i = 0; i < history.length; i++) {
+    const item = history[i];
+    if (item.type !== "llm-ir") continue;
+    if (item.ir.role === "checkpoint") lastCheckpointIndex = i;
+    if (item.ir.role === "assistant") {
+      for (const call of item.ir.toolCalls ?? []) {
+        allCalls.push({ id: call.toolCallId, callType: call.type, index: i });
+      }
+    }
+  }
+
+  for (let i = 0; i < history.length; i++) {
+    const item = history[i];
+    if (item.type !== "llm-ir") continue;
+    const ir = item.ir;
+    const callId = answeredToolCallId(ir as any);
+    if (callId == null) continue;
+
+    const violation = (problem: string) =>
+      violations.push({ index: i, role: ir.role, callId, problem });
+
+    const preceding = allCalls.filter(c => c.index < i && c.id === callId);
+    if (preceding.length === 0) {
+      const later = allCalls.filter(c => c.index > i && c.id === callId);
+      violation(
+        later.length > 0
+          ? `answers a tool_call that only appears later in history (assistant at index ` +
+              `${later.map(c => c.index).join(", ")}) — ordering violation`
+          : "orphan: no assistant tool_call with this ID anywhere in history",
+      );
+      continue;
+    }
+
+    // The matching call must be the right kind for the answer: parse errors answer malformed
+    // requests, everything else answers well-formed tool calls.
+    if (ir.role === "tool-parse-error") {
+      if (!preceding.some(c => c.callType === "malformed-tool-request")) {
+        violation("no malformed-tool-request with this ID in any preceding assistant message");
+      }
+    } else if (!preceding.some(c => c.callType === "tool-call")) {
+      violation("only malformed-tool-request entries with this ID in preceding assistant messages");
+    }
+
+    // lower() slices history at the most recent checkpoint: an output inside the tail whose only
+    // matching call is before the checkpoint compiles into an orphan tool message.
+    if (lastCheckpointIndex >= 0 && i > lastCheckpointIndex) {
+      if (!preceding.some(c => c.index > lastCheckpointIndex)) {
+        violation(
+          `answered only before the most recent checkpoint (index ${lastCheckpointIndex}); ` +
+            "checkpoint slicing orphans it at compile time",
+        );
+      }
+    }
+  }
+
+  return violations;
+}
+
+/*
+ * Repairs histories written by old versions of octo, which could drop the assistant message on
+ * abort (e.g. aborting mid-diff-autofix emitted a tool-validation-error answer but sliced away
+ * the assistant message carrying the tool call). The orphan answer would compile to a tool
+ * message whose tool_call_id resolves to nothing, which strict backends reject on every resumed
+ * request.
+ *
+ * Orphan answers are converted into user messages: a user message is always legal for any
+ * backend, keeps the information visible to the model, and synthesizes no assistant history.
+ * Only true orphans are repaired — answers whose tool call appears nowhere in history. Any
+ * remaining violation is an unknown bug and is left for assertToolCallPairing to report loudly.
+ */
+export function repairOrphanedToolOutputs(history: readonly HistoryNode[]): HistoryNode[] {
+  const requestedIds = new Set<string>();
+  for (const item of history) {
+    if (item.type !== "llm-ir" || item.ir.role !== "assistant") continue;
+    for (const call of item.ir.toolCalls ?? []) {
+      requestedIds.add(call.toolCallId);
+    }
+  }
+
+  return history.map(item => {
+    if (item.type !== "llm-ir") return item;
+    const callId = answeredToolCallId(item.ir as any);
+    if (callId == null || requestedIds.has(callId)) return item;
+    return { ...item, ir: orphanAnswerToUserMessage(item.ir) };
+  });
+}
+
+function orphanAnswerToUserMessage(ir: OctoIR): OctoIR {
+  const lostCallNote =
+    "Original note from octofriend: this message refers to a tool call whose assistant message " +
+    "was lost, e.g. because octofriend was aborted mid-turn in an older version. " +
+    "It is replayed here as a user message instead of a tool message.";
+
+  switch (ir.role) {
+    case "tool-output":
+      return {
+        role: "user",
+        content: [
+          { type: "text", content: lostCallNote },
+          { type: "text", content: `Output of the ${ir.toolCall.name} tool call:` },
+          ...ir.content,
+        ],
+      };
+    case "tool-skip-output":
+      return {
+        role: "user",
+        content: [
+          { type: "text", content: lostCallNote },
+          {
+            type: "text",
+            content: `The ${ir.toolCall.name} tool call was skipped and didn't run: ${ir.reason}`,
+          },
+        ],
+      };
+    case "tool-validation-error":
+      return {
+        role: "user",
+        content: [
+          { type: "text", content: lostCallNote },
+          {
+            type: "text",
+            content: `The ${ir.toolCall.name} tool call failed validation: ${ir.error}`,
+          },
+        ],
+      };
+    case "tool-runtime-error":
+      return {
+        role: "user",
+        content: [
+          { type: "text", content: lostCallNote },
+          { type: "text", content: `The ${ir.toolCall.name} tool call failed: ${ir.error}` },
+        ],
+      };
+    case "tool-parse-error":
+      return {
+        role: "user",
+        content: [
+          { type: "text", content: lostCallNote },
+          { type: "text", content: `Malformed tool call: ${ir.malformedRequest.error}` },
+        ],
+      };
+    case "tool-reject":
+      return {
+        role: "user",
+        content: [
+          { type: "text", content: lostCallNote },
+          { type: "text", content: `The ${ir.toolCall.name} tool call was rejected by the user.` },
+        ],
+      };
+    case "file-read":
+      return {
+        role: "user",
+        content: [
+          { type: "text", content: lostCallNote },
+          { type: "text", content: `Contents of ${ir.path}:\n${ir.content}` },
+        ],
+      };
+    case "file-mutate":
+      return {
+        role: "user",
+        content: [
+          { type: "text", content: lostCallNote },
+          { type: "text", content: `The file ${ir.path} was modified.` },
+        ],
+      };
+    default:
+      return {
+        role: "user",
+        content: [{ type: "text", content: lostCallNote }],
+      };
+  }
+}
+
+export function assertToolCallPairing(history: readonly HistoryNode[]): void {
+  const violations = findToolPairingViolations(history);
+  if (violations.length === 0) return;
+  const details = violations
+    .slice(0, 10)
+    .map(
+      v =>
+        `  - [index ${v.index}] ${v.role} (tool_call_id ${JSON.stringify(v.callId)}): ${v.problem}`,
+    )
+    .join("\n");
+  const rest = violations.length > 10 ? `\n  ... and ${violations.length - 10} more` : "";
+  throw new Error(
+    `Session history contains ${violations.length} dangling tool output(s):\n${details}${rest}`,
+  );
+}

--- a/source/state.ts
+++ b/source/state.ts
@@ -17,6 +17,10 @@ import {
   Session,
 } from "./session-history/index.ts";
 import { serializeModelJson } from "./session-history/model-json.ts";
+import {
+  assertToolCallPairing,
+  repairOrphanedToolOutputs,
+} from "./session-history/tool-pairing.ts";
 import type { ParsedCliArgs } from "./cli/cli-args.ts";
 import { runTool } from "./tools/index.ts";
 import type { ToolRunResult } from "./tools/index.ts";
@@ -644,8 +648,12 @@ export const useAppStore = create<UiState>((set, get) => ({
   },
 
   hydrateSession: history => {
+    const repairedHistory = repairOrphanedToolOutputs(history);
+    // Canary builds fail loudly on any remaining pairing violation: after repair, any dangling
+    // tool output is an unknown bug we want to hear about rather than resume around.
+    if (process.env["CANARY_OCTO"] === "1") assertToolCallPairing(repairedHistory);
     set(state => ({
-      history,
+      history: repairedHistory,
       modelOverride: latestModelJson(history),
       lastUserPromptIndex: null,
       byteCount: 0,


### PR DESCRIPTION
This fixes the bug I reported in Slack the other day — it was possible to drop tool calls in two ways, which would break Kimi K3 since we wouldn't drop the resulting tool output (and Kimi always needs paired tool calls with tool output):

- We dropped mangled tool calls, since backends may not accept e.g. invalid JSON. To handle this pairing issue, we now send the response to the mangled tool calls as a `user` message in the standard compiler.
- If you aborted an autofix request, we accidentally dropped the assistant message that you aborted. To handle this we... don't do that :laughing: 

This PR also adds fix-on-hydrate code to automatically fix broken historical sessions that encountered this bug, since this would perma-break Kimi K3 sessions. To avoid silently covering up these kinds of errors in the future, in canary builds we loudly error on hydrate if there are any unpaired tool calls.