### PR TITLE
Autofix more tool pairing bugs

### DIFF
--- a/source/session-history/tool-pairing.test.ts
+++ b/source/session-history/tool-pairing.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import {
+  assertToolCallPairing,
+  findToolPairingViolations,
+  repairOrphanedToolOutputs,
+} from "./tool-pairing.ts";
+import type { HistoryNode } from "./index.ts";
+import { compilerUsage } from "../libocto/compilers/compiler-interface.ts";
+import type { ToolCall } from "../libocto/tool-def.ts";
+import type { OctoIR } from "../ir/octo-ir.ts";
+import type toolMap from "../tools/tool-defs/index.ts";
+
+type ShellToolCall = Extract<ToolCall<typeof toolMap>, { name: "shell" }>;
+
+let nextNodeId = 1;
+
+function node(ir: OctoIR): HistoryNode {
+  return { type: "llm-ir", nodeId: nextNodeId++, modelJson: null, ir };
+}
+
+function shellCall(id: string, cmd: string): ShellToolCall {
+  return {
+    type: "tool-call",
+    name: "shell",
+    toolCallId: id,
+    original: { cmd, timeout: 60_000 },
+    parsed: { cmd, timeout: 60_000 },
+  };
+}
+
+function assistantNode(calls: ShellToolCall[]): HistoryNode {
+  return node({
+    role: "assistant",
+    content: "On it.",
+    usage: compilerUsage(0, 0),
+    toolCalls: calls,
+  });
+}
+
+function toolOutputNode(call: ShellToolCall): HistoryNode {
+  return node({
+    role: "tool-output",
+    toolCall: call,
+    content: [{ type: "text", content: "done" }],
+  });
+}
+
+function toolValidationErrorNode(call: ShellToolCall): HistoryNode {
+  return node({
+    role: "tool-validation-error",
+    toolCall: call,
+    error: "invalid arguments",
+    aborted: false,
+  });
+}
+
+function expectRepairedToUser(
+  item: HistoryNode,
+): HistoryNode & { type: "llm-ir"; ir: Extract<OctoIR, { role: "user" }> } {
+  if (item.type !== "llm-ir" || item.ir.role !== "user") {
+    throw new Error(`Expected a user message, got ${JSON.stringify(item)}`);
+  }
+  return item as HistoryNode & { type: "llm-ir"; ir: Extract<OctoIR, { role: "user" }> };
+}
+
+describe("repairOrphanedToolOutputs", () => {
+  it("leaves well-ordered tool call/answer pairs untouched", () => {
+    const callA = shellCall("shell:1", "echo a");
+    const callB = shellCall("shell:2", "echo b");
+    const history = [
+      assistantNode([callA, callB]),
+      toolOutputNode(callA),
+      toolValidationErrorNode(callB),
+    ];
+
+    expect(repairOrphanedToolOutputs(history)).toEqual(history);
+    expect(() => assertToolCallPairing(history)).not.toThrow();
+  });
+
+  it("repairs an orphan answer whose call appears nowhere in history", () => {
+    const history = [toolValidationErrorNode(shellCall("shell:9", "echo lost"))];
+
+    const repaired = repairOrphanedToolOutputs(history);
+    expect(repaired).toHaveLength(1);
+    const userItem = expectRepairedToUser(repaired[0]);
+    expect(userItem.ir.role).toBe("user");
+    expect(() => assertToolCallPairing(repaired)).not.toThrow();
+  });
+
+  /*
+   * Regression test: providers recycle tool call IDs across turns (e.g. per-response counters
+   * like edit:215). When an old dangled answer's ID is later reused by an unrelated assistant
+   * turn, the recycled call can't pair with the earlier answer: answers compile to tool messages
+   * that must resolve to a preceding tool_call, and the recycled call precedes none of them it
+   * didn't request. The stale answer must still be repaired, and the recycled pair left alone.
+   */
+  it("repairs an orphan answer whose ID is recycled by a later call", () => {
+    const orphan = toolValidationErrorNode(shellCall("edit:215", "echo orphaned"));
+    const recycledCall = shellCall("edit:215", "echo recycled");
+    const recycledOther = shellCall("edit:216", "echo also recycled");
+    const history = [
+      orphan,
+      assistantNode([recycledCall, recycledOther]),
+      toolOutputNode(recycledCall),
+      toolOutputNode(recycledOther),
+    ];
+
+    // Pre-repair, the recycled ID hides the orphan from anywhere-in-history checks: the only
+    // detectable violation is ordering.
+    const violations = findToolPairingViolations(history);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].problem).toContain("ordering violation");
+
+    const repaired = repairOrphanedToolOutputs(history);
+    expect(repaired).toHaveLength(4);
+
+    // The orphan answer becomes a user message mentioning the failure.
+    const userItem = expectRepairedToUser(repaired[0]);
+    expect(userItem.ir.role).toBe("user");
+    const text = userItem.ir.content
+      .map(part => (part.type === "text" ? part.content : ""))
+      .join("\n");
+    expect(text).toContain("invalid arguments");
+
+    // The recycled call/answer pairs are untouched.
+    expect(repaired[1].type === "llm-ir" && repaired[1].ir.role).toBe("assistant");
+    expect(repaired[2].type === "llm-ir" && repaired[2].ir.role).toBe("tool-output");
+    expect(repaired[3].type === "llm-ir" && repaired[3].ir.role).toBe("tool-output");
+
+    expect(() => assertToolCallPairing(repaired)).not.toThrow();
+  });
+
+  it("leaves a recycled ID's answers paired with an earlier call untouched", () => {
+    const first = shellCall("call_0", "echo first");
+    const second = shellCall("call_0", "echo second");
+    const history = [
+      assistantNode([first]),
+      toolOutputNode(first),
+      assistantNode([second]),
+      toolOutputNode(second),
+    ];
+
+    expect(repairOrphanedToolOutputs(history)).toEqual(history);
+    expect(() => assertToolCallPairing(history)).not.toThrow();
+  });
+});

