### PR TITLE
OctoProcessManager to spawn, manage, and kill child processes

### DIFF
--- a/source/browser-spawn.ts
+++ b/source/browser-spawn.ts
@@ -1,20 +1,22 @@
-import { spawn } from "child_process";
+import { OctoProcessManager } from "./octo-process.ts";
 
 export function spawnBrowser(url: string): Promise<boolean> {
   const command = browserOpenCommand(url);
   if (!command) return Promise.resolve(false);
 
   return new Promise(resolve => {
-    const child = spawn(command.command, command.args, {
+    const octoProcessManager = new OctoProcessManager();
+    const octoProcess = octoProcessManager.spawn(command.command, command.args, {
       detached: true,
       stdio: "ignore",
+      surviveAfterOctoExit: true, // browser shouldn't be tied to Octo's state
     });
 
-    child.once("spawn", () => {
-      child.unref();
+    octoProcess.childProcess.once("spawn", () => {
+      octoProcess.childProcess.unref();
       resolve(true);
     });
-    child.once("error", () => {
+    octoProcess.childProcess.once("error", () => {
       resolve(false);
     });
   });

--- a/source/browser-spawn.ts
+++ b/source/browser-spawn.ts
@@ -12,11 +12,11 @@ export function spawnBrowser(url: string): Promise<boolean> {
       surviveAfterOctoExit: true, // browser shouldn't be tied to Octo's state
     });
 
-    octoProcess.childProcess.once("spawn", () => {
-      octoProcess.childProcess.unref();
+    octoProcess.once("spawn", () => {
+      octoProcess.unref();
       resolve(true);
     });
-    octoProcess.childProcess.once("error", () => {
+    octoProcess.once("error", () => {
       resolve(false);
     });
   });

--- a/source/browser-spawn.ts
+++ b/source/browser-spawn.ts
@@ -1,12 +1,11 @@
-import { OctoProcessManager } from "./octo-process.ts";
+import { processes } from "./octo-process.ts";
 
 export function spawnBrowser(url: string): Promise<boolean> {
   const command = browserOpenCommand(url);
   if (!command) return Promise.resolve(false);
 
   return new Promise(resolve => {
-    const octoProcessManager = new OctoProcessManager();
-    const octoProcess = octoProcessManager.spawn(command.command, command.args, {
+    const octoProcess = processes.manager().spawn(command.command, command.args, {
       detached: true,
       stdio: "ignore",
       surviveAfterOctoExit: true, // browser shouldn't be tied to Octo's state

--- a/source/cli/cli.tsx
+++ b/source/cli/cli.tsx
@@ -44,7 +44,7 @@ import { render, type CreateRootOptions } from "paintcannon-react";
 import { ToastProvider } from "../components/toast.tsx";
 import { setOctoTitles } from "./titles.ts";
 import changelog from "../../CHANGELOG.md" with { type: "text" };
-import { installGlobalProcessSignalHandlers, registerCleanup } from "../octo-process.ts";
+import { processes } from "../octo-process.ts";
 
 const INTERACTIVE_RENDER_OPTIONS = {
   alternateScreen: true,
@@ -71,7 +71,7 @@ function renderInteractive(element: React.ReactNode, options: { captureCtrlC: bo
 const CONFIG_STANDARD_DIR = path.join(os.homedir(), ".config/octofriend/");
 const CONFIG_JSON5_FILE = path.join(CONFIG_STANDARD_DIR, "octofriend.json5");
 
-installGlobalProcessSignalHandlers();
+processes.manager().installGlobalProcessSignalHandlers();
 
 const cli = withOctoFlags(
   new Command().description("If run with no subcommands, runs Octo interactively."),
@@ -242,7 +242,7 @@ async function runMain(opts: {
     restoreTitles();
     await opts.transport.close();
   };
-  const markCleanupAsComplete = registerCleanup(cleanup);
+  const unregisterCleanup = processes.manager().registerCleanup(cleanup);
 
   try {
     let { config, configPath } = await loadConfig(opts.parsedCliArgs.config);
@@ -310,7 +310,7 @@ async function runMain(opts: {
       }
     }
   } finally {
-    markCleanupAsComplete();
+    unregisterCleanup();
     await cleanup();
   }
 }

--- a/source/cli/cli.tsx
+++ b/source/cli/cli.tsx
@@ -237,10 +237,13 @@ async function runMain(opts: {
   const cleanup = async () => {
     if (cleanedUp) return;
     cleanedUp = true;
-    await shutdownLspClients();
-    await shutdownMcpClients();
     restoreTitles();
-    await opts.transport.close();
+    await Promise.all([
+      shutdownLspClients(),
+      shutdownMcpClients(),
+      opts.transport.close(),
+      processes.manager().terminateAll(),
+    ]);
   };
   const unregisterCleanup = processes.manager().registerCleanup(cleanup);
 

--- a/source/cli/cli.tsx
+++ b/source/cli/cli.tsx
@@ -44,6 +44,7 @@ import { render, type CreateRootOptions } from "paintcannon-react";
 import { ToastProvider } from "../components/toast.tsx";
 import { setOctoTitles } from "./titles.ts";
 import changelog from "../../CHANGELOG.md" with { type: "text" };
+import { installGlobalProcessSignalHandlers, registerCleanup } from "../octo-process.ts";
 
 const INTERACTIVE_RENDER_OPTIONS = {
   alternateScreen: true,
@@ -69,6 +70,8 @@ function renderInteractive(element: React.ReactNode, options: { captureCtrlC: bo
 
 const CONFIG_STANDARD_DIR = path.join(os.homedir(), ".config/octofriend/");
 const CONFIG_JSON5_FILE = path.join(CONFIG_STANDARD_DIR, "octofriend.json5");
+
+installGlobalProcessSignalHandlers();
 
 const cli = withOctoFlags(
   new Command().description("If run with no subcommands, runs Octo interactively."),
@@ -230,6 +233,17 @@ async function runMain(opts: {
     session = useAppStore.getState().startNewSession(opts.transport.cwd, opts.parsedCliArgs);
   }
 
+  let cleanedUp = false;
+  const cleanup = async () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    await shutdownLspClients();
+    await shutdownMcpClients();
+    restoreTitles();
+    await opts.transport.close();
+  };
+  const markCleanupAsComplete = registerCleanup(cleanup);
+
   try {
     let { config, configPath } = await loadConfig(opts.parsedCliArgs.config);
 
@@ -296,10 +310,8 @@ async function runMain(opts: {
       }
     }
   } finally {
-    await shutdownLspClients();
-    await shutdownMcpClients();
-    restoreTitles();
-    await opts.transport.close();
+    markCleanupAsComplete();
+    await cleanup();
   }
 }
 

--- a/source/config.ts
+++ b/source/config.ts
@@ -221,7 +221,7 @@ export async function runNotifyCommand(config: Config): Promise<void> {
       env: process.env,
     });
 
-    octoProcess.childProcess.on("close", (code: number | null) => {
+    octoProcess.on("close", (code: number | null) => {
       if (code !== 0) {
         reject(new Error(`notifyFinishCommand exited with code ${code}`));
         return;
@@ -229,7 +229,7 @@ export async function runNotifyCommand(config: Config): Promise<void> {
       resolve();
     });
 
-    octoProcess.childProcess.on("error", reject);
+    octoProcess.on("error", reject);
   });
 }
 
@@ -345,13 +345,11 @@ export async function resolveAuth(auth: Auth): Promise<AuthResult> {
       },
     );
 
-    const childProcess = octoProcess.childProcess;
-
     // execFile should kill on timeout, but just to be safe
     setTimeout(() => {
       if (!resolved) {
         resolved = true;
-        childProcess.kill("SIGKILL");
+        octoProcess.kill("SIGKILL");
         resolve({
           ok: false,
           error: {

--- a/source/config.ts
+++ b/source/config.ts
@@ -4,7 +4,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import json5 from "json5";
-import { execFile, spawn } from "child_process";
+import { OctoProcessManager } from "./octo-process.ts";
 import { fileExists } from "./fs-utils.ts";
 import { providerForBaseUrl, keyFromName, ProviderConfig } from "./providers.ts";
 import { getCodexOAuthTokens } from "./codex-oauth.ts";
@@ -207,6 +207,7 @@ const AUTH_COMMAND_TIMEOUT_MS = 15_000;
 const AUTH_COMMAND_MAX_OUTPUT_BYTES = 16 * 1024;
 
 const NOTIFY_COMMAND_TIMEOUT_MS = 10_000;
+const octoProcessManager = new OctoProcessManager();
 
 export async function runNotifyCommand(config: Config): Promise<void> {
   const cmd = config.notifications?.notifyCommand;
@@ -214,13 +215,13 @@ export async function runNotifyCommand(config: Config): Promise<void> {
   const shell = process.env["SHELL"] || "/bin/sh";
 
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(shell, ["-c", cmd], {
+    const octoProcess = octoProcessManager.spawn(shell, ["-c", cmd], {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: NOTIFY_COMMAND_TIMEOUT_MS,
       env: process.env,
     });
 
-    child.on("close", (code: number | null) => {
+    octoProcess.childProcess.on("close", (code: number | null) => {
       if (code !== 0) {
         reject(new Error(`notifyFinishCommand exited with code ${code}`));
         return;
@@ -228,7 +229,7 @@ export async function runNotifyCommand(config: Config): Promise<void> {
       resolve();
     });
 
-    child.on("error", reject);
+    octoProcess.childProcess.on("error", reject);
   });
 }
 
@@ -301,7 +302,7 @@ export async function resolveAuth(auth: Auth): Promise<AuthResult> {
     let stderr = "";
     let resolved = false;
 
-    const child = execFile(
+    const octoProcess = octoProcessManager.execFile(
       cmd,
       args,
       {
@@ -344,11 +345,13 @@ export async function resolveAuth(auth: Auth): Promise<AuthResult> {
       },
     );
 
+    const childProcess = octoProcess.childProcess;
+
     // execFile should kill on timeout, but just to be safe
     setTimeout(() => {
       if (!resolved) {
         resolved = true;
-        child.kill("SIGKILL");
+        childProcess.kill("SIGKILL");
         resolve({
           ok: false,
           error: {

--- a/source/config.ts
+++ b/source/config.ts
@@ -4,7 +4,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import json5 from "json5";
-import { OctoProcessManager } from "./octo-process.ts";
+import { processes } from "./octo-process.ts";
 import { fileExists } from "./fs-utils.ts";
 import { providerForBaseUrl, keyFromName, ProviderConfig } from "./providers.ts";
 import { getCodexOAuthTokens } from "./codex-oauth.ts";
@@ -207,7 +207,6 @@ const AUTH_COMMAND_TIMEOUT_MS = 15_000;
 const AUTH_COMMAND_MAX_OUTPUT_BYTES = 16 * 1024;
 
 const NOTIFY_COMMAND_TIMEOUT_MS = 10_000;
-const octoProcessManager = new OctoProcessManager();
 
 export async function runNotifyCommand(config: Config): Promise<void> {
   const cmd = config.notifications?.notifyCommand;
@@ -215,7 +214,7 @@ export async function runNotifyCommand(config: Config): Promise<void> {
   const shell = process.env["SHELL"] || "/bin/sh";
 
   await new Promise<void>((resolve, reject) => {
-    const octoProcess = octoProcessManager.spawn(shell, ["-c", cmd], {
+    const octoProcess = processes.manager().spawn(shell, ["-c", cmd], {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: NOTIFY_COMMAND_TIMEOUT_MS,
       env: process.env,
@@ -302,7 +301,7 @@ export async function resolveAuth(auth: Auth): Promise<AuthResult> {
     let stderr = "";
     let resolved = false;
 
-    const octoProcess = octoProcessManager.execFile(
+    const octoProcess = processes.manager().execFile(
       cmd,
       args,
       {

--- a/source/lsp/client.ts
+++ b/source/lsp/client.ts
@@ -11,7 +11,7 @@ import type {
   Range,
 } from "vscode-languageserver-types";
 import { DiagnosticSeverity, SymbolKind } from "vscode-languageserver-types";
-import { type OctoProcess, OctoProcessManager } from "../octo-process.ts";
+import { type OctoProcess, processes } from "../octo-process.ts";
 
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#headerPart
 const HEADER_DELIMITER_STRING = "\r\n\r\n";
@@ -118,7 +118,7 @@ const CLIENT_CAPABILITIES = {
 };
 
 export class LspClient {
-  private readonly octoProcessManager = new OctoProcessManager();
+  private readonly octoProcessManager = processes.manager();
   private octoProcess: OctoProcess | null = null;
   private requestIdCounter = 1;
   private pendingRequests = new Map<number, PendingRequest>(); // indexed by requestId

--- a/source/lsp/client.ts
+++ b/source/lsp/client.ts
@@ -1,4 +1,3 @@
-import { spawn, type ChildProcess } from "child_process";
 import { type Writable } from "node:stream";
 import path from "path";
 import type {
@@ -12,6 +11,7 @@ import type {
   Range,
 } from "vscode-languageserver-types";
 import { DiagnosticSeverity, SymbolKind } from "vscode-languageserver-types";
+import { type OctoProcess, OctoProcessManager } from "../octo-process.ts";
 
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#headerPart
 const HEADER_DELIMITER_STRING = "\r\n\r\n";
@@ -118,7 +118,8 @@ const CLIENT_CAPABILITIES = {
 };
 
 export class LspClient {
-  private process: ChildProcess | null = null;
+  private readonly octoProcessManager = new OctoProcessManager();
+  private octoProcess: OctoProcess | null = null;
   private requestIdCounter = 1;
   private pendingRequests = new Map<number, PendingRequest>(); // indexed by requestId
   private buffer = Buffer.alloc(0);
@@ -136,16 +137,17 @@ export class LspClient {
     const [cmd, ...args] = this.serverConfig.command;
     if (!cmd) throw new Error(`LSP server "${this.serverConfig.serverName}" has empty command`);
 
-    this.process = spawn(cmd, args, {
+    this.octoProcess = this.octoProcessManager.spawn(cmd, args, {
       stdio: ["pipe", "pipe", "ignore"],
       env: process.env,
     });
+    const childProcess = this.octoProcess.childProcess;
 
-    const stdout = this.process.stdout;
+    const stdout = childProcess.stdout;
     if (!stdout) throw new Error(`LSP server "${this.serverConfig.serverName}" has no stdout`);
     stdout.on("data", (chunk: Buffer) => this.onData(chunk));
 
-    this.process.on("error", err => {
+    childProcess.on("error", err => {
       for (const [, req] of this.pendingRequests) {
         req.reject(
           new Error(`LSP server "${this.serverConfig.serverName}" crashed: ${err.message}`),
@@ -154,7 +156,7 @@ export class LspClient {
       this.pendingRequests.clear();
     });
 
-    this.process.on("exit", () => {
+    childProcess.on("exit", () => {
       for (const [, req] of this.pendingRequests) {
         req.reject(new Error(`LSP server "${this.serverConfig.serverName}" exited unexpectedly`));
       }
@@ -317,15 +319,17 @@ export class LspClient {
   }
 
   async shutdown(): Promise<void> {
-    if (!this.process || !this.initialized) return;
-    try {
-      await this.request("shutdown", null);
-      this.notify("exit", undefined);
-    } catch {
-      // if it errors, we'll just kill the process anyways
+    if (!this.octoProcess) return;
+    if (this.initialized) {
+      try {
+        await this.request("shutdown", null);
+        this.notify("exit", undefined);
+      } catch {
+        // if it errors, we'll just kill the process anyways
+      }
     }
-    this.process.kill();
-    this.process = null;
+    this.octoProcess.terminate();
+    this.octoProcess = null;
     this.initialized = false;
   }
 
@@ -335,7 +339,7 @@ export class LspClient {
     timeoutMs: number = REQUEST_TIMEOUT_MS,
   ): Promise<any> {
     return new Promise((resolve, reject) => {
-      const stdin = this.process?.stdin;
+      const stdin = this.octoProcess?.childProcess.stdin;
       if (!stdin?.writable) {
         reject(new Error(`LSP server "${this.serverConfig.serverName}" is not running`));
         return;
@@ -363,7 +367,7 @@ export class LspClient {
 
   // used for LSP methods `initialized`, `exit`, `textDocument/didOpen`, `textDocument/didChange`
   private notify(method: string, params: any): void {
-    const stdin = this.process?.stdin;
+    const stdin = this.octoProcess?.childProcess.stdin;
     if (!stdin?.writable) return;
     this.send(stdin, { jsonrpc: "2.0", method, params });
   }

--- a/source/lsp/client.ts
+++ b/source/lsp/client.ts
@@ -141,13 +141,13 @@ export class LspClient {
       stdio: ["pipe", "pipe", "ignore"],
       env: process.env,
     });
-    const childProcess = this.octoProcess.childProcess;
+    const octoProcess = this.octoProcess;
 
-    const stdout = childProcess.stdout;
+    const stdout = octoProcess.stdout;
     if (!stdout) throw new Error(`LSP server "${this.serverConfig.serverName}" has no stdout`);
     stdout.on("data", (chunk: Buffer) => this.onData(chunk));
 
-    childProcess.on("error", err => {
+    octoProcess.on("error", err => {
       for (const [, req] of this.pendingRequests) {
         req.reject(
           new Error(`LSP server "${this.serverConfig.serverName}" crashed: ${err.message}`),
@@ -156,7 +156,7 @@ export class LspClient {
       this.pendingRequests.clear();
     });
 
-    childProcess.on("exit", () => {
+    octoProcess.on("exit", () => {
       for (const [, req] of this.pendingRequests) {
         req.reject(new Error(`LSP server "${this.serverConfig.serverName}" exited unexpectedly`));
       }
@@ -339,7 +339,7 @@ export class LspClient {
     timeoutMs: number = REQUEST_TIMEOUT_MS,
   ): Promise<any> {
     return new Promise((resolve, reject) => {
-      const stdin = this.octoProcess?.childProcess.stdin;
+      const stdin = this.octoProcess?.stdin;
       if (!stdin?.writable) {
         reject(new Error(`LSP server "${this.serverConfig.serverName}" is not running`));
         return;
@@ -367,7 +367,7 @@ export class LspClient {
 
   // used for LSP methods `initialized`, `exit`, `textDocument/didOpen`, `textDocument/didChange`
   private notify(method: string, params: any): void {
-    const stdin = this.octoProcess?.childProcess.stdin;
+    const stdin = this.octoProcess?.stdin;
     if (!stdin?.writable) return;
     this.send(stdin, { jsonrpc: "2.0", method, params });
   }

--- a/source/octo-process.test.ts
+++ b/source/octo-process.test.ts
@@ -1,14 +1,11 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OctoProcess, OctoProcessManager } from "./octo-process.ts";
+import { afterEach, describe, expect, it, jest } from "bun:test";
+import { OctoProcessManager, type OctoProcess } from "./octo-process.ts";
 
 /**
- * The module under test keeps process-global state (the process registry, the
- * cleanup registry, once-only flags), so each test imports a fresh copy.
+ * Each OctoProcessManager owns its own state (tracked processes, registered
+ * cleanups, once-only flags), so tests construct their own instances and can't
+ * leak state into each other — there's no shared module-global state to reset.
  */
-async function freshLifecycle() {
-  vi.resetModules();
-  return await import("./octo-process.ts");
-}
 
 function spawnSleeper(
   octoProcesses: OctoProcessManager,
@@ -21,14 +18,13 @@ function spawnSleeper(
 }
 
 afterEach(() => {
-  vi.restoreAllMocks();
-  vi.useRealTimers();
+  jest.restoreAllMocks();
+  jest.useRealTimers();
 });
 
 describe("OctoProcessManager.spawn", () => {
   it("supports omitting the args array, like child_process.spawn", async () => {
-    const mod = await freshLifecycle();
-    const octoProcess = new mod.OctoProcessManager().spawn(process.execPath, { stdio: "ignore" });
+    const octoProcess = new OctoProcessManager().spawn(process.execPath, { stdio: "ignore" });
 
     const code = await new Promise<number | null>(resolve => {
       octoProcess.once("close", code => resolve(code));
@@ -37,20 +33,20 @@ describe("OctoProcessManager.spawn", () => {
     expect(code).toBe(0);
   });
 
-  it("exit-tracks spawned processes so killAllOctoProcesses terminates them", async () => {
-    const mod = await freshLifecycle();
-    const octoProcess = spawnSleeper(new mod.OctoProcessManager());
+  it("exit-tracks spawned processes so runCleanups terminates them", async () => {
+    const manager = new OctoProcessManager();
+    const octoProcess = spawnSleeper(manager);
 
-    mod.killAllOctoProcesses();
+    await manager.runCleanups();
 
     await waitFor(() => !isAlive(octoProcess.pid!));
   });
 
   it("does not exit-track processes spawned with surviveAfterOctoExit", async () => {
-    const mod = await freshLifecycle();
-    const octoProcess = spawnSleeper(new mod.OctoProcessManager(), true);
+    const manager = new OctoProcessManager();
+    const octoProcess = spawnSleeper(manager, true);
 
-    mod.killAllOctoProcesses();
+    await manager.runCleanups();
     // Give any mis-sent signal a chance to land
     await new Promise(resolve => setTimeout(resolve, 250));
 
@@ -61,14 +57,13 @@ describe("OctoProcessManager.spawn", () => {
   });
 
   it("stops tracking processes when they close", async () => {
-    const mod = await freshLifecycle();
-    const octoProcesses = new mod.OctoProcessManager();
-    const octoProcess = octoProcesses.spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+    const manager = new OctoProcessManager();
+    const octoProcess = manager.spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
     await new Promise(resolve => octoProcess.once("close", resolve));
-    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
+    const kill = jest.spyOn(octoProcess, "kill").mockReturnValue(true);
 
-    octoProcesses.terminateAll();
-    mod.killAllOctoProcesses();
+    manager.terminateAll();
+    await manager.runCleanups();
 
     expect(kill).not.toHaveBeenCalled();
   });
@@ -76,23 +71,22 @@ describe("OctoProcessManager.spawn", () => {
 
 describe("OctoProcess.terminate", () => {
   it("sends SIGTERM immediately and escalates to SIGKILL after graceMs", async () => {
-    const mod = await freshLifecycle();
-    const octoProcess = spawnSleeper(new mod.OctoProcessManager());
-    vi.useFakeTimers();
-    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
+    const octoProcess = spawnSleeper(new OctoProcessManager());
+    jest.useFakeTimers();
+    const kill = jest.spyOn(octoProcess, "kill").mockReturnValue(true);
 
     octoProcess.terminate({ graceMs: 100 });
 
     expect(kill).toHaveBeenCalledWith("SIGTERM");
     expect(kill).not.toHaveBeenCalledWith("SIGKILL");
 
-    vi.advanceTimersByTime(99);
+    jest.advanceTimersByTime(99);
     expect(kill).not.toHaveBeenCalledWith("SIGKILL");
-    vi.advanceTimersByTime(1);
+    jest.advanceTimersByTime(1);
     expect(kill).toHaveBeenCalledWith("SIGKILL");
 
     kill.mockRestore();
-    vi.useRealTimers();
+    jest.useRealTimers();
     octoProcess.kill("SIGKILL");
     await waitFor(() => !isAlive(octoProcess.pid!));
   });
@@ -100,12 +94,11 @@ describe("OctoProcess.terminate", () => {
   it.skipIf(process.platform === "win32")(
     "signals the whole process group for detached processes",
     async () => {
-      const mod = await freshLifecycle();
-      const octoProcess = new mod.OctoProcessManager().spawn("sleep", ["30"], {
+      const octoProcess = new OctoProcessManager().spawn("sleep", ["30"], {
         detached: true,
         stdio: "ignore",
       });
-      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+      const killSpy = jest.spyOn(process, "kill").mockImplementation(() => true);
 
       octoProcess.terminate();
 
@@ -121,17 +114,16 @@ describe("OctoProcess.terminate", () => {
   );
 
   it("signals only the process itself when not detached", async () => {
-    const mod = await freshLifecycle();
-    const octoProcess = spawnSleeper(new mod.OctoProcessManager());
-    const processKillSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
+    const octoProcess = spawnSleeper(new OctoProcessManager());
+    const processKillSpy = jest.spyOn(process, "kill").mockImplementation(() => true);
+    const kill = jest.spyOn(octoProcess, "kill").mockReturnValue(true);
 
     octoProcess.terminate();
 
     expect(processKillSpy).not.toHaveBeenCalled();
     expect(kill).toHaveBeenCalledWith("SIGTERM");
 
-    vi.restoreAllMocks();
+    jest.restoreAllMocks();
     octoProcess.kill("SIGKILL");
     await waitFor(() => !isAlive(octoProcess.pid!));
   });
@@ -139,22 +131,21 @@ describe("OctoProcess.terminate", () => {
   it.skipIf(process.platform === "win32")(
     "falls back to signaling just the process if the group signal fails",
     async () => {
-      const mod = await freshLifecycle();
-      const octoProcess = new mod.OctoProcessManager().spawn("sleep", ["30"], {
+      const octoProcess = new OctoProcessManager().spawn("sleep", ["30"], {
         detached: true,
         stdio: "ignore",
       });
-      vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
+      jest.spyOn(process, "kill").mockImplementation(((pid: number) => {
         if (pid < 0) throw new Error("ESRCH: no such process group");
         return true;
       }) as typeof process.kill);
-      const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
+      const kill = jest.spyOn(octoProcess, "kill").mockReturnValue(true);
 
       octoProcess.terminate();
 
       expect(kill).toHaveBeenCalledWith("SIGTERM");
 
-      vi.restoreAllMocks();
+      jest.restoreAllMocks();
       try {
         process.kill(-octoProcess.pid!, "SIGKILL");
         octoProcess.kill("SIGKILL");
@@ -164,33 +155,31 @@ describe("OctoProcess.terminate", () => {
   );
 
   it("escalates to SIGKILL after the default grace period", async () => {
-    const mod = await freshLifecycle();
-    const octoProcess = spawnSleeper(new mod.OctoProcessManager());
-    vi.useFakeTimers();
-    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
+    const octoProcess = spawnSleeper(new OctoProcessManager());
+    jest.useFakeTimers();
+    const kill = jest.spyOn(octoProcess, "kill").mockReturnValue(true);
 
     octoProcess.terminate();
 
     expect(kill).toHaveBeenCalledWith("SIGTERM");
-    vi.advanceTimersByTime(999);
+    jest.advanceTimersByTime(999);
     expect(kill).not.toHaveBeenCalledWith("SIGKILL");
-    vi.advanceTimersByTime(1);
+    jest.advanceTimersByTime(1);
     expect(kill).toHaveBeenCalledWith("SIGKILL");
 
     kill.mockRestore();
-    vi.useRealTimers();
+    jest.useRealTimers();
     octoProcess.kill("SIGKILL");
     await waitFor(() => !isAlive(octoProcess.pid!));
   });
 
   it("is safe to call on a closed process and to call twice", async () => {
-    const mod = await freshLifecycle();
-    const octoProcesses = new mod.OctoProcessManager();
-    const exited = octoProcesses.spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+    const manager = new OctoProcessManager();
+    const exited = manager.spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
     await new Promise(resolve => exited.once("close", resolve));
     expect(() => exited.terminate()).not.toThrow();
 
-    const sleeper = spawnSleeper(octoProcesses);
+    const sleeper = spawnSleeper(manager);
     expect(() => {
       sleeper.terminate();
       sleeper.terminate();
@@ -200,8 +189,7 @@ describe("OctoProcess.terminate", () => {
   });
 
   it("works on processes spawned with surviveAfterOctoExit", async () => {
-    const mod = await freshLifecycle();
-    const octoProcess = spawnSleeper(new mod.OctoProcessManager(), true);
+    const octoProcess = spawnSleeper(new OctoProcessManager(), true);
 
     octoProcess.terminate({ graceMs: 100 });
 
@@ -211,40 +199,38 @@ describe("OctoProcess.terminate", () => {
 
 describe("OctoProcessManager.terminateAll", () => {
   it("terminates only the manager's own processes", async () => {
-    const mod = await freshLifecycle();
-    const here = new mod.OctoProcessManager();
-    const there = new mod.OctoProcessManager();
+    const here = new OctoProcessManager();
+    const there = new OctoProcessManager();
     const mine = spawnSleeper(here);
     const theirs = spawnSleeper(there);
-    const killMine = vi.spyOn(mine, "kill").mockReturnValue(true);
-    const killTheirs = vi.spyOn(theirs, "kill").mockReturnValue(true);
+    const killMine = jest.spyOn(mine, "kill").mockReturnValue(true);
+    const killTheirs = jest.spyOn(theirs, "kill").mockReturnValue(true);
 
     here.terminateAll({ graceMs: 5000 });
 
     expect(killMine).toHaveBeenCalledWith("SIGTERM");
     expect(killTheirs).not.toHaveBeenCalled();
 
-    vi.restoreAllMocks();
+    jest.restoreAllMocks();
     mine.kill("SIGKILL");
     theirs.kill("SIGKILL");
     await waitFor(() => !isAlive(mine.pid!) && !isAlive(theirs.pid!));
   });
 
   it("escalates to SIGKILL after the given graceMs", async () => {
-    const mod = await freshLifecycle();
-    const octoProcesses = new mod.OctoProcessManager();
-    const octoProcess = spawnSleeper(octoProcesses);
-    vi.useFakeTimers();
-    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
+    const manager = new OctoProcessManager();
+    const octoProcess = spawnSleeper(manager);
+    jest.useFakeTimers();
+    const kill = jest.spyOn(octoProcess, "kill").mockReturnValue(true);
 
-    octoProcesses.terminateAll({ graceMs: 100 });
+    manager.terminateAll({ graceMs: 100 });
 
     expect(kill).toHaveBeenCalledWith("SIGTERM");
-    vi.advanceTimersByTime(100);
+    jest.advanceTimersByTime(100);
     expect(kill).toHaveBeenCalledWith("SIGKILL");
 
     kill.mockRestore();
-    vi.useRealTimers();
+    jest.useRealTimers();
     octoProcess.kill("SIGKILL");
     await waitFor(() => !isAlive(octoProcess.pid!));
   });
@@ -252,9 +238,8 @@ describe("OctoProcessManager.terminateAll", () => {
 
 describe("OctoProcessManager.execFile", () => {
   it("buffers output to the callback, like child_process.execFile", async () => {
-    const mod = await freshLifecycle();
     const stdout = await new Promise<string | Buffer>((resolve, reject) => {
-      new mod.OctoProcessManager().execFile(
+      new OctoProcessManager().execFile(
         process.execPath,
         ["-e", "console.log('hello')"],
         (error, stdout) => (error ? reject(error) : resolve(stdout)),
@@ -265,11 +250,11 @@ describe("OctoProcessManager.execFile", () => {
   });
 
   it("supports omitting the args array and options, like child_process.execFile", async () => {
-    const mod = await freshLifecycle();
     const stdoutPromise = new Promise<string | Buffer>((resolve, reject) => {
-      const octoProcess = new mod.OctoProcessManager().execFile(
-        process.execPath,
-        (error, stdout) => (error ? reject(error) : resolve(stdout)),
+      // Can't use process.execPath here like the other tests: under `bun test`
+      // that's the bun binary, and only node reads stdin as a script with no args.
+      const octoProcess = new OctoProcessManager().execFile("node", (error, stdout) =>
+        error ? reject(error) : resolve(stdout),
       );
       // node with no args reads stdin as a script; close it so it sees EOF and exits
       octoProcess.stdin!.end();
@@ -279,9 +264,8 @@ describe("OctoProcessManager.execFile", () => {
   });
 
   it("passes options through to child_process.execFile", async () => {
-    const mod = await freshLifecycle();
     const stdout = await new Promise<string | Buffer>((resolve, reject) => {
-      new mod.OctoProcessManager().execFile(
+      new OctoProcessManager().execFile(
         process.execPath,
         ["-e", "process.stdout.write('buffered')"],
         { encoding: "buffer" },
@@ -294,26 +278,23 @@ describe("OctoProcessManager.execFile", () => {
   });
 
   it("reports spawn failures to the callback, like child_process.execFile", async () => {
-    const mod = await freshLifecycle();
     const error = await new Promise<Error | null>(resolve => {
-      new mod.OctoProcessManager().execFile(process.execPath, ["-e", "process.exit(3)"], error =>
+      new OctoProcessManager().execFile(process.execPath, ["-e", "process.exit(3)"], error =>
         resolve(error),
       );
     });
 
     expect(error).not.toBeNull();
-    expect((error as NodeJS.ErrnoException & { code: number }).code).toBe(3);
+    expect((error as unknown as { code: number }).code).toBe(3);
   });
 
   it("does not exit-track processes spawned with surviveAfterOctoExit", async () => {
-    const mod = await freshLifecycle();
-    const octoProcess = new mod.OctoProcessManager().execFile(
-      process.execPath,
-      ["-e", "setTimeout(() => {}, 30000)"],
-      { surviveAfterOctoExit: true },
-    );
+    const manager = new OctoProcessManager();
+    const octoProcess = manager.execFile(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
+      surviveAfterOctoExit: true,
+    });
 
-    mod.killAllOctoProcesses();
+    await manager.runCleanups();
     // Give any mis-sent signal a chance to land
     await new Promise(resolve => setTimeout(resolve, 250));
 
@@ -323,41 +304,38 @@ describe("OctoProcessManager.execFile", () => {
     await waitFor(() => !isAlive(octoProcess.pid!));
   });
 
-  it("exit-tracks spawned processes so killAllOctoProcesses terminates them", async () => {
-    const mod = await freshLifecycle();
-    const octoProcess = new mod.OctoProcessManager().execFile(process.execPath, [
-      "-e",
-      "setTimeout(() => {}, 30000)",
-    ]);
+  it("exit-tracks spawned processes so runCleanups terminates them", async () => {
+    const manager = new OctoProcessManager();
+    const octoProcess = manager.execFile(process.execPath, ["-e", "setTimeout(() => {}, 30000)"]);
 
-    mod.killAllOctoProcesses();
+    await manager.runCleanups();
 
     await waitFor(() => !isAlive(octoProcess.pid!));
   });
 });
 
-describe("runCleanups", () => {
+describe("OctoProcessManager.runCleanups", () => {
   it("runs registered cleanups once, tolerates failures, and terminates remaining processes", async () => {
-    const mod = await freshLifecycle();
+    const manager = new OctoProcessManager();
     const calls: string[] = [];
-    mod.registerCleanup(() => {
+    manager.registerCleanup(() => {
       calls.push("sync");
     });
-    mod.registerCleanup(async () => {
+    manager.registerCleanup(async () => {
       calls.push("async");
     });
-    mod.registerCleanup(() => {
+    manager.registerCleanup(() => {
       throw new Error("a failing cleanup must not block the others");
     });
-    const octoProcess = spawnSleeper(new mod.OctoProcessManager());
-    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
+    const octoProcess = spawnSleeper(manager);
+    const kill = jest.spyOn(octoProcess, "kill").mockReturnValue(true);
 
-    await mod.runCleanups();
+    await manager.runCleanups();
 
     expect(calls.sort()).toEqual(["async", "sync"]);
     expect(kill).toHaveBeenCalledWith("SIGTERM");
 
-    await mod.runCleanups();
+    await manager.runCleanups();
     expect(calls.sort()).toEqual(["async", "sync"]);
 
     kill.mockRestore();
@@ -366,32 +344,43 @@ describe("runCleanups", () => {
   });
 
   it("does not run unregistered cleanups", async () => {
-    const mod = await freshLifecycle();
-    const cleanup = vi.fn();
-    const unregister = mod.registerCleanup(cleanup);
+    const manager = new OctoProcessManager();
+    const cleanup = jest.fn();
+    const unregister = manager.registerCleanup(cleanup);
 
     unregister();
     // Unregistering twice must be harmless
     expect(() => unregister()).not.toThrow();
-    await mod.runCleanups();
+    await manager.runCleanups();
+
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it("does not share cleanups between manager instances", async () => {
+    const here = new OctoProcessManager();
+    const there = new OctoProcessManager();
+    const cleanup = jest.fn();
+    there.registerCleanup(cleanup);
+
+    await here.runCleanups();
 
     expect(cleanup).not.toHaveBeenCalled();
   });
 
   it("bounds hung cleanups by a timeout so shutdown can't be blocked", async () => {
-    vi.useFakeTimers();
-    const mod = await freshLifecycle();
-    mod.registerCleanup(() => new Promise<void>(() => {}));
+    jest.useFakeTimers();
+    const manager = new OctoProcessManager();
+    manager.registerCleanup(() => new Promise<void>(() => {}));
 
-    const promise = mod.runCleanups();
-    await vi.advanceTimersByTimeAsync(5000);
+    const promise = manager.runCleanups();
+    jest.advanceTimersByTime(5000);
 
     // Resolves thanks to the cleanup timeout rather than hanging forever
     await promise;
   });
 });
 
-describe("installProcessSignalHandlers", () => {
+describe("OctoProcessManager.installGlobalProcessSignalHandlers", () => {
   it("installs one handler per termination signal and is idempotent", async () => {
     const signals = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
     const listenersBefore = new Map(
@@ -399,17 +388,17 @@ describe("installProcessSignalHandlers", () => {
     );
     const exitListenersBefore = process.listeners("exit");
 
-    const mod = await freshLifecycle();
+    const manager = new OctoProcessManager();
     try {
-      mod.installGlobalProcessSignalHandlers();
-      mod.installGlobalProcessSignalHandlers();
+      manager.installGlobalProcessSignalHandlers();
+      manager.installGlobalProcessSignalHandlers();
 
       for (const signal of signals) {
         expect(process.listenerCount(signal)).toBe(listenersBefore.get(signal)!.length + 1);
       }
       expect(process.listenerCount("exit")).toBe(exitListenersBefore.length + 1);
     } finally {
-      // Remove the module's listeners so a stray signal during the test run
+      // Remove the manager's listeners so a stray signal during the test run
       // can't trigger the real shutdown path.
       for (const signal of signals) {
         for (const listener of process.listeners(signal)) {
@@ -435,14 +424,14 @@ describe("installProcessSignalHandlers", () => {
     const listenersBefore = new Map(
       [...signals, "exit"].map(signal => [signal, listeners(signal)] as const),
     );
-    const mod = await freshLifecycle();
-    const cleanup = vi.fn();
-    mod.registerCleanup(cleanup);
+    const manager = new OctoProcessManager();
+    const cleanup = jest.fn();
+    manager.registerCleanup(cleanup);
     // Swallow the re-raised signal and intercept exit so the test runner survives
-    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
-    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const kill = jest.spyOn(process, "kill").mockImplementation(() => true);
+    const exit = jest.spyOn(process, "exit").mockImplementation((() => undefined) as never);
     try {
-      mod.installGlobalProcessSignalHandlers();
+      manager.installGlobalProcessSignalHandlers();
       const handler = process
         .listeners("SIGTERM")
         .find(listener => !listenersBefore.get("SIGTERM")!.includes(listener)) as () => void;

--- a/source/octo-process.test.ts
+++ b/source/octo-process.test.ts
@@ -1,0 +1,495 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OctoProcess, OctoProcessManager } from "./octo-process.ts";
+
+/**
+ * The module under test keeps process-global state (the process registry, the
+ * cleanup registry, once-only flags), so each test imports a fresh copy.
+ */
+async function freshLifecycle() {
+  vi.resetModules();
+  return await import("./octo-process.ts");
+}
+
+function spawnSleeper(
+  octoProcesses: OctoProcessManager,
+  surviveAfterOctoExit = false,
+): OctoProcess {
+  return octoProcesses.spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
+    stdio: "ignore",
+    surviveAfterOctoExit,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("OctoProcessManager.spawn", () => {
+  it("supports omitting the args array, like child_process.spawn", async () => {
+    const mod = await freshLifecycle();
+    const octoProcess = new mod.OctoProcessManager().spawn(process.execPath, { stdio: "ignore" });
+
+    const code = await new Promise<number | null>(resolve => {
+      octoProcess.childProcess.once("close", code => resolve(code));
+    });
+
+    expect(code).toBe(0);
+  });
+
+  it("exit-tracks spawned processes so killAllOctoProcesses terminates them", async () => {
+    const mod = await freshLifecycle();
+    const octoProcess = spawnSleeper(new mod.OctoProcessManager());
+
+    mod.killAllOctoProcesses();
+
+    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+  });
+
+  it("does not exit-track processes spawned with surviveAfterOctoExit", async () => {
+    const mod = await freshLifecycle();
+    const octoProcess = spawnSleeper(new mod.OctoProcessManager(), true);
+
+    mod.killAllOctoProcesses();
+    // Give any mis-sent signal a chance to land
+    await new Promise(resolve => setTimeout(resolve, 250));
+
+    expect(isAlive(octoProcess.childProcess.pid!)).toBe(true);
+
+    octoProcess.childProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+  });
+
+  it("stops tracking processes when they close", async () => {
+    const mod = await freshLifecycle();
+    const octoProcesses = new mod.OctoProcessManager();
+    const octoProcess = octoProcesses.spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+    await new Promise(resolve => octoProcess.childProcess.once("close", resolve));
+    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+
+    octoProcesses.terminateAll();
+    mod.killAllOctoProcesses();
+
+    expect(kill).not.toHaveBeenCalled();
+  });
+});
+
+describe("OctoProcess.terminate", () => {
+  it("sends SIGTERM immediately and escalates to SIGKILL after graceMs", async () => {
+    const mod = await freshLifecycle();
+    const octoProcess = spawnSleeper(new mod.OctoProcessManager());
+    vi.useFakeTimers();
+    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+
+    octoProcess.terminate({ graceMs: 100 });
+
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+    expect(kill).not.toHaveBeenCalledWith("SIGKILL");
+
+    vi.advanceTimersByTime(99);
+    expect(kill).not.toHaveBeenCalledWith("SIGKILL");
+    vi.advanceTimersByTime(1);
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
+
+    kill.mockRestore();
+    vi.useRealTimers();
+    octoProcess.childProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "signals the whole process group for detached processes",
+    async () => {
+      const mod = await freshLifecycle();
+      const octoProcess = new mod.OctoProcessManager().spawn("sleep", ["30"], {
+        detached: true,
+        stdio: "ignore",
+      });
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      octoProcess.terminate();
+
+      expect(killSpy).toHaveBeenCalledWith(-octoProcess.childProcess.pid!, "SIGTERM");
+
+      // Actually kill the real process, since process.kill was mocked
+      killSpy.mockRestore();
+      try {
+        process.kill(-octoProcess.childProcess.pid!, "SIGKILL");
+      } catch {}
+      await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    },
+  );
+
+  it("signals only the process itself when not detached", async () => {
+    const mod = await freshLifecycle();
+    const octoProcess = spawnSleeper(new mod.OctoProcessManager());
+    const processKillSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+
+    octoProcess.terminate();
+
+    expect(processKillSpy).not.toHaveBeenCalled();
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+
+    vi.restoreAllMocks();
+    octoProcess.childProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "falls back to signaling just the process if the group signal fails",
+    async () => {
+      const mod = await freshLifecycle();
+      const octoProcess = new mod.OctoProcessManager().spawn("sleep", ["30"], {
+        detached: true,
+        stdio: "ignore",
+      });
+      vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
+        if (pid < 0) throw new Error("ESRCH: no such process group");
+        return true;
+      }) as typeof process.kill);
+      const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+
+      octoProcess.terminate();
+
+      expect(kill).toHaveBeenCalledWith("SIGTERM");
+
+      vi.restoreAllMocks();
+      try {
+        process.kill(-octoProcess.childProcess.pid!, "SIGKILL");
+        octoProcess.childProcess.kill("SIGKILL");
+      } catch {}
+      await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    },
+  );
+
+  it("escalates to SIGKILL after the default grace period", async () => {
+    const mod = await freshLifecycle();
+    const octoProcess = spawnSleeper(new mod.OctoProcessManager());
+    vi.useFakeTimers();
+    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+
+    octoProcess.terminate();
+
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+    vi.advanceTimersByTime(999);
+    expect(kill).not.toHaveBeenCalledWith("SIGKILL");
+    vi.advanceTimersByTime(1);
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
+
+    kill.mockRestore();
+    vi.useRealTimers();
+    octoProcess.childProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+  });
+
+  it("is safe to call on a closed process and to call twice", async () => {
+    const mod = await freshLifecycle();
+    const octoProcesses = new mod.OctoProcessManager();
+    const exited = octoProcesses.spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+    await new Promise(resolve => exited.childProcess.once("close", resolve));
+    expect(() => exited.terminate()).not.toThrow();
+
+    const sleeper = spawnSleeper(octoProcesses);
+    expect(() => {
+      sleeper.terminate();
+      sleeper.terminate();
+    }).not.toThrow();
+
+    await waitFor(() => !isAlive(sleeper.childProcess.pid!));
+  });
+
+  it("works on processes spawned with surviveAfterOctoExit", async () => {
+    const mod = await freshLifecycle();
+    const octoProcess = spawnSleeper(new mod.OctoProcessManager(), true);
+
+    octoProcess.terminate({ graceMs: 100 });
+
+    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+  });
+});
+
+describe("OctoProcessManager.terminateAll", () => {
+  it("terminates only the manager's own processes", async () => {
+    const mod = await freshLifecycle();
+    const here = new mod.OctoProcessManager();
+    const there = new mod.OctoProcessManager();
+    const mine = spawnSleeper(here);
+    const theirs = spawnSleeper(there);
+    const killMine = vi.spyOn(mine.childProcess, "kill").mockReturnValue(true);
+    const killTheirs = vi.spyOn(theirs.childProcess, "kill").mockReturnValue(true);
+
+    here.terminateAll({ graceMs: 5000 });
+
+    expect(killMine).toHaveBeenCalledWith("SIGTERM");
+    expect(killTheirs).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+    mine.childProcess.kill("SIGKILL");
+    theirs.childProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(mine.childProcess.pid!) && !isAlive(theirs.childProcess.pid!));
+  });
+
+  it("escalates to SIGKILL after the given graceMs", async () => {
+    const mod = await freshLifecycle();
+    const octoProcesses = new mod.OctoProcessManager();
+    const octoProcess = spawnSleeper(octoProcesses);
+    vi.useFakeTimers();
+    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+
+    octoProcesses.terminateAll({ graceMs: 100 });
+
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+    vi.advanceTimersByTime(100);
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
+
+    kill.mockRestore();
+    vi.useRealTimers();
+    octoProcess.childProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+  });
+});
+
+describe("OctoProcessManager.execFile", () => {
+  it("buffers output to the callback, like child_process.execFile", async () => {
+    const mod = await freshLifecycle();
+    const stdout = await new Promise<string | Buffer>((resolve, reject) => {
+      new mod.OctoProcessManager().execFile(
+        process.execPath,
+        ["-e", "console.log('hello')"],
+        (error, stdout) => (error ? reject(error) : resolve(stdout)),
+      );
+    });
+
+    expect(stdout.toString()).toBe("hello\n");
+  });
+
+  it("supports omitting the args array and options, like child_process.execFile", async () => {
+    const mod = await freshLifecycle();
+    const stdoutPromise = new Promise<string | Buffer>((resolve, reject) => {
+      const octoProcess = new mod.OctoProcessManager().execFile(
+        process.execPath,
+        (error, stdout) => (error ? reject(error) : resolve(stdout)),
+      );
+      // node with no args reads stdin as a script; close it so it sees EOF and exits
+      octoProcess.childProcess.stdin!.end();
+    });
+
+    expect((await stdoutPromise).toString()).toBe("");
+  });
+
+  it("passes options through to child_process.execFile", async () => {
+    const mod = await freshLifecycle();
+    const stdout = await new Promise<string | Buffer>((resolve, reject) => {
+      new mod.OctoProcessManager().execFile(
+        process.execPath,
+        ["-e", "process.stdout.write('buffered')"],
+        { encoding: "buffer" },
+        (error, stdout) => (error ? reject(error) : resolve(stdout)),
+      );
+    });
+
+    expect(Buffer.isBuffer(stdout)).toBe(true);
+    expect(stdout.toString()).toBe("buffered");
+  });
+
+  it("reports spawn failures to the callback, like child_process.execFile", async () => {
+    const mod = await freshLifecycle();
+    const error = await new Promise<Error | null>(resolve => {
+      new mod.OctoProcessManager().execFile(process.execPath, ["-e", "process.exit(3)"], error =>
+        resolve(error),
+      );
+    });
+
+    expect(error).not.toBeNull();
+    expect((error as NodeJS.ErrnoException & { code: number }).code).toBe(3);
+  });
+
+  it("does not exit-track processes spawned with surviveAfterOctoExit", async () => {
+    const mod = await freshLifecycle();
+    const octoProcess = new mod.OctoProcessManager().execFile(
+      process.execPath,
+      ["-e", "setTimeout(() => {}, 30000)"],
+      { surviveAfterOctoExit: true },
+    );
+
+    mod.killAllOctoProcesses();
+    // Give any mis-sent signal a chance to land
+    await new Promise(resolve => setTimeout(resolve, 250));
+
+    expect(isAlive(octoProcess.childProcess.pid!)).toBe(true);
+
+    octoProcess.childProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+  });
+
+  it("exit-tracks spawned processes so killAllOctoProcesses terminates them", async () => {
+    const mod = await freshLifecycle();
+    const octoProcess = new mod.OctoProcessManager().execFile(process.execPath, [
+      "-e",
+      "setTimeout(() => {}, 30000)",
+    ]);
+
+    mod.killAllOctoProcesses();
+
+    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+  });
+});
+
+describe("runCleanups", () => {
+  it("runs registered cleanups once, tolerates failures, and terminates remaining processes", async () => {
+    const mod = await freshLifecycle();
+    const calls: string[] = [];
+    mod.registerCleanup(() => {
+      calls.push("sync");
+    });
+    mod.registerCleanup(async () => {
+      calls.push("async");
+    });
+    mod.registerCleanup(() => {
+      throw new Error("a failing cleanup must not block the others");
+    });
+    const octoProcess = spawnSleeper(new mod.OctoProcessManager());
+    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+
+    await mod.runCleanups();
+
+    expect(calls.sort()).toEqual(["async", "sync"]);
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+
+    await mod.runCleanups();
+    expect(calls.sort()).toEqual(["async", "sync"]);
+
+    kill.mockRestore();
+    octoProcess.childProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+  });
+
+  it("does not run unregistered cleanups", async () => {
+    const mod = await freshLifecycle();
+    const cleanup = vi.fn();
+    const unregister = mod.registerCleanup(cleanup);
+
+    unregister();
+    // Unregistering twice must be harmless
+    expect(() => unregister()).not.toThrow();
+    await mod.runCleanups();
+
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it("bounds hung cleanups by a timeout so shutdown can't be blocked", async () => {
+    vi.useFakeTimers();
+    const mod = await freshLifecycle();
+    mod.registerCleanup(() => new Promise<void>(() => {}));
+
+    const promise = mod.runCleanups();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // Resolves thanks to the cleanup timeout rather than hanging forever
+    await promise;
+  });
+});
+
+describe("installProcessSignalHandlers", () => {
+  it("installs one handler per termination signal and is idempotent", async () => {
+    const signals = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+    const listenersBefore = new Map(
+      signals.map(signal => [signal, process.listeners(signal)] as const),
+    );
+    const exitListenersBefore = process.listeners("exit");
+
+    const mod = await freshLifecycle();
+    try {
+      mod.installGlobalProcessSignalHandlers();
+      mod.installGlobalProcessSignalHandlers();
+
+      for (const signal of signals) {
+        expect(process.listenerCount(signal)).toBe(listenersBefore.get(signal)!.length + 1);
+      }
+      expect(process.listenerCount("exit")).toBe(exitListenersBefore.length + 1);
+    } finally {
+      // Remove the module's listeners so a stray signal during the test run
+      // can't trigger the real shutdown path.
+      for (const signal of signals) {
+        for (const listener of process.listeners(signal)) {
+          if (!listenersBefore.get(signal)!.includes(listener)) {
+            process.removeListener(signal, listener);
+          }
+        }
+      }
+      for (const listener of process.listeners("exit")) {
+        if (!exitListenersBefore.includes(listener)) {
+          process.removeListener("exit", listener);
+        }
+      }
+    }
+  });
+
+  it("runs cleanups, re-raises the signal, and force-exits if the re-raise is swallowed", async () => {
+    const signals = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+    // Bypass process.listeners' overloads, which don't accept a union of signals and "exit"
+    const listeners = process.listeners.bind(process) as (
+      event: string,
+    ) => ((...args: any[]) => void)[];
+    const listenersBefore = new Map(
+      [...signals, "exit"].map(signal => [signal, listeners(signal)] as const),
+    );
+    const mod = await freshLifecycle();
+    const cleanup = vi.fn();
+    mod.registerCleanup(cleanup);
+    // Swallow the re-raised signal and intercept exit so the test runner survives
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    try {
+      mod.installGlobalProcessSignalHandlers();
+      const handler = process
+        .listeners("SIGTERM")
+        .find(listener => !listenersBefore.get("SIGTERM")!.includes(listener)) as () => void;
+
+      handler();
+
+      // The handler should re-raise SIGTERM to this process after cleanup
+      await waitFor(() =>
+        kill.mock.calls.some(([pid, signal]) => pid === process.pid && signal === "SIGTERM"),
+      );
+      expect(cleanup).toHaveBeenCalledTimes(1);
+
+      // A second signal arriving mid-shutdown must be ignored
+      handler();
+      expect(cleanup).toHaveBeenCalledTimes(1);
+
+      // Since the mocked process.kill swallowed the re-raise, the fallback
+      // must force an exit with the conventional 128 + signo code (SIGTERM is 15).
+      // Waiting for it to fire also drains its timer before the exit mock is restored.
+      await waitFor(() => exit.mock.calls.length > 0);
+      expect(exit).toHaveBeenCalledWith(143);
+    } finally {
+      for (const [signal, before] of listenersBefore) {
+        for (const listener of listeners(signal)) {
+          if (!before.includes(listener)) {
+            process.removeListener(signal, listener);
+          }
+        }
+      }
+    }
+  });
+});
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM means the process exists but we can't signal it
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 10_000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("Timed out waiting for condition");
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+}

--- a/source/octo-process.test.ts
+++ b/source/octo-process.test.ts
@@ -403,12 +403,16 @@ describe("OctoProcessManager.installGlobalProcessSignalHandlers", () => {
       for (const signal of signals) {
         for (const listener of process.listeners(signal)) {
           if (!listenersBefore.get(signal)!.includes(listener)) {
+            // @ts-expect-error @types/node's process.removeListener overloads
+            // omit the signal events, despite Process being an EventEmitter.
             process.removeListener(signal, listener);
           }
         }
       }
       for (const listener of process.listeners("exit")) {
         if (!exitListenersBefore.includes(listener)) {
+          // @ts-expect-error @types/node's process.removeListener overloads
+          // omit the "exit" event, despite Process being an EventEmitter.
           process.removeListener("exit", listener);
         }
       }
@@ -457,6 +461,9 @@ describe("OctoProcessManager.installGlobalProcessSignalHandlers", () => {
       for (const [signal, before] of listenersBefore) {
         for (const listener of listeners(signal)) {
           if (!before.includes(listener)) {
+            // @ts-expect-error @types/node's process.removeListener overloads
+            // omit the signal and "exit" events, despite Process being an
+            // EventEmitter.
             process.removeListener(signal, listener);
           }
         }

--- a/source/octo-process.test.ts
+++ b/source/octo-process.test.ts
@@ -31,7 +31,7 @@ describe("OctoProcessManager.spawn", () => {
     const octoProcess = new mod.OctoProcessManager().spawn(process.execPath, { stdio: "ignore" });
 
     const code = await new Promise<number | null>(resolve => {
-      octoProcess.childProcess.once("close", code => resolve(code));
+      octoProcess.once("close", code => resolve(code));
     });
 
     expect(code).toBe(0);
@@ -43,7 +43,7 @@ describe("OctoProcessManager.spawn", () => {
 
     mod.killAllOctoProcesses();
 
-    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    await waitFor(() => !isAlive(octoProcess.pid!));
   });
 
   it("does not exit-track processes spawned with surviveAfterOctoExit", async () => {
@@ -54,18 +54,18 @@ describe("OctoProcessManager.spawn", () => {
     // Give any mis-sent signal a chance to land
     await new Promise(resolve => setTimeout(resolve, 250));
 
-    expect(isAlive(octoProcess.childProcess.pid!)).toBe(true);
+    expect(isAlive(octoProcess.pid!)).toBe(true);
 
-    octoProcess.childProcess.kill("SIGKILL");
-    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    octoProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.pid!));
   });
 
   it("stops tracking processes when they close", async () => {
     const mod = await freshLifecycle();
     const octoProcesses = new mod.OctoProcessManager();
     const octoProcess = octoProcesses.spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
-    await new Promise(resolve => octoProcess.childProcess.once("close", resolve));
-    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+    await new Promise(resolve => octoProcess.once("close", resolve));
+    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
 
     octoProcesses.terminateAll();
     mod.killAllOctoProcesses();
@@ -79,7 +79,7 @@ describe("OctoProcess.terminate", () => {
     const mod = await freshLifecycle();
     const octoProcess = spawnSleeper(new mod.OctoProcessManager());
     vi.useFakeTimers();
-    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
 
     octoProcess.terminate({ graceMs: 100 });
 
@@ -93,8 +93,8 @@ describe("OctoProcess.terminate", () => {
 
     kill.mockRestore();
     vi.useRealTimers();
-    octoProcess.childProcess.kill("SIGKILL");
-    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    octoProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.pid!));
   });
 
   it.skipIf(process.platform === "win32")(
@@ -109,14 +109,14 @@ describe("OctoProcess.terminate", () => {
 
       octoProcess.terminate();
 
-      expect(killSpy).toHaveBeenCalledWith(-octoProcess.childProcess.pid!, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(-octoProcess.pid!, "SIGTERM");
 
       // Actually kill the real process, since process.kill was mocked
       killSpy.mockRestore();
       try {
-        process.kill(-octoProcess.childProcess.pid!, "SIGKILL");
+        process.kill(-octoProcess.pid!, "SIGKILL");
       } catch {}
-      await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+      await waitFor(() => !isAlive(octoProcess.pid!));
     },
   );
 
@@ -124,7 +124,7 @@ describe("OctoProcess.terminate", () => {
     const mod = await freshLifecycle();
     const octoProcess = spawnSleeper(new mod.OctoProcessManager());
     const processKillSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
 
     octoProcess.terminate();
 
@@ -132,8 +132,8 @@ describe("OctoProcess.terminate", () => {
     expect(kill).toHaveBeenCalledWith("SIGTERM");
 
     vi.restoreAllMocks();
-    octoProcess.childProcess.kill("SIGKILL");
-    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    octoProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.pid!));
   });
 
   it.skipIf(process.platform === "win32")(
@@ -148,7 +148,7 @@ describe("OctoProcess.terminate", () => {
         if (pid < 0) throw new Error("ESRCH: no such process group");
         return true;
       }) as typeof process.kill);
-      const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+      const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
 
       octoProcess.terminate();
 
@@ -156,10 +156,10 @@ describe("OctoProcess.terminate", () => {
 
       vi.restoreAllMocks();
       try {
-        process.kill(-octoProcess.childProcess.pid!, "SIGKILL");
-        octoProcess.childProcess.kill("SIGKILL");
+        process.kill(-octoProcess.pid!, "SIGKILL");
+        octoProcess.kill("SIGKILL");
       } catch {}
-      await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+      await waitFor(() => !isAlive(octoProcess.pid!));
     },
   );
 
@@ -167,7 +167,7 @@ describe("OctoProcess.terminate", () => {
     const mod = await freshLifecycle();
     const octoProcess = spawnSleeper(new mod.OctoProcessManager());
     vi.useFakeTimers();
-    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
 
     octoProcess.terminate();
 
@@ -179,15 +179,15 @@ describe("OctoProcess.terminate", () => {
 
     kill.mockRestore();
     vi.useRealTimers();
-    octoProcess.childProcess.kill("SIGKILL");
-    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    octoProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.pid!));
   });
 
   it("is safe to call on a closed process and to call twice", async () => {
     const mod = await freshLifecycle();
     const octoProcesses = new mod.OctoProcessManager();
     const exited = octoProcesses.spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
-    await new Promise(resolve => exited.childProcess.once("close", resolve));
+    await new Promise(resolve => exited.once("close", resolve));
     expect(() => exited.terminate()).not.toThrow();
 
     const sleeper = spawnSleeper(octoProcesses);
@@ -196,7 +196,7 @@ describe("OctoProcess.terminate", () => {
       sleeper.terminate();
     }).not.toThrow();
 
-    await waitFor(() => !isAlive(sleeper.childProcess.pid!));
+    await waitFor(() => !isAlive(sleeper.pid!));
   });
 
   it("works on processes spawned with surviveAfterOctoExit", async () => {
@@ -205,7 +205,7 @@ describe("OctoProcess.terminate", () => {
 
     octoProcess.terminate({ graceMs: 100 });
 
-    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    await waitFor(() => !isAlive(octoProcess.pid!));
   });
 });
 
@@ -216,8 +216,8 @@ describe("OctoProcessManager.terminateAll", () => {
     const there = new mod.OctoProcessManager();
     const mine = spawnSleeper(here);
     const theirs = spawnSleeper(there);
-    const killMine = vi.spyOn(mine.childProcess, "kill").mockReturnValue(true);
-    const killTheirs = vi.spyOn(theirs.childProcess, "kill").mockReturnValue(true);
+    const killMine = vi.spyOn(mine, "kill").mockReturnValue(true);
+    const killTheirs = vi.spyOn(theirs, "kill").mockReturnValue(true);
 
     here.terminateAll({ graceMs: 5000 });
 
@@ -225,9 +225,9 @@ describe("OctoProcessManager.terminateAll", () => {
     expect(killTheirs).not.toHaveBeenCalled();
 
     vi.restoreAllMocks();
-    mine.childProcess.kill("SIGKILL");
-    theirs.childProcess.kill("SIGKILL");
-    await waitFor(() => !isAlive(mine.childProcess.pid!) && !isAlive(theirs.childProcess.pid!));
+    mine.kill("SIGKILL");
+    theirs.kill("SIGKILL");
+    await waitFor(() => !isAlive(mine.pid!) && !isAlive(theirs.pid!));
   });
 
   it("escalates to SIGKILL after the given graceMs", async () => {
@@ -235,7 +235,7 @@ describe("OctoProcessManager.terminateAll", () => {
     const octoProcesses = new mod.OctoProcessManager();
     const octoProcess = spawnSleeper(octoProcesses);
     vi.useFakeTimers();
-    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
 
     octoProcesses.terminateAll({ graceMs: 100 });
 
@@ -245,8 +245,8 @@ describe("OctoProcessManager.terminateAll", () => {
 
     kill.mockRestore();
     vi.useRealTimers();
-    octoProcess.childProcess.kill("SIGKILL");
-    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    octoProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.pid!));
   });
 });
 
@@ -272,7 +272,7 @@ describe("OctoProcessManager.execFile", () => {
         (error, stdout) => (error ? reject(error) : resolve(stdout)),
       );
       // node with no args reads stdin as a script; close it so it sees EOF and exits
-      octoProcess.childProcess.stdin!.end();
+      octoProcess.stdin!.end();
     });
 
     expect((await stdoutPromise).toString()).toBe("");
@@ -317,10 +317,10 @@ describe("OctoProcessManager.execFile", () => {
     // Give any mis-sent signal a chance to land
     await new Promise(resolve => setTimeout(resolve, 250));
 
-    expect(isAlive(octoProcess.childProcess.pid!)).toBe(true);
+    expect(isAlive(octoProcess.pid!)).toBe(true);
 
-    octoProcess.childProcess.kill("SIGKILL");
-    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    octoProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.pid!));
   });
 
   it("exit-tracks spawned processes so killAllOctoProcesses terminates them", async () => {
@@ -332,7 +332,7 @@ describe("OctoProcessManager.execFile", () => {
 
     mod.killAllOctoProcesses();
 
-    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    await waitFor(() => !isAlive(octoProcess.pid!));
   });
 });
 
@@ -350,7 +350,7 @@ describe("runCleanups", () => {
       throw new Error("a failing cleanup must not block the others");
     });
     const octoProcess = spawnSleeper(new mod.OctoProcessManager());
-    const kill = vi.spyOn(octoProcess.childProcess, "kill").mockReturnValue(true);
+    const kill = vi.spyOn(octoProcess, "kill").mockReturnValue(true);
 
     await mod.runCleanups();
 
@@ -361,8 +361,8 @@ describe("runCleanups", () => {
     expect(calls.sort()).toEqual(["async", "sync"]);
 
     kill.mockRestore();
-    octoProcess.childProcess.kill("SIGKILL");
-    await waitFor(() => !isAlive(octoProcess.childProcess.pid!));
+    octoProcess.kill("SIGKILL");
+    await waitFor(() => !isAlive(octoProcess.pid!));
   });
 
   it("does not run unregistered cleanups", async () => {

--- a/source/octo-process.ts
+++ b/source/octo-process.ts
@@ -1,0 +1,259 @@
+import {
+  execFile,
+  spawn,
+  type ChildProcess,
+  type ExecFileException,
+  type ExecFileOptions,
+  type SpawnOptions,
+} from "child_process";
+
+/**
+ * Child process lifecycle management, over `child_process`.
+ *
+ * All spawning goes through {@link OctoProcessManager}; every process it
+ * spawns carries a `terminate` callback and is terminated when Octo exits
+ * (unless spawned with `surviveExit`). {@link registerCleanup} and
+ * {@link installGlobalProcessSignalHandlers} run shutdown logic even on
+ * SIGINT/SIGTERM/SIGHUP, where `try/finally` blocks never run.
+ */
+
+type OctoProcessOptions = {
+  /**
+   * Run the child in its own process group, independent of Octo's session;
+   * termination then signals the whole group, so grandchildren die too.
+   */
+  detached?: boolean;
+  /** Don't terminate the process when Octo exits. */
+  surviveAfterOctoExit?: boolean;
+};
+
+export type OctoProcess = OctoProcessOptions & {
+  childProcess: ChildProcess;
+  terminate(opts?: { graceMs?: number }): void;
+};
+
+export type OctoSpawnOptions = SpawnOptions & OctoProcessOptions;
+export type OctoExecFileOptions = ExecFileOptions & OctoProcessOptions;
+
+/** `stdout`/`stderr` are strings unless `encoding: "buffer"` is passed, mirroring `child_process.execFile`. */
+export type OctoExecFileCallback = (
+  error: ExecFileException | null,
+  stdout: string | Buffer,
+  stderr: string | Buffer,
+) => void;
+
+const octoProcesses = new Set<OctoProcess>();
+
+const cleanups = new Set<() => Promise<void> | void>();
+
+const SIGKILL_GRACE_MS = 1000;
+const CLEANUP_TIMEOUT_MS = 5000;
+const FORCE_EXIT_FALLBACK_MS = 1000;
+
+const TERMINATION_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+type TerminationSignal = (typeof TERMINATION_SIGNALS)[number];
+
+// Conventional exit codes: 128 + signal number
+const SIGNAL_EXIT_CODES: Record<TerminationSignal, number> = {
+  SIGHUP: 129,
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+/**
+ * The only way to spawn child processes: like `child_process.spawn`/
+ * `child_process.execFile`, but everything spawned is tracked here (for
+ * {@link OctoProcessManager.terminateAll}) and in the exit-time registry,
+ * and is untracked automatically when it closes.
+ */
+export class OctoProcessManager {
+  private readonly processes = new Set<OctoProcess>();
+
+  /** Terminate every process this manager spawned that is still running. */
+  terminateAll(opts: { graceMs?: number } = {}): void {
+    for (const octoProcess of [...this.processes]) {
+      octoProcess.terminate(opts);
+    }
+  }
+
+  spawn(command: string, options?: OctoSpawnOptions): OctoProcess;
+  spawn(command: string, args: readonly string[], options?: OctoSpawnOptions): OctoProcess;
+  spawn(
+    command: string,
+    argsOrOptions?: readonly string[] | OctoSpawnOptions,
+    maybeOptions: OctoSpawnOptions = {},
+  ): OctoProcess {
+    const hasArgs = Array.isArray(argsOrOptions);
+    const args = (hasArgs ? argsOrOptions : []) as readonly string[];
+    const options = ((hasArgs ? maybeOptions : argsOrOptions) ?? {}) as OctoSpawnOptions;
+    const { surviveAfterOctoExit: surviveExit, ...spawnOptions } = options;
+    return this.manage(spawn(command, args, spawnOptions), {
+      surviveAfterOctoExit: surviveExit,
+      detached: spawnOptions.detached,
+    });
+  }
+
+  execFile(file: string, callback?: OctoExecFileCallback): OctoProcess;
+  execFile(file: string, args: readonly string[], callback?: OctoExecFileCallback): OctoProcess;
+  execFile(
+    file: string,
+    options?: OctoExecFileOptions,
+    callback?: OctoExecFileCallback,
+  ): OctoProcess;
+  execFile(
+    file: string,
+    args: readonly string[],
+    options?: OctoExecFileOptions,
+    callback?: OctoExecFileCallback,
+  ): OctoProcess;
+  execFile(
+    file: string,
+    argsOrOptionsOrCallback?: readonly string[] | OctoExecFileOptions | OctoExecFileCallback,
+    optionsOrCallback?: OctoExecFileOptions | OctoExecFileCallback,
+    maybeCallback?: OctoExecFileCallback,
+  ): OctoProcess {
+    const hasArgs = Array.isArray(argsOrOptionsOrCallback);
+    const args = (hasArgs ? argsOrOptionsOrCallback : []) as readonly string[];
+    const optionsArg = hasArgs ? optionsOrCallback : argsOrOptionsOrCallback;
+    const callbackArg = hasArgs ? maybeCallback : optionsOrCallback;
+    const options = (typeof optionsArg === "function" ? undefined : optionsArg) as
+      | OctoExecFileOptions
+      | undefined;
+    const callback = (typeof optionsArg === "function" ? optionsArg : callbackArg) as
+      | OctoExecFileCallback
+      | undefined;
+    const { surviveAfterOctoExit: surviveExit, ...execOptions } = options ?? {};
+    return this.manage(execFile(file, args, execOptions, callback ?? null), {
+      surviveAfterOctoExit: surviveExit,
+    });
+  }
+
+  private manage(childProcess: ChildProcess, options: OctoProcessOptions): OctoProcess {
+    const terminate = (opts: { graceMs?: number } = {}) => {
+      signalOctoProcess(octoProcess, "SIGTERM");
+      const timer = setTimeout(
+        () => signalOctoProcess(octoProcess, "SIGKILL"),
+        opts.graceMs ?? SIGKILL_GRACE_MS,
+      );
+      // The escalation timer must not keep the event loop alive on its own.
+      timer.unref?.();
+    };
+    const octoProcess: OctoProcess = {
+      ...options,
+      childProcess,
+      terminate,
+    };
+
+    this.processes.add(octoProcess);
+    octoProcess.childProcess.once("close", () => this.processes.delete(octoProcess));
+    if (!options.surviveAfterOctoExit) {
+      octoProcesses.add(octoProcess);
+      octoProcess.childProcess.once("close", () => octoProcesses.delete(octoProcess));
+    }
+    return octoProcess;
+  }
+}
+
+function signalOctoProcess(octoProcess: OctoProcess, signal: NodeJS.Signals) {
+  const childProcess = octoProcess.childProcess;
+  if (octoProcess.detached && childProcess.pid != null) {
+    try {
+      // Negative PID signals the whole process group
+      process.kill(-childProcess.pid, signal);
+      return;
+    } catch {
+      // Fall through to signaling just the process
+    }
+  }
+  try {
+    childProcess.kill(signal);
+  } catch {}
+}
+
+/** Terminate every exit-tracked process, escalating to SIGKILL. */
+export function killAllOctoProcesses(): void {
+  for (const octoProcess of [...octoProcesses]) {
+    octoProcess.terminate();
+  }
+}
+
+export function registerCleanup(cleanup: () => Promise<void> | void): () => void {
+  cleanups.add(cleanup);
+  return () => {
+    cleanups.delete(cleanup);
+  };
+}
+
+let cleanupsStarted = false;
+
+/**
+ * Run registered cleanups (bounded by a timeout so a hung cleanup can't block
+ * shutdown), then terminate remaining tracked processes. Only runs once.
+ */
+export async function runCleanups(): Promise<void> {
+  if (cleanupsStarted) return;
+  cleanupsStarted = true;
+
+  const work = (async () => {
+    for (const cleanup of [...cleanups]) {
+      try {
+        await cleanup();
+      } catch {
+        // Cleanup is best-effort during shutdown
+      }
+    }
+    killAllOctoProcesses();
+  })();
+
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      work,
+      new Promise<void>(resolve => {
+        timer = setTimeout(resolve, CLEANUP_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+let signalHandlersInstalled = false;
+let handlingTerminationSignal = false;
+
+/**
+ * On SIGINT/SIGTERM/SIGHUP, run cleanups and then re-raise the signal so the
+ * process dies with conventional signal semantics.
+ */
+export function installGlobalProcessSignalHandlers(): void {
+  if (signalHandlersInstalled) return;
+  signalHandlersInstalled = true;
+
+  process.once("exit", () => {
+    for (const octoProcess of [...octoProcesses]) {
+      signalOctoProcess(octoProcess, "SIGKILL");
+    }
+  });
+
+  for (const signal of TERMINATION_SIGNALS) {
+    process.once(signal, () => {
+      void handleTerminationSignal(signal);
+    });
+  }
+}
+
+async function handleTerminationSignal(signal: TerminationSignal): Promise<void> {
+  if (handlingTerminationSignal) return;
+  handlingTerminationSignal = true;
+
+  try {
+    await runCleanups();
+  } finally {
+    const forceExit = setTimeout(() => {
+      process.exit(SIGNAL_EXIT_CODES[signal]);
+    }, FORCE_EXIT_FALLBACK_MS);
+    forceExit.unref?.();
+
+    process.kill(process.pid, signal);
+  }
+}

--- a/source/octo-process.ts
+++ b/source/octo-process.ts
@@ -1,20 +1,26 @@
 import {
   execFile,
   spawn,
-  ChildProcess,
+  type ChildProcess,
   type ExecFileException,
   type ExecFileOptions,
   type SpawnOptions,
 } from "child_process";
+import { EventEmitter } from "events";
+import type { Readable, Writable } from "stream";
+import { registry } from "antipattern";
+import { sleep } from "./sleep.ts";
 
 /**
- * Child process lifecycle management, over `child_process`.
- *
- * All spawning goes through {@link OctoProcessManager}, so spawned processes
+ * Spawning child processes should go through {@link OctoProcessManager}, so all processes
  * can be terminated when Octo exits (unless spawned with
- * `surviveAfterOctoExit`). {@link registerCleanup} and
- * {@link installGlobalProcessSignalHandlers} run shutdown logic even on
- * SIGINT/SIGTERM/SIGHUP, where `try/finally` blocks never run.
+ * `surviveAfterOctoExit`). {@link OctoProcessManager.registerCleanup} and
+ * {@link OctoProcessManager.installGlobalProcessSignalHandlers} run shutdown
+ * logic even on SIGINT/SIGTERM/SIGHUP
+ *
+ * Each manager owns its own tracked processes and cleanups; call sites should
+ * generally use the shared instance from {@link processes} rather than
+ * constructing their own, so tests can mock out process management entirely.
  */
 
 type OctoProcessOptions = {
@@ -27,22 +33,60 @@ type OctoProcessOptions = {
   surviveAfterOctoExit?: boolean;
 };
 
-export class OctoProcess extends ChildProcess {
+export type OctoProcessEvents = {
+  /** The process could not be spawned or was killed by a signal. */
+  error: [error: Error];
+  /** The process successfully spawned. */
+  spawn: [];
+  /** The process ended on its own. */
+  exit: [code: number | null, signal: NodeJS.Signals | null];
+  /** The process ended and its stdio streams have closed. */
+  close: [code: number | null, signal: NodeJS.Signals | null];
+};
+
+export class OctoProcess extends EventEmitter<OctoProcessEvents> {
   /** signal the whole process group on terminate */
-  declare detached?: boolean;
+  readonly detached?: boolean;
   /** don't kill when Octo exits */
-  declare surviveAfterOctoExit?: boolean;
+  readonly surviveAfterOctoExit?: boolean;
+
+  private readonly childProcess: ChildProcess;
+
+  readonly stdin: Writable | null;
+  readonly stdout: Readable | null;
+  readonly stderr: Readable | null;
 
   constructor(childProcess: ChildProcess, options: OctoProcessOptions) {
     super();
-    // Since Node creates processes via factories (spawn), we can't use `extends` directly
-    const octoProcess = childProcess as OctoProcess;
-    Object.setPrototypeOf(octoProcess, OctoProcess.prototype);
-    octoProcess.detached = options.detached;
-    octoProcess.surviveAfterOctoExit = options.surviveAfterOctoExit;
-    return octoProcess;
+    this.childProcess = childProcess;
+    this.detached = options.detached;
+    this.surviveAfterOctoExit = options.surviveAfterOctoExit;
+    this.stdin = childProcess.stdin;
+    this.stdout = childProcess.stdout;
+    this.stderr = childProcess.stderr;
+
+    childProcess.on("error", error => this.emit("error", error));
+    childProcess.on("spawn", () => this.emit("spawn"));
+    childProcess.on("exit", (code, signal) => this.emit("exit", code, signal));
+    childProcess.on("close", (code, signal) => this.emit("close", code, signal));
   }
 
+  /** The process's PID, like `ChildProcess.pid`. */
+  get pid(): number | undefined {
+    return this.childProcess.pid;
+  }
+
+  /** Send a signal to the process, like `ChildProcess.kill`. */
+  kill(signal?: NodeJS.Signals | number): boolean {
+    return this.childProcess.kill(signal);
+  }
+
+  /** Allow the parent to exit independently of this process, like `ChildProcess.unref`. */
+  unref(): void {
+    this.childProcess.unref();
+  }
+
+  /** Send SIGTERM, escalating to SIGKILL after the grace period (default 1s). */
   terminate(opts: { graceMs?: number } = {}): void {
     signalOctoProcess(this, "SIGTERM");
     const timer = setTimeout(
@@ -64,9 +108,7 @@ export type OctoExecFileCallback = (
   stderr: string | Buffer,
 ) => void;
 
-const octoProcesses = new Set<OctoProcess>();
-
-const cleanups = new Set<() => Promise<void> | void>();
+type Cleanup = () => Promise<void> | void;
 
 const SIGKILL_GRACE_MS = 1000;
 const CLEANUP_TIMEOUT_MS = 5000;
@@ -84,12 +126,16 @@ const SIGNAL_EXIT_CODES: Record<TerminationSignal, number> = {
 
 /**
  * The only way to spawn child processes: like `child_process.spawn`/
- * `child_process.execFile`, but everything spawned is tracked here (for
- * {@link OctoProcessManager.terminateAll}) and in the exit-time registry,
+ * `child_process.execFile`, but everything spawned is tracked by the manager
+ * (for {@link OctoProcessManager.terminateAll} and exit-time termination),
  * and is untracked automatically when it closes.
  */
 export class OctoProcessManager {
   private readonly processes = new Set<OctoProcess>();
+  private readonly cleanups = new Set<Cleanup>();
+  private cleanupsStarted = false;
+  private signalHandlersInstalled = false;
+  private handlingTerminationSignal = false;
 
   /** Terminate every process this manager spawned that is still running. */
   terminateAll(opts: { graceMs?: number } = {}): void {
@@ -155,11 +201,86 @@ export class OctoProcessManager {
 
     this.processes.add(octoProcess);
     octoProcess.once("close", () => this.processes.delete(octoProcess));
-    if (!options.surviveAfterOctoExit) {
-      octoProcesses.add(octoProcess);
-      octoProcess.once("close", () => octoProcesses.delete(octoProcess));
-    }
     return octoProcess;
+  }
+
+  /** Tracked processes that should die when Octo exits. */
+  private exitTrackedProcesses(): OctoProcess[] {
+    return [...this.processes].filter(octoProcess => !octoProcess.surviveAfterOctoExit);
+  }
+
+  /** Terminate every exit-tracked process, escalating to SIGKILL. */
+  private shutdownChildProcesses(): void {
+    for (const octoProcess of this.exitTrackedProcesses()) {
+      octoProcess.terminate();
+    }
+  }
+
+  /** Register a cleanup to run during shutdown; returns an unregister function. */
+  registerCleanup(cleanup: Cleanup): () => void {
+    this.cleanups.add(cleanup);
+    return () => {
+      this.cleanups.delete(cleanup);
+    };
+  }
+
+  /**
+   * Run registered cleanups (bounded by a timeout so a hung cleanup can't block
+   * shutdown), then terminate remaining exit-tracked processes. Only runs once.
+   */
+  async runCleanups(): Promise<void> {
+    if (this.cleanupsStarted) return;
+    this.cleanupsStarted = true;
+
+    const cleanupFns = (async () => {
+      for (const cleanup of [...this.cleanups]) {
+        try {
+          await cleanup();
+        } catch {
+          // Cleanup is best-effort during shutdown
+        }
+      }
+      this.shutdownChildProcesses();
+    })();
+
+    await Promise.race([cleanupFns, sleep(CLEANUP_TIMEOUT_MS)]);
+  }
+
+  /**
+   * On SIGINT/SIGTERM/SIGHUP, run cleanups and then re-raise the signal so the
+   * process dies with conventional signal semantics.
+   */
+  installGlobalProcessSignalHandlers(): void {
+    if (this.signalHandlersInstalled) return;
+    this.signalHandlersInstalled = true;
+
+    process.once("exit", () => {
+      for (const octoProcess of this.exitTrackedProcesses()) {
+        signalOctoProcess(octoProcess, "SIGKILL");
+      }
+    });
+
+    for (const signal of TERMINATION_SIGNALS) {
+      process.once(signal, () => {
+        void this.handleTerminationSignal(signal);
+      });
+    }
+  }
+
+  private async handleTerminationSignal(signal: TerminationSignal): Promise<void> {
+    if (this.handlingTerminationSignal) return;
+    this.handlingTerminationSignal = true;
+
+    try {
+      await this.runCleanups();
+    } finally {
+      const forceExit = setTimeout(() => {
+        process.exit(SIGNAL_EXIT_CODES[signal]);
+      }, FORCE_EXIT_FALLBACK_MS);
+      forceExit.unref?.();
+
+      process.kill(process.pid, signal);
+    }
   }
 }
 
@@ -178,90 +299,14 @@ function signalOctoProcess(octoProcess: OctoProcess, signal: NodeJS.Signals) {
   } catch {}
 }
 
-/** Terminate every exit-tracked process, escalating to SIGKILL. */
-export function killAllOctoProcesses(): void {
-  for (const octoProcess of [...octoProcesses]) {
-    octoProcess.terminate();
-  }
-}
-
-export function registerCleanup(cleanup: () => Promise<void> | void): () => void {
-  cleanups.add(cleanup);
-  return () => {
-    cleanups.delete(cleanup);
-  };
-}
-
-let cleanupsStarted = false;
+const manager = new OctoProcessManager();
 
 /**
- * Run registered cleanups (bounded by a timeout so a hung cleanup can't block
- * shutdown), then terminate remaining tracked processes. Only runs once.
+ * The shared process manager used throughout the app. In tests, mock out all
+ * process management with `withMock(processes, "manager", () => mock, cb)`.
  */
-export async function runCleanups(): Promise<void> {
-  if (cleanupsStarted) return;
-  cleanupsStarted = true;
-
-  const work = (async () => {
-    for (const cleanup of [...cleanups]) {
-      try {
-        await cleanup();
-      } catch {
-        // Cleanup is best-effort during shutdown
-      }
-    }
-    killAllOctoProcesses();
-  })();
-
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    await Promise.race([
-      work,
-      new Promise<void>(resolve => {
-        timer = setTimeout(resolve, CLEANUP_TIMEOUT_MS);
-      }),
-    ]);
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-let signalHandlersInstalled = false;
-let handlingTerminationSignal = false;
-
-/**
- * On SIGINT/SIGTERM/SIGHUP, run cleanups and then re-raise the signal so the
- * process dies with conventional signal semantics.
- */
-export function installGlobalProcessSignalHandlers(): void {
-  if (signalHandlersInstalled) return;
-  signalHandlersInstalled = true;
-
-  process.once("exit", () => {
-    for (const octoProcess of [...octoProcesses]) {
-      signalOctoProcess(octoProcess, "SIGKILL");
-    }
-  });
-
-  for (const signal of TERMINATION_SIGNALS) {
-    process.once(signal, () => {
-      void handleTerminationSignal(signal);
-    });
-  }
-}
-
-async function handleTerminationSignal(signal: TerminationSignal): Promise<void> {
-  if (handlingTerminationSignal) return;
-  handlingTerminationSignal = true;
-
-  try {
-    await runCleanups();
-  } finally {
-    const forceExit = setTimeout(() => {
-      process.exit(SIGNAL_EXIT_CODES[signal]);
-    }, FORCE_EXIT_FALLBACK_MS);
-    forceExit.unref?.();
-
-    process.kill(process.pid, signal);
-  }
-}
+export const processes = registry({
+  manager: () => {
+    return manager;
+  },
+});

--- a/source/octo-process.ts
+++ b/source/octo-process.ts
@@ -1,7 +1,7 @@
 import {
   execFile,
   spawn,
-  type ChildProcess,
+  ChildProcess,
   type ExecFileException,
   type ExecFileOptions,
   type SpawnOptions,
@@ -10,9 +10,9 @@ import {
 /**
  * Child process lifecycle management, over `child_process`.
  *
- * All spawning goes through {@link OctoProcessManager}; every process it
- * spawns carries a `terminate` callback and is terminated when Octo exits
- * (unless spawned with `surviveExit`). {@link registerCleanup} and
+ * All spawning goes through {@link OctoProcessManager}, so spawned processes
+ * can be terminated when Octo exits (unless spawned with
+ * `surviveAfterOctoExit`). {@link registerCleanup} and
  * {@link installGlobalProcessSignalHandlers} run shutdown logic even on
  * SIGINT/SIGTERM/SIGHUP, where `try/finally` blocks never run.
  */
@@ -27,10 +27,32 @@ type OctoProcessOptions = {
   surviveAfterOctoExit?: boolean;
 };
 
-export type OctoProcess = OctoProcessOptions & {
-  childProcess: ChildProcess;
-  terminate(opts?: { graceMs?: number }): void;
-};
+export class OctoProcess extends ChildProcess {
+  /** signal the whole process group on terminate */
+  declare detached?: boolean;
+  /** don't kill when Octo exits */
+  declare surviveAfterOctoExit?: boolean;
+
+  constructor(childProcess: ChildProcess, options: OctoProcessOptions) {
+    super();
+    // Since Node creates processes via factories (spawn), we can't use `extends` directly
+    const octoProcess = childProcess as OctoProcess;
+    Object.setPrototypeOf(octoProcess, OctoProcess.prototype);
+    octoProcess.detached = options.detached;
+    octoProcess.surviveAfterOctoExit = options.surviveAfterOctoExit;
+    return octoProcess;
+  }
+
+  terminate(opts: { graceMs?: number } = {}): void {
+    signalOctoProcess(this, "SIGTERM");
+    const timer = setTimeout(
+      () => signalOctoProcess(this, "SIGKILL"),
+      opts.graceMs ?? SIGKILL_GRACE_MS,
+    );
+    // The escalation timer must not keep the event loop alive on its own.
+    timer.unref?.();
+  }
+}
 
 export type OctoSpawnOptions = SpawnOptions & OctoProcessOptions;
 export type OctoExecFileOptions = ExecFileOptions & OctoProcessOptions;
@@ -129,44 +151,30 @@ export class OctoProcessManager {
   }
 
   private manage(childProcess: ChildProcess, options: OctoProcessOptions): OctoProcess {
-    const terminate = (opts: { graceMs?: number } = {}) => {
-      signalOctoProcess(octoProcess, "SIGTERM");
-      const timer = setTimeout(
-        () => signalOctoProcess(octoProcess, "SIGKILL"),
-        opts.graceMs ?? SIGKILL_GRACE_MS,
-      );
-      // The escalation timer must not keep the event loop alive on its own.
-      timer.unref?.();
-    };
-    const octoProcess: OctoProcess = {
-      ...options,
-      childProcess,
-      terminate,
-    };
+    const octoProcess = new OctoProcess(childProcess, options);
 
     this.processes.add(octoProcess);
-    octoProcess.childProcess.once("close", () => this.processes.delete(octoProcess));
+    octoProcess.once("close", () => this.processes.delete(octoProcess));
     if (!options.surviveAfterOctoExit) {
       octoProcesses.add(octoProcess);
-      octoProcess.childProcess.once("close", () => octoProcesses.delete(octoProcess));
+      octoProcess.once("close", () => octoProcesses.delete(octoProcess));
     }
     return octoProcess;
   }
 }
 
 function signalOctoProcess(octoProcess: OctoProcess, signal: NodeJS.Signals) {
-  const childProcess = octoProcess.childProcess;
-  if (octoProcess.detached && childProcess.pid != null) {
+  if (octoProcess.detached && octoProcess.pid != null) {
     try {
       // Negative PID signals the whole process group
-      process.kill(-childProcess.pid, signal);
+      process.kill(-octoProcess.pid, signal);
       return;
     } catch {
       // Fall through to signaling just the process
     }
   }
   try {
-    childProcess.kill(signal);
+    octoProcess.kill(signal);
   } catch {}
 }
 

--- a/source/transports/docker.ts
+++ b/source/transports/docker.ts
@@ -20,17 +20,16 @@ export async function manageContainer(args: string[]) {
     const octoProcess = octoProcessManager.spawn("docker", ["run", ...args], {
       stdio: ["ignore", "pipe", "inherit"],
     });
-    const childProcess = octoProcess.childProcess;
-    if (!childProcess.stdout) {
+    if (!octoProcess.stdout) {
       reject(new Error("Failed to spawn docker process with piped stdout"));
       return;
     }
-    childProcess.on("error", e => {
+    octoProcess.on("error", e => {
       error = true;
       reject(e);
     });
-    childProcess.stdout.on("data", data => stdout.push(data));
-    childProcess.on("close", code => {
+    octoProcess.stdout.on("data", data => stdout.push(data));
+    octoProcess.on("close", code => {
       if (code != null && code !== 0) {
         if (!error) reject("Command exited with non-zero exit code: " + code);
       } else if (!error) {
@@ -45,7 +44,7 @@ export async function manageContainer(args: string[]) {
   const killContainer = () => {
     try {
       const octoProcess = octoProcessManager.spawn("docker", ["kill", name], { stdio: "ignore" });
-      octoProcess.childProcess.unref();
+      octoProcess.unref();
     } catch {}
   };
   const unregisterCleanup = registerCleanup(killContainer);
@@ -78,8 +77,7 @@ async function runDockerCommand(
       timeout,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const childProcess = octoProcess.childProcess;
-    if (!childProcess.stdout || !childProcess.stderr) {
+    if (!octoProcess.stdout || !octoProcess.stderr) {
       reject(new Error("Failed to spawn docker process with piped stdio"));
       return;
     }
@@ -106,15 +104,15 @@ async function runDockerCommand(
       signal.removeEventListener("abort", onAbort);
     };
 
-    childProcess.stdout.on("data", data => {
+    octoProcess.stdout.on("data", data => {
       if (!output.append(data)) killChild();
     });
 
-    childProcess.stderr.on("data", data => {
+    octoProcess.stderr.on("data", data => {
       if (!output.append(data)) killChild();
     });
 
-    childProcess.on("close", code => {
+    octoProcess.on("close", code => {
       cleanup();
       if (aborted) {
         reject(new AbortError());
@@ -151,7 +149,7 @@ output: ${commandOutput}`,
       }
     });
 
-    childProcess.on("error", err => {
+    octoProcess.on("error", err => {
       cleanup();
       if (aborted) {
         reject(new AbortError());

--- a/source/transports/docker.ts
+++ b/source/transports/docker.ts
@@ -1,4 +1,3 @@
-import { spawn } from "child_process";
 import {
   Transport,
   AbortError,
@@ -7,24 +6,31 @@ import {
   ShellOutput,
   TransportError,
 } from "./transport-common.ts";
+import { OctoProcessManager, registerCleanup } from "../octo-process.ts";
 
 export async function manageContainer(args: string[]) {
   console.log("Spawning Docker container...");
 
+  const octoProcessManager = new OctoProcessManager();
   const { stdout } = await new Promise<{
     stdout: string;
   }>((resolve, reject) => {
     const stdout: string[] = [];
     let error = false;
-    const child = spawn("docker", ["run", ...args], {
+    const octoProcess = octoProcessManager.spawn("docker", ["run", ...args], {
       stdio: ["ignore", "pipe", "inherit"],
     });
-    child.on("error", e => {
+    const childProcess = octoProcess.childProcess;
+    if (!childProcess.stdout) {
+      reject(new Error("Failed to spawn docker process with piped stdout"));
+      return;
+    }
+    childProcess.on("error", e => {
       error = true;
       reject(e);
     });
-    child.stdout.on("data", data => stdout.push(data));
-    child.on("close", code => {
+    childProcess.stdout.on("data", data => stdout.push(data));
+    childProcess.on("close", code => {
       if (code != null && code !== 0) {
         if (!error) reject("Command exited with non-zero exit code: " + code);
       } else if (!error) {
@@ -36,10 +42,21 @@ export async function manageContainer(args: string[]) {
   });
 
   const name = stdout.trim();
+  const killContainer = () => {
+    try {
+      const octoProcess = octoProcessManager.spawn("docker", ["kill", name], { stdio: "ignore" });
+      octoProcess.childProcess.unref();
+    } catch {}
+  };
+  const unregisterCleanup = registerCleanup(killContainer);
+  let closed = false;
   return {
     container: name,
     close: async () => {
-      spawn("docker", ["kill", name]);
+      if (closed) return;
+      closed = true;
+      unregisterCleanup();
+      killContainer();
     },
   };
 }
@@ -57,10 +74,15 @@ async function runDockerCommand(
   const dockerCmd = ["docker", "exec", container, "/bin/sh", "-c", command.join(" ")];
 
   return new Promise<string>((resolve, reject) => {
-    const child = spawn(dockerCmd[0], dockerCmd.slice(1), {
+    const octoProcess = new OctoProcessManager().spawn(dockerCmd[0], dockerCmd.slice(1), {
       timeout,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    const childProcess = octoProcess.childProcess;
+    if (!childProcess.stdout || !childProcess.stderr) {
+      reject(new Error("Failed to spawn docker process with piped stdio"));
+      return;
+    }
 
     const output = new ShellOutput();
     let aborted = false;
@@ -69,14 +91,7 @@ async function runDockerCommand(
     const killChild = () => {
       if (killed) return;
       killed = true;
-      // Try graceful termination first
-      child.kill("SIGTERM");
-      // Fallback to SIGKILL if it doesn't exit quickly
-      setTimeout(() => {
-        try {
-          child.kill("SIGKILL");
-        } catch {}
-      }, 500).unref?.();
+      octoProcess.terminate({ graceMs: 500 });
     };
 
     const onAbort = () => {
@@ -91,15 +106,15 @@ async function runDockerCommand(
       signal.removeEventListener("abort", onAbort);
     };
 
-    child.stdout.on("data", data => {
+    childProcess.stdout.on("data", data => {
       if (!output.append(data)) killChild();
     });
 
-    child.stderr.on("data", data => {
+    childProcess.stderr.on("data", data => {
       if (!output.append(data)) killChild();
     });
 
-    child.on("close", code => {
+    childProcess.on("close", code => {
       cleanup();
       if (aborted) {
         reject(new AbortError());
@@ -136,7 +151,7 @@ output: ${commandOutput}`,
       }
     });
 
-    child.on("error", err => {
+    childProcess.on("error", err => {
       cleanup();
       if (aborted) {
         reject(new AbortError());

--- a/source/transports/docker.ts
+++ b/source/transports/docker.ts
@@ -6,12 +6,12 @@ import {
   ShellOutput,
   TransportError,
 } from "./transport-common.ts";
-import { OctoProcessManager, registerCleanup } from "../octo-process.ts";
+import { processes } from "../octo-process.ts";
 
 export async function manageContainer(args: string[]) {
   console.log("Spawning Docker container...");
 
-  const octoProcessManager = new OctoProcessManager();
+  const octoProcessManager = processes.manager();
   const { stdout } = await new Promise<{
     stdout: string;
   }>((resolve, reject) => {
@@ -47,7 +47,7 @@ export async function manageContainer(args: string[]) {
       octoProcess.unref();
     } catch {}
   };
-  const unregisterCleanup = registerCleanup(killContainer);
+  const unregisterCleanup = octoProcessManager.registerCleanup(killContainer);
   let closed = false;
   return {
     container: name,
@@ -73,7 +73,7 @@ async function runDockerCommand(
   const dockerCmd = ["docker", "exec", container, "/bin/sh", "-c", command.join(" ")];
 
   return new Promise<string>((resolve, reject) => {
-    const octoProcess = new OctoProcessManager().spawn(dockerCmd[0], dockerCmd.slice(1), {
+    const octoProcess = processes.manager().spawn(dockerCmd[0], dockerCmd.slice(1), {
       timeout,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/source/transports/local.ts
+++ b/source/transports/local.ts
@@ -8,7 +8,7 @@ import {
   ShellOutput,
   TransportError,
 } from "./transport-common.ts";
-import { processes } from "../octo-process.ts";
+import { OctoProcessManager } from "../octo-process.ts";
 
 const KILL_GRACE_MS = 500;
 
@@ -16,7 +16,7 @@ const STRIPPED_ENV_VARS = ["NODE_ENV", "NAPI_RS_NATIVE_LIBRARY_PATH", "CANARY_OC
 
 export class LocalTransport implements Transport {
   cwd = process.cwd();
-  private readonly octoProcessManager = processes.manager();
+  private readonly octoProcessManager = new OctoProcessManager();
 
   async close() {
     this.octoProcessManager.terminateAll({ graceMs: KILL_GRACE_MS });

--- a/source/transports/local.ts
+++ b/source/transports/local.ts
@@ -8,7 +8,7 @@ import {
   ShellOutput,
   TransportError,
 } from "./transport-common.ts";
-import { OctoProcessManager } from "../octo-process.ts";
+import { processes } from "../octo-process.ts";
 
 const KILL_GRACE_MS = 500;
 
@@ -16,7 +16,7 @@ const STRIPPED_ENV_VARS = ["NODE_ENV", "NAPI_RS_NATIVE_LIBRARY_PATH", "CANARY_OC
 
 export class LocalTransport implements Transport {
   cwd = process.cwd();
-  private readonly octoProcessManager = new OctoProcessManager();
+  private readonly octoProcessManager = processes.manager();
 
   async close() {
     this.octoProcessManager.terminateAll({ graceMs: KILL_GRACE_MS });

--- a/source/transports/local.ts
+++ b/source/transports/local.ts
@@ -1,6 +1,5 @@
 import fs from "fs/promises";
 import path from "path";
-import { spawn } from "child_process";
 import {
   Transport,
   AbortError,
@@ -9,13 +8,19 @@ import {
   ShellOutput,
   TransportError,
 } from "./transport-common.ts";
+import { OctoProcessManager } from "../octo-process.ts";
+
+const KILL_GRACE_MS = 500;
 
 const STRIPPED_ENV_VARS = ["NODE_ENV", "NAPI_RS_NATIVE_LIBRARY_PATH", "CANARY_OCTO"];
 
 export class LocalTransport implements Transport {
   cwd = process.cwd();
+  private readonly octoProcessManager = new OctoProcessManager();
 
-  async close() {}
+  async close() {
+    this.octoProcessManager.terminateAll({ graceMs: KILL_GRACE_MS });
+  }
 
   async writeFile(_: AbortSignal, file: string, contents: string) {
     return await fs.writeFile(file, contents, "utf8");
@@ -88,13 +93,19 @@ export class LocalTransport implements Transport {
     return new Promise<string>((resolve, reject) => {
       const env = { ...process.env };
       for (const name of STRIPPED_ENV_VARS) delete env[name];
-      const child = spawn(cmd, {
+
+      const octoProcess = this.octoProcessManager.spawn(cmd, {
         cwd: process.cwd(),
         shell: "bash",
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
         env,
       });
+      const childProcess = octoProcess.childProcess;
+      if (!childProcess.stdout || !childProcess.stderr) {
+        reject(new Error("Failed to spawn shell process with piped stdio"));
+        return;
+      }
 
       const output = new ShellOutput();
       let aborted = false;
@@ -104,24 +115,7 @@ export class LocalTransport implements Transport {
       function killGroup() {
         if (killed) return;
         killed = true;
-        // Kill the entire process group to handle child processes
-        try {
-          // First, try to kill the process group with SIGTERM
-          process.kill(-child.pid!, "SIGTERM");
-        } catch (e) {
-          // Fallback to just killing the main process if process group doesn't exist
-          child.kill("SIGTERM");
-        }
-        // Fallback to SIGKILL if it doesn't exit quickly
-        setTimeout(() => {
-          try {
-            process.kill(-child.pid!, "SIGKILL");
-          } catch {
-            try {
-              child.kill("SIGKILL");
-            } catch {}
-          }
-        }, 500).unref?.();
+        octoProcess.terminate({ graceMs: KILL_GRACE_MS });
       }
 
       function onAbort() {
@@ -142,15 +136,15 @@ export class LocalTransport implements Transport {
       if (signal.aborted) onAbort();
       signal.addEventListener("abort", onAbort);
 
-      child.stdout.on("data", data => {
+      childProcess.stdout.on("data", data => {
         if (!output.append(data)) killGroup();
       });
 
-      child.stderr.on("data", data => {
+      childProcess.stderr.on("data", data => {
         if (!output.append(data)) killGroup();
       });
 
-      child.on("close", code => {
+      childProcess.on("close", code => {
         cleanup();
         if (aborted) {
           reject(new AbortError());
@@ -196,7 +190,7 @@ output: ${commandOutput}`,
         }
       });
 
-      child.on("error", err => {
+      childProcess.on("error", err => {
         cleanup();
         if (aborted) {
           reject(new AbortError());

--- a/source/transports/local.ts
+++ b/source/transports/local.ts
@@ -101,8 +101,7 @@ export class LocalTransport implements Transport {
         detached: true,
         env,
       });
-      const childProcess = octoProcess.childProcess;
-      if (!childProcess.stdout || !childProcess.stderr) {
+      if (!octoProcess.stdout || !octoProcess.stderr) {
         reject(new Error("Failed to spawn shell process with piped stdio"));
         return;
       }
@@ -136,15 +135,15 @@ export class LocalTransport implements Transport {
       if (signal.aborted) onAbort();
       signal.addEventListener("abort", onAbort);
 
-      childProcess.stdout.on("data", data => {
+      octoProcess.stdout.on("data", data => {
         if (!output.append(data)) killGroup();
       });
 
-      childProcess.stderr.on("data", data => {
+      octoProcess.stderr.on("data", data => {
         if (!output.append(data)) killGroup();
       });
 
-      childProcess.on("close", code => {
+      octoProcess.on("close", code => {
         cleanup();
         if (aborted) {
           reject(new AbortError());
@@ -190,7 +189,7 @@ output: ${commandOutput}`,
         }
       });
 
-      childProcess.on("error", err => {
+      octoProcess.on("error", err => {
         cleanup();
         if (aborted) {
           reject(new AbortError());


### PR DESCRIPTION
To prepare for the background process tool in octo, making an OctoProcessManager to keep track of and clean up processes (on Octo exit).

~TODO~
~- [x] add a PR stacked ontop of this with eslint to ensure that you can't import from `"child_process"` directly (only use OctoProcessManager)~