### PR TITLE
Fix disappearing input during tool calls

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -717,50 +717,12 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
     },
     [query, modeData.mode, config, transport, session, setQuery, showToast],
   );
-  if (modeData.mode === "error-recovery") return <Loading />;
-  if (modeData.mode === "payment-error") {
-    return <PaymentErrorScreen error={modeData.error} />;
-  }
-  if (modeData.mode === "rate-limit-error") {
-    return <RateLimitErrorScreen error={modeData.error} />;
-  }
-  if (modeData.mode === "auth-error") {
-    return (
-      <AuthErrorScreen
-        model={modeData.model}
-        error={modeData.error}
-        config={config}
-        transport={transport}
-        session={session}
-      />
-    );
-  }
-  if (modeData.mode === "request-error") {
-    return (
-      <RequestErrorScreen
-        mode="request-error"
-        contextualMessage="It looks like you've hit a request error!"
-        error={modeData.error}
-        curlCommand={modeData.curlCommand}
-      />
-    );
-  }
-  if (modeData.mode === "compaction-error") {
-    return (
-      <RequestErrorScreen
-        mode="compaction-error"
-        contextualMessage="History compaction failed due to a request error!"
-        error={modeData.error}
-        curlCommand={modeData.curlCommand}
-      />
-    );
-  }
-  if (!inputFieldAvailable(modeData)) return null;
   if (
     modeData.mode === "responding" ||
     modeData.mode === "compacting" ||
     modeData.mode === "diff-apply" ||
-    modeData.mode === "fix-json"
+    modeData.mode === "fix-json" ||
+    modeData.mode === "tool-call"
   ) {
     const overrideStrings = (() => {
       if (modeData.mode === "compacting") return ["Compacting history to save context tokens"];
@@ -819,32 +781,46 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
       </TerminalFlex>
     );
   }
-  if (modeData.mode === "tool-call") {
+  if (modeData.mode === "error-recovery") return <Loading />;
+  if (modeData.mode === "payment-error") {
+    return <PaymentErrorScreen error={modeData.error} />;
+  }
+  if (modeData.mode === "rate-limit-error") {
+    return <RateLimitErrorScreen error={modeData.error} />;
+  }
+  if (modeData.mode === "auth-error") {
     return (
-      <TerminalFlex
-        style={{
-          flexDirection: "column",
-        }}
-      >
-        <QueuedUserMessages messages={queuedMessages} />
-        <MultimediaInput
-          inputHistory={inputHistory}
-          value={query}
-          onChange={setQuery}
-          attachedImages={attachedImages}
-          addAttachedImage={addAttachedImage}
-          removeLastAttachedImage={removeLastAttachedImage}
-          clearAttachedImages={clearAttachedImages}
-          onSubmit={onSubmit}
-          vimEnabled={vimEnabled}
-          vimMode={vimMode}
-          setVimMode={setVimMode}
-          modalities={model.modalities}
-        />
-        <VimModeIndicator vimEnabled={vimEnabled} vimMode={vimMode} />
-      </TerminalFlex>
+      <AuthErrorScreen
+        model={modeData.model}
+        error={modeData.error}
+        config={config}
+        transport={transport}
+        session={session}
+      />
     );
   }
+  if (modeData.mode === "request-error") {
+    return (
+      <RequestErrorScreen
+        mode="request-error"
+        contextualMessage="It looks like you've hit a request error!"
+        error={modeData.error}
+        curlCommand={modeData.curlCommand}
+      />
+    );
+  }
+  if (modeData.mode === "compaction-error") {
+    return (
+      <RequestErrorScreen
+        mode="compaction-error"
+        contextualMessage="History compaction failed due to a request error!"
+        error={modeData.error}
+        curlCommand={modeData.curlCommand}
+      />
+    );
+  }
+  if (modeData.mode === "tool-call-request") return null;
+  const _: "menu" | "ready-for-request" = modeData.mode;
   return (
     <TerminalFlex
       style={{
@@ -1430,23 +1406,16 @@ function ToolRequestRenderer({
 } & RunArgs) {
   const themeColor = useColor();
   const scrollTranscriptToBottomIfNeeded = useScrollTranscriptToBottom();
-  const {
-    runTool,
-    rejectTool,
-    isWhitelisted,
-    addToWhitelist,
-    notifyReadyForInput,
-    requestToolPermission,
-  } = useAppStore(
-    useShallow(state => ({
-      runTool: state.runTool,
-      rejectTool: state.rejectTool,
-      isWhitelisted: state.isWhitelisted,
-      addToWhitelist: state.addToWhitelist,
-      notifyReadyForInput: state.notifyReadyForInput,
-      requestToolPermission: state.requestToolPermission,
-    })),
-  );
+  const { runTool, rejectTool, addToWhitelist, notifyReadyForInput, requestToolPermission } =
+    useAppStore(
+      useShallow(state => ({
+        runTool: state.runTool,
+        rejectTool: state.rejectTool,
+        addToWhitelist: state.addToWhitelist,
+        notifyReadyForInput: state.notifyReadyForInput,
+        requestToolPermission: state.requestToolPermission,
+      })),
+    );
   const unchained = useUnchained();
   const whitelistKey = (() => {
     const fn = parsedToolSchema(toolReq);
@@ -1479,6 +1448,7 @@ function ToolRequestRenderer({
     }
     return `${fn.name}:*`;
   })();
+  const isToolWhitelisted = useAppStore(state => state.whitelist.has(whitelistKey));
   const prompt = (() => {
     const fn = parsedToolSchema(toolReq);
     switch (fn.name) {
@@ -1534,13 +1504,6 @@ function ToolRequestRenderer({
     return null;
   })();
   const toolName = toolReq.name;
-  const [isToolWhitelisted, setIsToolWhitelisted] = useState<boolean | null>(null);
-  useEffect(() => {
-    (async () => {
-      const whitelisted = await isWhitelisted(whitelistKey);
-      setIsToolWhitelisted(whitelisted);
-    })();
-  }, [whitelistKey, isWhitelisted]);
   type SelectItem = {
     label: string;
     value: string;
@@ -1572,13 +1535,14 @@ function ToolRequestRenderer({
       if (item.value === "no") {
         rejectTool(toolReq, { config, transport, session });
       } else if (item.value === "yes-whitelist") {
-        await addToWhitelist(whitelistKey);
-        await runTool({
+        const pendingToolRun = runTool({
           toolReq,
           config,
           transport,
           session,
         });
+        await addToWhitelist(whitelistKey);
+        await pendingToolRun;
       } else {
         await runTool({
           toolReq,
@@ -1593,10 +1557,11 @@ function ToolRequestRenderer({
   const runningToolCallId = useAppStore(state => state.runningToolCallId);
   const isRunning = runningToolCallId === toolReq.toolCallId;
   const noConfirmationNeeded =
-    unchained || SKIP_CONFIRMATION_TOOLS.includes(toolReq.name) || isToolWhitelisted === true;
+    unchained || SKIP_CONFIRMATION_TOOLS.includes(toolReq.name) || isToolWhitelisted;
   useLayoutEffect(() => {
+    if (!isRunning && !noConfirmationNeeded) requestToolPermission();
     onContentLayout();
-  }, [isRunning, noConfirmationNeeded, onContentLayout]);
+  }, [isRunning, noConfirmationNeeded, requestToolPermission, onContentLayout]);
   useEffect(() => {
     // Already in flight (e.g. remounted mid-run after the menu closed): render progress without
     // re-invoking the tool.
@@ -1609,16 +1574,20 @@ function ToolRequestRenderer({
         session,
       });
     } else {
-      requestToolPermission();
       notifyReadyForInput(config);
     }
-  }, [toolReq, isRunning, noConfirmationNeeded, config, transport, session]);
+  }, [
+    toolReq,
+    isRunning,
+    noConfirmationNeeded,
+    config,
+    transport,
+    session,
+    runTool,
+    notifyReadyForInput,
+  ]);
   if (noConfirmationNeeded || isRunning) {
-    return (
-      <Loading
-        overrideStrings={["Waiting", "Watching", "Smiling", "Hungering", "Splashing", "Writhing"]}
-      />
-    );
+    return null;
   }
   return (
     <TerminalFlex

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -472,7 +472,8 @@ export default function App({
                                     modeData.inflightResponse.content) && (
                                     <MessageDisplay item={modeData.inflightResponse} />
                                   )}
-                                {modeData.mode === "tool-call" && (
+                                {(modeData.mode === "tool-call" ||
+                                  modeData.mode === "tool-call-request") && (
                                   <ToolRequestsRenderer
                                     toolReqs={modeData.toolReqs}
                                     config={currConfig}
@@ -716,6 +717,45 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
     },
     [query, modeData.mode, config, transport, session, setQuery, showToast],
   );
+  if (modeData.mode === "error-recovery") return <Loading />;
+  if (modeData.mode === "payment-error") {
+    return <PaymentErrorScreen error={modeData.error} />;
+  }
+  if (modeData.mode === "rate-limit-error") {
+    return <RateLimitErrorScreen error={modeData.error} />;
+  }
+  if (modeData.mode === "auth-error") {
+    return (
+      <AuthErrorScreen
+        model={modeData.model}
+        error={modeData.error}
+        config={config}
+        transport={transport}
+        session={session}
+      />
+    );
+  }
+  if (modeData.mode === "request-error") {
+    return (
+      <RequestErrorScreen
+        mode="request-error"
+        contextualMessage="It looks like you've hit a request error!"
+        error={modeData.error}
+        curlCommand={modeData.curlCommand}
+      />
+    );
+  }
+  if (modeData.mode === "compaction-error") {
+    return (
+      <RequestErrorScreen
+        mode="compaction-error"
+        contextualMessage="History compaction failed due to a request error!"
+        error={modeData.error}
+        curlCommand={modeData.curlCommand}
+      />
+    );
+  }
+  if (!inputFieldAvailable(modeData)) return null;
   if (
     modeData.mode === "responding" ||
     modeData.mode === "compacting" ||
@@ -779,48 +819,32 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
       </TerminalFlex>
     );
   }
-  if (modeData.mode === "error-recovery") return <Loading />;
-  if (modeData.mode === "payment-error") {
-    return <PaymentErrorScreen error={modeData.error} />;
-  }
-  if (modeData.mode === "rate-limit-error") {
-    return <RateLimitErrorScreen error={modeData.error} />;
-  }
-  if (modeData.mode === "auth-error") {
-    return (
-      <AuthErrorScreen
-        model={modeData.model}
-        error={modeData.error}
-        config={config}
-        transport={transport}
-        session={session}
-      />
-    );
-  }
-  if (modeData.mode === "request-error") {
-    return (
-      <RequestErrorScreen
-        mode="request-error"
-        contextualMessage="It looks like you've hit a request error!"
-        error={modeData.error}
-        curlCommand={modeData.curlCommand}
-      />
-    );
-  }
-  if (modeData.mode === "compaction-error") {
-    return (
-      <RequestErrorScreen
-        mode="compaction-error"
-        contextualMessage="History compaction failed due to a request error!"
-        error={modeData.error}
-        curlCommand={modeData.curlCommand}
-      />
-    );
-  }
   if (modeData.mode === "tool-call") {
-    return null;
+    return (
+      <TerminalFlex
+        style={{
+          flexDirection: "column",
+        }}
+      >
+        <QueuedUserMessages messages={queuedMessages} />
+        <MultimediaInput
+          inputHistory={inputHistory}
+          value={query}
+          onChange={setQuery}
+          attachedImages={attachedImages}
+          addAttachedImage={addAttachedImage}
+          removeLastAttachedImage={removeLastAttachedImage}
+          clearAttachedImages={clearAttachedImages}
+          onSubmit={onSubmit}
+          vimEnabled={vimEnabled}
+          vimMode={vimMode}
+          setVimMode={setVimMode}
+          modalities={model.modalities}
+        />
+        <VimModeIndicator vimEnabled={vimEnabled} vimMode={vimMode} />
+      </TerminalFlex>
+    );
   }
-  const _: "menu" | "ready-for-request" = modeData.mode;
   return (
     <TerminalFlex
       style={{
@@ -1406,13 +1430,21 @@ function ToolRequestRenderer({
 } & RunArgs) {
   const themeColor = useColor();
   const scrollTranscriptToBottomIfNeeded = useScrollTranscriptToBottom();
-  const { runTool, rejectTool, isWhitelisted, addToWhitelist, notifyReadyForInput } = useAppStore(
+  const {
+    runTool,
+    rejectTool,
+    isWhitelisted,
+    addToWhitelist,
+    notifyReadyForInput,
+    requestToolPermission,
+  } = useAppStore(
     useShallow(state => ({
       runTool: state.runTool,
       rejectTool: state.rejectTool,
       isWhitelisted: state.isWhitelisted,
       addToWhitelist: state.addToWhitelist,
       notifyReadyForInput: state.notifyReadyForInput,
+      requestToolPermission: state.requestToolPermission,
     })),
   );
   const unchained = useUnchained();
@@ -1577,6 +1609,7 @@ function ToolRequestRenderer({
         session,
       });
     } else {
+      requestToolPermission();
       notifyReadyForInput(config);
     }
   }, [toolReq, isRunning, noConfirmationNeeded, config, transport, session]);

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -473,7 +473,7 @@ export default function App({
                                     <MessageDisplay item={modeData.inflightResponse} />
                                   )}
                                 {(modeData.mode === "tool-call" ||
-                                  modeData.mode === "tool-call-request") && (
+                                  modeData.mode === "tool-call-permission") && (
                                   <ToolRequestsRenderer
                                     toolReqs={modeData.toolReqs}
                                     config={currConfig}
@@ -819,7 +819,7 @@ function BottomBarContent({ inputHistory }: { inputHistory: InputHistory }) {
       />
     );
   }
-  if (modeData.mode === "tool-call-request") return null;
+  if (modeData.mode === "tool-call-permission") return null;
   const _: "menu" | "ready-for-request" = modeData.mode;
   return (
     <TerminalFlex

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -5,7 +5,7 @@ import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { eq } from "drizzle-orm";
 import { withMock } from "antipattern";
-import { useAppStore, nextToolAction } from "./state.ts";
+import { inputFieldAvailable, nextToolAction, useAppStore } from "./state.ts";
 import type { Config } from "./config.ts";
 import { db } from "./db/db.ts";
 import type { HistoryNode } from "./session-history/index.ts";
@@ -164,6 +164,35 @@ function setupToolBatch(callA: ShellToolCall, callB: ShellToolCall) {
   });
   return { session, abortController };
 }
+
+describe("tool permission mode", () => {
+  it("only hides the input while a permission request is pending", () => {
+    const callA = shellCall("call_a", "echo a");
+    const callB = shellCall("call_b", "echo b");
+    setupToolBatch(callA, callB);
+
+    expect(inputFieldAvailable(useAppStore.getState().modeData)).toBe(true);
+
+    useAppStore.getState().requestToolPermission();
+
+    expect(useAppStore.getState().modeData.mode).toBe("tool-call-request");
+    expect(inputFieldAvailable(useAppStore.getState().modeData)).toBe(false);
+  });
+
+  it("restores the input before an approved tool starts", async () => {
+    const transport = new LocalTransport();
+    const callA = shellCall("call_a", "echo a");
+    const callB = shellCall("call_b", "echo b");
+    const { session } = setupToolBatch(callA, callB);
+    useAppStore.getState().requestToolPermission();
+
+    const running = useAppStore.getState().runTool({ config, transport, session, toolReq: callA });
+
+    expect(useAppStore.getState().modeData.mode).toBe("tool-call");
+    expect(inputFieldAvailable(useAppStore.getState().modeData)).toBe(true);
+    await running;
+  });
+});
 
 describe("aborting a tool batch", () => {
   it("marks pending tool calls as answered when aborting between tool calls", async () => {

--- a/source/state.test.ts
+++ b/source/state.test.ts
@@ -175,7 +175,7 @@ describe("tool permission mode", () => {
 
     useAppStore.getState().requestToolPermission();
 
-    expect(useAppStore.getState().modeData.mode).toBe("tool-call-request");
+    expect(useAppStore.getState().modeData.mode).toBe("tool-call-permission");
     expect(inputFieldAvailable(useAppStore.getState().modeData)).toBe(false);
   });
 

--- a/source/state.ts
+++ b/source/state.ts
@@ -103,7 +103,7 @@ export type UiState = {
         abortController: AbortController;
       }
     | {
-        mode: "tool-call-request";
+        mode: "tool-call-permission";
         toolReqs: ToolCallRequest[];
         abortController: AbortController;
       }
@@ -207,7 +207,7 @@ export type UiState = {
 
 export function inputFieldAvailable(modeData: UiState["modeData"]): boolean {
   switch (modeData.mode) {
-    case "tool-call-request":
+    case "tool-call-permission":
     case "menu":
     case "error-recovery":
     case "payment-error":
@@ -504,14 +504,14 @@ export const useAppStore = create<UiState>((set, get) => ({
   requestToolPermission: () => {
     const { modeData } = get();
     if (modeData.mode !== "tool-call") return;
-    set({ modeData: { ...modeData, mode: "tool-call-request" } });
+    set({ modeData: { ...modeData, mode: "tool-call-permission" } });
   },
 
   abortResponse: (session: Session, config, opts?: { exiting?: boolean }) => {
     const { modeData, runningToolCallId } = get();
     if ("abortController" in modeData) modeData.abortController.abort();
     set({ queuedUserMessages: [] });
-    if (modeData.mode !== "tool-call" && modeData.mode !== "tool-call-request") return;
+    if (modeData.mode !== "tool-call" && modeData.mode !== "tool-call-permission") return;
 
     /*
      * Aborting a tool batch mid-flight leaves every request that never ran unanswered in
@@ -726,7 +726,7 @@ export const useAppStore = create<UiState>((set, get) => ({
 
   runTool: async ({ config, toolReq, transport, session }) => {
     const { modeData } = get();
-    if (modeData.mode !== "tool-call" && modeData.mode !== "tool-call-request") {
+    if (modeData.mode !== "tool-call" && modeData.mode !== "tool-call-permission") {
       throw new Error(`Impossible tool mode: ${modeData.mode}`);
     }
     if (get().runningToolCallId != null) {

--- a/source/state.ts
+++ b/source/state.ts
@@ -207,13 +207,6 @@ export type UiState = {
 
 export function inputFieldAvailable(modeData: UiState["modeData"]): boolean {
   switch (modeData.mode) {
-    case "ready-for-request":
-    case "responding":
-    case "compacting":
-    case "diff-apply":
-    case "fix-json":
-    case "tool-call":
-      return true;
     case "tool-call-request":
     case "menu":
     case "error-recovery":
@@ -223,6 +216,15 @@ export function inputFieldAvailable(modeData: UiState["modeData"]): boolean {
     case "request-error":
     case "compaction-error":
       return false;
+    // DO NOT turn these cases into "default".
+    // each new mode should consider whether the input field should be available
+    case "ready-for-request":
+    case "responding":
+    case "compacting":
+    case "diff-apply":
+    case "fix-json":
+    case "tool-call":
+      return true;
   }
 }
 

--- a/source/state.ts
+++ b/source/state.ts
@@ -103,6 +103,11 @@ export type UiState = {
         abortController: AbortController;
       }
     | {
+        mode: "tool-call-request";
+        toolReqs: ToolCallRequest[];
+        abortController: AbortController;
+      }
+    | {
         mode: "error-recovery";
       }
     | {
@@ -172,6 +177,7 @@ export type UiState = {
   input: (args: RunArgs & { query: string; images?: ImageInfo[] }) => Promise<void>;
   runTool: (args: RunArgs & { toolReq: ToolCallRequest }) => Promise<void>;
   rejectTool: (toolCall: ToolCallRequest, args: RunArgs) => void;
+  requestToolPermission: () => void;
   abortResponse: (session: Session, config: Config, opts?: { exiting?: boolean }) => void;
   toggleMenu: () => void;
   openMenu: () => void;
@@ -206,8 +212,16 @@ export function inputFieldAvailable(modeData: UiState["modeData"]): boolean {
     case "compacting":
     case "diff-apply":
     case "fix-json":
+    case "tool-call":
       return true;
-    default:
+    case "tool-call-request":
+    case "menu":
+    case "error-recovery":
+    case "payment-error":
+    case "rate-limit-error":
+    case "auth-error":
+    case "request-error":
+    case "compaction-error":
       return false;
   }
 }
@@ -485,11 +499,17 @@ export const useAppStore = create<UiState>((set, get) => ({
     }
   },
 
+  requestToolPermission: () => {
+    const { modeData } = get();
+    if (modeData.mode !== "tool-call") return;
+    set({ modeData: { ...modeData, mode: "tool-call-request" } });
+  },
+
   abortResponse: (session: Session, config, opts?: { exiting?: boolean }) => {
     const { modeData, runningToolCallId } = get();
     if ("abortController" in modeData) modeData.abortController.abort();
     set({ queuedUserMessages: [] });
-    if (modeData.mode !== "tool-call") return;
+    if (modeData.mode !== "tool-call" && modeData.mode !== "tool-call-request") return;
 
     /*
      * Aborting a tool batch mid-flight leaves every request that never ran unanswered in
@@ -704,7 +724,7 @@ export const useAppStore = create<UiState>((set, get) => ({
 
   runTool: async ({ config, toolReq, transport, session }) => {
     const { modeData } = get();
-    if (modeData.mode !== "tool-call") {
+    if (modeData.mode !== "tool-call" && modeData.mode !== "tool-call-request") {
       throw new Error(`Impossible tool mode: ${modeData.mode}`);
     }
     if (get().runningToolCallId != null) {
@@ -716,7 +736,10 @@ export const useAppStore = create<UiState>((set, get) => ({
     }
 
     const abortController = modeData.abortController;
-    set({ runningToolCallId: toolReq.toolCallId });
+    set({
+      modeData: { ...modeData, mode: "tool-call" },
+      runningToolCallId: toolReq.toolCallId,
+    });
 
     const tools = await loadTools(transport, abortController.signal, config);
 


### PR DESCRIPTION
A bug was reported that the input field disappears during tool calls when using the queue messages feature.

By adding a new mode `tool-call-request`, we can determine whether we show the input based on the `mode` octo is in.

Also fixed a long-standing issue of checking the permissions whitelist being async and potentially showing the wrong state for a frame with a quick fix (since it's related to the input field i added it to this PR)