### PR TITLE
Memoize input

### DIFF
--- a/source/components/input-with-history.tsx
+++ b/source/components/input-with-history.tsx
@@ -20,7 +20,7 @@ interface Props {
   vimMode?: "NORMAL" | "INSERT";
   setVimMode?: (mode: "NORMAL" | "INSERT") => void;
 }
-export const InputWithHistory = (props: Props) => {
+export const InputWithHistory = React.memo((props: Props) => {
   const themeColor = useColor();
   const [currentIndex, setCurrentIndex] = useState(-1);
   const [originalInput, setOriginalInput] = useState("");
@@ -188,7 +188,8 @@ export const InputWithHistory = (props: Props) => {
       </TerminalFlex>
     </TerminalFlex>
   );
-};
+});
+
 function replaceSelectedMentions(input: string, selectedSuggestions: Set<string>): string {
   let output = input;
   for (const filename of selectedSuggestions) {


### PR DESCRIPTION
Tiny perf improvement, although I think it does help typing latency — uses `React.memo` to prevent re-rendering the input box unless the props change. We used to do this, but an Ink upgrade broke it (due to a React bug! `useEffectEvent` is known-broken when used inside React.memo, and Ink swapped their text input to be based on `useEffectEvent`).

Since Paintcannon doesn't rely on `useEffectEvent`, we can memoize this again.