--- a/source/session-history/tool-pairing.ts
+++ b/source/session-history/tool-pairing.ts
@@ -100,22 +100,26 @@ export function findToolPairingViolations(history: readonly HistoryNode[]): Pair
  *
  * Orphan answers are converted into user messages: a user message is always legal for any
  * backend, keeps the information visible to the model, and synthesizes no assistant history.
- * Only true orphans are repaired — answers whose tool call appears nowhere in history. Any
- * remaining violation is an unknown bug and is left for assertToolCallPairing to report loudly.
+ *
+ * An answer is orphaned when no assistant call with its ID precedes it: answers are only ever
+ * appended after the call they answer, so a matching call later in history can never pair with
+ * it. That can happen because provider-generated IDs are only unique within a single response
+ * and some providers recycle IDs across turns — a later turn can coincidentally reuse the ID of
+ * an answer whose original call was sliced away. Only true orphans are repaired; any remaining
+ * violation is an unknown bug and is left for assertToolCallPairing to report loudly.
  */
 export function repairOrphanedToolOutputs(history: readonly HistoryNode[]): HistoryNode[] {
-  const requestedIds = new Set<string>();
-  for (const item of history) {
-    if (item.type !== "llm-ir" || item.ir.role !== "assistant") continue;
-    for (const call of item.ir.toolCalls ?? []) {
-      requestedIds.add(call.toolCallId);
-    }
-  }
-
+  const precedingCallIds = new Set<string>();
   return history.map(item => {
     if (item.type !== "llm-ir") return item;
+    if (item.ir.role === "assistant") {
+      for (const call of item.ir.toolCalls ?? []) {
+        precedingCallIds.add(call.toolCallId);
+      }
+      return item;
+    }
     const callId = answeredToolCallId(item.ir as any);
-    if (callId == null || requestedIds.has(callId)) return item;
+    if (callId == null || precedingCallIds.has(callId)) return item;
     return { ...item, ir: orphanAnswerToUserMessage(item.ir) };
   });
 }


### PR DESCRIPTION
I found a couple more tool pairing bugs thanks to our canary builds now throwing errors on tool pairing issues. While Octo *no longer generates these*, old sessions might still have them stored in the DB, so it's worth autofixing. This autofixes the ones I found and adds tests.